### PR TITLE
PTL-349 fix(docs): unpin CSS minimizer webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@mui/icons-material": "^5.10.6",
     "@mui/material": "^5.10.6",
     "classnames": "^2.3.1",
-    "css-minimizer-webpack-plugin": "^4.1.0",
     "docusaurus-gtm-plugin": "^0.0.2",
     "fs-extra": "^10.1.0",
     "mdx-mermaid": "1.2.2",


### PR DESCRIPTION
The issue identified in 943a9160 has since been resolved upstream. See #710 for the original fix and linked threads to the relevant upstream dependencies.

**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-349

