### PR TITLE
PDOC-168 Reshuffle information about type-safe messages and genesis set into its own section

### DIFF
--- a/docs/platform-reference/Inter-process messages/genesis-set.mdx
+++ b/docs/platform-reference/Inter-process messages/genesis-set.mdx
@@ -2,7 +2,7 @@
 title: GenesisSet
 sidebar_label: GenesisSet
 id: genesis-set
-sidebar_position: 6
+sidebar_position: 1
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/platform-reference/Inter-process messages/metadata-annotations.md
+++ b/docs/platform-reference/Inter-process messages/metadata-annotations.md
@@ -2,12 +2,12 @@
 id: metadata-annotations
 title: Metadata annotations
 sidebar_label: Metadata annotations
-sidebar_position: 6
+sidebar_position: 3
 ---
 
 # Metadata annotations
 
-The following annotations are found in the package `global.genesis.message.core.annotation` and can be applied when defining Kotlin data classes to be used as input `I` message types. As an example, these input types can be used in event handlers and custom request replies (see [event handler API document for a brief introduction](event-handler-api.md)). IMPORTANT! These annotations do not currently enforce validation checks in the backend and are informative only. As an example, if `MinLength` and `MaxLength` is used to annotate a metadata property for a String, the backend will not be checking the size of it automatically.
+The following annotations are found in the package `global.genesis.message.core.annotation` and can be applied when defining Kotlin data classes to be used as input `I` message types. As an example, these input types can be used in event handlers and custom request replies (see [type-safe messages document](type-safe-messages.md)). IMPORTANT! These annotations do not currently enforce validation checks in the backend and are informative only. As an example, if `MinLength` and `MaxLength` is used to annotate a metadata property for a String, the backend will not be checking the size of it automatically.
 
 | Annotation name | Targets | Parameters | Description |
 |----|----|----| --- |

--- a/docs/platform-reference/Inter-process messages/type-safe-messages.md
+++ b/docs/platform-reference/Inter-process messages/type-safe-messages.md
@@ -1,0 +1,85 @@
+---
+title: Type safe messages
+sidebar_label: Type safe messages
+id: type-safe-messages
+sidebar_position: 2
+---
+# Type-safe messages
+
+The genesis platform provisions the use of type safe messages both to perform message serialization and deserialization, and also to automatically extract relevant metadata information to be exposed to the frontend. These type-safe messages are most commonly used in custom request replies, GPAL event handlers and custom event handlers.
+
+Type safe messages are generally divided in two sections: input messages and output messages.
+
+## Input messages
+
+The input message type `I` is defined as a Kotlin data class and which will determine all the necessary information to parse the incoming message and also to expose as metadata. E.g:
+
+```kotlin
+enum class LogLevel {
+    TRACE, DEBUG, INFO, WARN, ERROR
+}
+
+data class SetLogLevel(
+    @Title("Process name")
+    val processName: String,
+    @Description("Represents the target logging level")
+    val logLevel: LogLevel? = null,
+    val datadump: Boolean = false,
+    val expiration: Int = 0
+)
+```
+
+In this example, the `SetLogLevel` data class has a single constructor which also defines the data class properties. We can see that `processName` does not have a default value associated with it, therefore it is implicity mandatory and necessary to construct this message. As such, it will exposed as a *mandatory* metadata field. On the other `logLevel`, `datadump` and `expiration` have default values and therefore will be exposed as optional metadata fields.
+
+In terms of metadata fields types, we are free to use our metadata field basic types (Boolean, Short, Int, Long, Double, String, BigDecimal or Joda DateTime), basic collection types (List, Set and Map), enumerated types (i.e. see defined `LogLevel` above) and other Kotlin data classes as long as they are composed using the same elements. All of these different types will be understood by the metadata system and exposed accordingly. Kotlin also has nullable and non-nullable types, and the metadata system will expose this information too.
+
+Additionally, certain annotations like `@Title` and `@Description`, can be used to provide extra information to the frontend. For example, `@Title` could be used to provide a “human readable name” of a metadata field to be displayed in a grid column, and `@Description` could be used to provide tooltip information when hovering over that column header. Please see all supported metadata annotations [here](metadata-annotations.md).
+
+Read only values can be exposed inside a Kotlin companion object and can be as complex as any other metadata field definition. See example enhanced `SetLogLevel` class below which provides information about the default LogLevel:
+
+```kotlin
+data class SetLogLevel(
+    @Title("Process name")
+    val processName: String,
+    @Description("Represents the target logging level")
+    val logLevel: LogLevel? = null,
+    val datadump: Boolean = false,
+    val expiration: Int = 0
+) {
+    companion object ReadOnly {
+        val defaultLogLevel: LogLevel = LogLevel.INFO
+    }
+}
+```
+
+## Output messages
+
+The output message type `O` can be defined as a single Kotlin data class or as a Kotlin sealed class with multiple Kotlin data classes defined as subtypes. In case of using multiple subtypes, the genesis platform is able to extract information for all the possible messages and expose it as metadata.
+
+As an example, we will have a look at `EventReply` and how event handlers work with output types works in real life.
+
+### Event handler examples
+
+The default output message type to use in event handlers is `EventReply`. `EventReply` is a Kotlin sealed class which is most commonly represented by these two subtypes: `EventAck` and `EventNack`. See their Kotlin definitions below:
+
+```kotlin
+data class EventAck(val generated: List<Map<String, Any>> = emptyList()) : EventReply()
+data class EventNack(
+    val warning: List<GenesisError> = emptyList(),
+    val error: List<GenesisError> = emptyList()
+) : EventReply()
+```
+
+Alternatively, you can create your own reply type by using a normal Kotlin data class or a Kotlin sealed class. See example below for `EventSetLogLevelReply`:
+```kotlin
+sealed class EventSetLogLevelReply : Outbound() {
+    class EventSetLogLevelAck : EventSetLogLevelReply()
+    data class EventSetLogLevelNack(val error: String) : EventSetLogLevelReply()
+}
+```
+
+Custom reply types are powerful, as they allow a predetermined number of customised replies for an eventhandler with their type information exposed in the metadata system. However, they need to be handled carefully, as the internal event handler error handling mechanism is only ready to handle `EventReply` messages, therefore non-captured exceptions and errors will be handled as such and will break the type-safety guarantees of the reply. 
+
+:::warning
+IMPORTANT! The success message should always end in `Ack` in order for the internal event handler logic to handle validation correctly.
+:::

