### PR TITLE
feat: allow version switching (past, current, next) - PTF-269

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,10 +110,7 @@ module.exports = {
     },
     navbar: {
       items: [
-
-        //keep this commented out until we have multiple versions
-        // {type: 'docsVersionDropdown', className: "version-menu"},
-
+        {type: 'docsVersionDropdown', className: "version-menu"},
         {to: 'getting-started', label: 'Learning'},
         {to: 'database', label: 'Database'},
         {to: 'server', label: 'Server'},


### PR DESCRIPTION
**Related JIRA**

Highlighted when checking [PTF-269](https://genesisglobal.atlassian.net/browse/PTF-269) that will be in `next` for now

**What does this PR do?**

- Enable `docsVersionDropdown` so we can switch to `next` and work/view the `next/2022.4` docs

**Question**

Should we have this enabled or should it be a "local change" type of thing so deployed build doesn't allow users to check `next`?

**Sample**

![image](https://user-images.githubusercontent.com/1767830/201740778-190724a5-d0d4-49b8-955e-4706f763f688.png)
