### PR TITLE
fix(docs): sidebar caret size - PTL-195

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -330,6 +330,7 @@ nav.menu {
 }
 
 /* sidebar carets */
+button.menu__caret::before,
 a.menu__link--sublist-caret::after {
   min-width: 8px;
   min-height: 8px;


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-195

**What does this PR do?**

- Adds additional sidebar caret targeting to include button.menu__caret::before

** Before
<img width="409" alt="image" src="https://user-images.githubusercontent.com/82830570/184661690-a2a1a350-b303-4814-8196-b21f300bb348.png">

** After
![image](https://user-images.githubusercontent.com/82830570/184661797-0aa70478-d0a7-48c5-9b2a-85087af95a13.png)

