### PR TITLE
docs: corrected typo when entering docker commands

### DIFF
--- a/docs/01_getting-started/04_quick-start-tutorial.mdx
+++ b/docs/01_getting-started/04_quick-start-tutorial.mdx
@@ -591,7 +591,7 @@ docker login genesisglobal-docker-internal.jfrog.io
 
 You need to enter your artifactory credentials at this point
 
-The enter
+Then enter
 ...
 docker pull genesisglobal-docker-internal.jfrog.io/genesis-console-proxy:latest
 #...


### PR DESCRIPTION
**Related JIRA**

No JIRA for this as simple typo fix

**What does this PR do?**

- Fixes a typo in the quick start

**Where should the reviewer start?**

In the 04_quick-start-tutorial.mdx file