--- a/docs/platform-reference/custom-components/apis/event-handler-api.md
+++ b/docs/platform-reference/custom-components/apis/event-handler-api.md
@@ -12,71 +12,7 @@ Custom event handlers provide a way of implementing business logic in Java or Ko
 2. RxJava3 - RxJava3 event handlers use the RxJava3 library which is a popular option for composing asynchronous event based programs.
 3. Sync - Creates synchronous event handlers
 
-Each custom event handler needs to define an input message type `I` and an output message type `O` (like GPAL event handlers do). 
-
-## Input messages
-
-The input message type `I` is defined as a Kotlin data class and it will determine all the necessary information to parse the incoming message and also to expose as metadata. E.g:
-
-```kotlin
-enum class LogLevel {
-    TRACE, DEBUG, INFO, WARN, ERROR
-}
-
-data class SetLogLevel(
-    @Title("Process name")
-    val processName: String,
-    @Description("Represents the target logging level")
-    val logLevel: LogLevel? = null,
-    val datadump: Boolean = false,
-    val expiration: Int = 0
-)
-```
-
-In this example, the `SetLogLevel` data class has a single constructor which also defines the data class properties. We can see that `processName` does not have a default value associated with it, therefore it is implicity mandatory and necessary to construct this message. As such, it will exposed as a *mandatory* metadata field. On the other `logLevel`, `datadump` and `expiration` have default values and therefore will be exposed as optional metadata fields.
-
-In terms of metadata fields types, we are free to use our metadata field basic types (Boolean, Short, Int, Long, Double, String, BigDecimal or Joda DateTime), basic collection types (List, Set and Map), enumerated types (i.e. see defined `LogLevel` above) and other Kotlin data classes as long as they are composed using the same elements. All of these different types will be understood by the metadata system and exposed accordingly. Kotlin also has nullable and non-nullable types, and the metadata system will expose this information too.
-
-Additionally, certain annotations like `@Title` and `@Description`, can be used to provide extra information to the frontend. For example, `@Title` could be used to provide a “human readable name” of a metadata field to be displayed in a grid column, and `@Description` could be used to provide tooltip information when hovering over that column header. Please see all supported metadata annotations [here](metadata-annotations.md).
-
-Read only values can be exposed inside a Kotlin companion object and can be as complex as any other metadata field definition. See example enhanced `SetLogLevel` class below which provides information about the default LogLevel:
-
-```kotlin
-data class SetLogLevel(
-    @Title("Process name")
-    val processName: String,
-    @Description("Represents the target logging level")
-    val logLevel: LogLevel? = null,
-    val datadump: Boolean = false,
-    val expiration: Int = 0
-) {
-    companion object ReadOnly {
-        val defaultLogLevel: LogLevel = LogLevel.INFO
-    }
-}
-```
-
-## Output messages
-
-The default output message type to use in event handlers is `EventReply`. `EventReply` is a Kotlin sealed class which is most commonly represent by these two subtypes: `EventAck` and `EventNack`. See their Kotlin definitions below:
-
-```kotlin
-data class EventAck(val generated: List<Map<String, Any>> = emptyList()) : EventReply()
-data class EventNack(
-    val warning: List<GenesisError> = emptyList(),
-    val error: List<GenesisError> = emptyList()
-) : EventReply()
-```
-
-Alteratively, you can create your own reply by using a normal Kotlin data class or a Kotlin sealed class. See example below for `EventSetLogLevelReply`:
-```kotlin
-sealed class EventSetLogLevelReply : Outbound() {
-    class EventSetLogLevelAck : EventSetLogLevelReply()
-    data class EventSetLogLevelNack(val error: String) : EventSetLogLevelReply()
-}
-```
-
-Custom reply types are powerful, as they allow a fixed number of customised replies for an eventhandler with their type information exposed in the metadata system. However, they need to be handled carefully, as the internal event handler error handling mechanism is only ready to handle `EventReply` messages, therefore non-captured exceptions and errors will be handled as such and will break the type-safety guarantees of the reply. IMPORTANT! The success message should always end in `Ack` in order for the internal event handler logic to handle validation correctly.
+Each custom event handler needs to define an input message type `I` and an output message type `O` (like GPAL event handlers do). Please see the [type-safe messages](../../Inter-process%20messages/type-safe-messages.md) section for more information. 
 
 ## EventHandler interface
 


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PDOC-168

**What does this PR do?**

- Reshuffles docs from event handler and GenesisSet into a separate section for inter-process messages.

**Where should the reviewer start?**

docs/platform-reference/Inter-process messages
