### PR TITLE
PDOC-133: Fix DS category ordering

### DIFF
--- a/docs/web-ui-reference/components/form/button.md
+++ b/docs/web-ui-reference/components/form/button.md
@@ -36,34 +36,6 @@ Button supports several visual appearances (accent, lightweight, neutral, outlin
 </>
 ```
 
-Additionally, the following Rapid UX visual appearances are supported:
-
-### Rapid UX Primary
-
-```html live
-<>
-  <alpha-button appearance="primary-purple">Primary Purple Button</alpha-button>
-  <alpha-button appearance="primary-gradient">Primary Gradient Button</alpha-button>
-  <alpha-button appearance="primary-blue">Primary Blue Button</alpha-button>
-  <alpha-button appearance="outline-primary-gradient">Outline Primary Gradient Button</alpha-button>
-</>
-```
-
-### Rapid UX Secondary
-
-```html live
-<>
-  <alpha-button appearance="secondary-teal">Secondary Teal Button</alpha-button>
-  <alpha-button appearance="outline-secondary-teal">Outline Secondary Teal Button</alpha-button>
-</>
-```
-
-### Rapid UX Neutral
-
-```html live
-<alpha-button appearance="neutral-grey">Neutral Grey Button</alpha-button>
-```
-
 ## Disabled
 
 Disabled buttons prevent user interaction: they cannot be pressed or focused.

--- a/docs/web-ui-reference/design-systems/_category_.yml
+++ b/docs/web-ui-reference/design-systems/_category_.yml
@@ -1,2 +1,2 @@
 label: 'Design Systems'
-position: 20
+position: 65


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PDOC-0

**What does this PR do?**

* Puts Design Systems category after Components (we can debate the exact order, but it didn't make sense to have Design Systems before Set-up or CLI)
* Removes Rapid-specific appearance options for button (now that alpha extends foundation-ui rather than rapid/zero)

**Where should the reviewer start?**

Anywhere
