### PR TITLE
PTL-348 fix(docs): temporarily pin CSS minimizer webpack plugin to address build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mui/icons-material": "^5.10.6",
     "@mui/material": "^5.10.6",
     "classnames": "^2.3.1",
+    "css-minimizer-webpack-plugin": "^4.1.0",
     "docusaurus-gtm-plugin": "^0.0.2",
     "fs-extra": "^10.1.0",
     "mdx-mermaid": "1.2.2",


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-348

**What does this PR do?**

- Pins `css-minimizer-webpack-plugin` to `4.1.0` as the recently released `4.2.0` causes build issues with docusaurus:
-- https://github.com/facebook/docusaurus/issues/8147
-- https://github.com/webpack-contrib/css-minimizer-webpack-plugin/issues/198

