### PR TITLE
PTL-223 feat(docs): add CODEOWNERS and a (very) light touch CONTRIBUTING

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# For reference see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
+
+# John Hendry, Laura Colclough and Nick Payne (temporarily!)
+# Please reach out to any of us if you have any questions at all :)
+
+* @wjhendry @laurajcolclough @makeusabrew

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Genesis Documentation contribution guidelines
+
+The most up-to-date guidelines can always be found on Notion: https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-223

**What does this PR do?**

- Adds John, Laura and Nick (the latter as a short-term extra pair of hands) as code owners
- This will automatically add the three folks above as default reviewers
- Once merged I'll reach out to helpdesk who will enable the 'require reviews from code owners' option, meaning a review from the above group will be required before a ticket can be merged:

<img width="779" alt="image" src="https://user-images.githubusercontent.com/278461/185344821-d685cdee-514f-4152-87d5-5acba355238d.png">

**Where should the reviewer start?**

Click the files tab; not much to look at.
