### PR TITLE
fix(docs): add trailing slash to our redirect - PTL-292

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
 const Home = () => {
-  const redirectUrl = useBaseUrl('/getting-started');
+  const redirectUrl = useBaseUrl('/getting-started/');
   React.useEffect(() => {
     window.location.href = redirectUrl;
   }, []);


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-292

**What does this PR do?**

- Adds a trailing slash to our redirect (/getting-started -> /getting-started/)


