### PR TITLE
fix: change default Fuse Web server port PTF-350

### DIFF
--- a/docs/00_fuse/02_quick-start/03_start_application.md
+++ b/docs/00_fuse/02_quick-start/03_start_application.md
@@ -114,7 +114,7 @@ Once `INFO: Accepting connections` message is shown, we are ready to load our UI
 
 ### Accessing user interface
 
-We can now open <a href="http://localhost:5000/" target="_blank">http://localhost:5000/</a>.
+We can now open <a href="http://localhost:9000/" target="_blank">http://localhost:9000/</a>.
 
 ![](/img/gpl-seed-login.png)
 


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTF-350

**What does this PR do?**

* Updates default Fuse Web server port

**Where should the reviewer start?**

[03_start_application.md](https://github.com/genesislcap/docs/compare/ac/PTF-350-default-web-server-port?expand=1#diff-a13f630111c1652a928e3a404bad513840da48d333351b9b23bf2299bc112b51)
