### PR TITLE
PTL-291 feat(docs) update Stack Overflow link to point to Genesis Global team

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,7 +72,7 @@ module.exports = {
         {to: 'front-end', label: 'Web'},
         {to: 'operations', label: 'Operations'},
         {
-          href: "https://stackoverflow.com/",
+          href: "https://stackoverflow.com/c/genesis-global",
           className: "so-icon",
           "aria-label": "StackOverflow",
           position: "right"


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-291

**What does this PR do?**

- Ensure that we deep link users to the Genesis Global Stack Overflow team page, not the generic Stack Overflow homepage

**Where should the reviewer start?**

Simply follow the files tab; this is a one-line change
