### PR TITLE
fix: address <t> error from Card.js component - PTF-339

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,17 +3,16 @@ import {Card} from '@mui/material'
 import {ArrowForward} from '@mui/icons-material'
 
 export default function QuickCard({heading, link, text}){
-    return (
-        
-            <Card sx={{backgroundColor: 'var(--warm-gray-4)', padding: '2%', display: 'flexbox', flexGrow: '1', flexDirection: 'row', margin: '1%'}}>
-                <div style={{display: 'flex', flexDirection: 'column'}}>
-                    <h4 style={{display: 'flexbox', fontSize: '16px', fontWeight: 'bolder'}}>{heading}</h4>
-                    <t style={{display: 'flexbox', fontSize: '16px'}}>{text}</t>
-                    <a href={link} style={{display: 'flexbox', fontSize: '14px', fontWeight: 'bold'}}>Read more
-                        <ArrowForward sx={{height: '10px', width: 'auto', paddingLeft: '1%'}}/>
-                    </a>
-                </div>
-            </Card>
-        
-    )
+  return (
+    <Card sx={{backgroundColor: 'var(--warm-gray-4)', padding: '2%', display: 'flexbox', flexGrow: '1', flexDirection: 'row', margin: '1%'}} style={{height: '100%'}}>
+      <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+        <h4 style={{display: 'flexbox', fontSize: '16px', fontWeight: 'bolder'}}>{heading}</h4>
+        <p style={{display: 'flexbox', fontSize: '16px', flexGrow: '1'}}>{text}</p>
+        <a href={link} style={{display: 'flexbox', fontSize: '14px', fontWeight: 'bold'}}>
+          Read more
+          <ArrowForward sx={{height: '10px', width: 'auto', paddingLeft: '1%'}}/>
+        </a>
+      </div>
+    </Card>
+  )
 }


### PR DESCRIPTION
**Related JIRA**

[PTF-339](https://genesisglobal.atlassian.net/browse/PTF-339)

**What does this PR do?**

- Adds proper identation;
- Updates "height issue" (height would be based on text size = resulting different card height = weird looking)
- Replaces `<t>` for `<p>`, fixing [PTF-339](https://genesisglobal.atlassian.net/browse/PTF-339)

**Where should the reviewer start?**

Right [here](https://github.com/genesislcap/docs/pull/779/files#diff-7916963985f6b54523951aa9bdcdb855db5905bed40fc7775a485986aec0fa5dR10)

**Samples**

Before:

![before-t](https://user-images.githubusercontent.com/1767830/199574261-aaaa9572-4d0e-4ffa-b3b0-135b4f26b22c.png)

After:

![after-t](https://user-images.githubusercontent.com/1767830/199574277-35ccd585-38cc-4621-a542-0fbf03f4c930.png)
