### PR TITLE
PDOC-212: Updated documentation to reflect backJoin changes

### DIFF
--- a/docs/platform-reference/authentication-and-authorisation/authorisation.md
+++ b/docs/platform-reference/authentication-and-authorisation/authorisation.md
@@ -241,7 +241,7 @@ query("ALL_BID_OFFER_SELLER_DEALER", BID_OFFER_SELLER_VIEW) {
             BID_OFFER_SELLER_VIEW.SELLER_DEALER_ID
         }
         config {
-            backJoins = true
+            backwardsJoins = true
         }
     }
 }

--- a/docs/platform-reference/configure-key-modules/data-servers/examples.md
+++ b/docs/platform-reference/configure-key-modules/data-servers/examples.md
@@ -69,7 +69,7 @@ dataServer {
         config {
             // Items below only available in query level config
             defaultCriteria = "SIMPLE_PRICE > 0"
-            backJoins = false
+            backwardsJoins = false
             disableAuthUpdates = false
         }
     }
@@ -114,7 +114,9 @@ lmdbAllocateSize = 512.MEGA_BYTE()
 
 **disableAuthUpdates**. This disables real-time auth updates in order to improve the overall data responsiveness and performance of the server. Defaults to `false`.
 
-**backJoins**. This enables backwards joins on a view query, these need to be configured at the join level of the query in order to work correctly. Defaults to `true`.
+**backJoins**. This is deprecated, to be replaced by the setting below. It is functionally the same.
+
+**backwardsJoins**. This enables backwards joins on a view query, these need to be configured at the join level of the query in order to work correctly. Defaults to `true`.
 
 #### enableTypeAwareCriteriaEvaluator
 
@@ -133,7 +135,7 @@ As we have seen, each query to a data server creates what is effectively an open
 
 By default, the primary table and all joined tables and views with a backward join flag are monitored. Any changes to these are sent automatically.
 
-Queries that do not have **backJoins = false** will use any backwards joins in any view included in the query. The monitoring of these backward joins can come at a cost, as it can cause significant extra processing. Do not use backwards joins unless there is a need for the data in question to be updated in real time. Counterparty data, if changed, can wait until overnight, for example. The rule of thumb is that you should only use backwards joins where the underlying data is being updated intraday.
+Queries that do not have **backwardsJoins = false** will use any backwards joins in any view included in the query. The monitoring of these backward joins can come at a cost, as it can cause significant extra processing. Do not use backwards joins unless there is a need for the data in question to be updated in real time. Counterparty data, if changed, can wait until overnight, for example. The rule of thumb is that you should only use backwards joins where the underlying data is being updated intraday.
 
 
 ## Where clauses

--- a/docs/platform-reference/data-model/define.md
+++ b/docs/platform-reference/data-model/define.md
@@ -302,15 +302,15 @@ If you need to join to a table where there is real-time data, then you need to s
 This requires the statement **backwardsJoin = true** when you are specifying the join.
 
 When you refer to a table that has a backwards join in any of your [data servers](/platform-reference/configure-key-modules/data-servers/configure), 
-you must include a similar statement in order to enable the feature: **backJoins = true**. Don’t forget to add this!
+you must include a similar statement in order to enable the feature: **backwardsJoins = true**. Don’t forget to add this!
 
-Note that`backJoins` can be expensive in terms of computation and cost, so they should be used surgically rather than by default.
+Note that `backwardsJoins` can be expensive in terms of computation and cost, so they should be used surgically rather than by default.
 
 
 ```kotlin
 query("ALL_RFQ_BROKER_QUOTES_VIEW", RFQ_BROKER_QUOTES_VIEW) {
     config {
-        backJoins = true
+        backwardsJoins = true
     }
 }
 ```


### PR DESCRIPTION
**Related JIRA**

[PDOC-212](https://genesisglobal.atlassian.net/browse/PDOC-212)
&
[GSF-5076](https://genesisglobal.atlassian.net/browse/GSF-5076)

**What does this PR do?**

- Updates the usage of `backJoins` in data servers to `backwardsJoins` to match their use in views.
- Deprecates `backjoins` in data servers

**Where should the reviewer start?**

`docs/platform-reference/configure-key-modules/data-servers/examples.md`