### PR TITLE
fix: update node prereq info - PTF-410

### DIFF
--- a/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
+++ b/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
@@ -32,7 +32,7 @@ This page gives you the hardware and software requirements needed in order to ru
 | [IntelliJ](https://www.jetbrains.com/idea/download/?fromIDE=#section=windows)	| 2021.2.3 and above  |
 |[Visual Studio Code](https://code.visualstudio.com/Download)	|     1.52.1      |
 |[Java SDK or JDK](https://www.oracle.com/java/technologies/downloads/) (Choose the **x64 installer** download.)|       11        |
-| [NodeJS](https://nodejs.org/en/download/)  |     16 LTS+     |
+| [NodeJS](https://nodejs.org/download/release/latest-gallium/)  |     16 LTS     |
 | [Postman](https://www.postman.com/downloads/) (optional)	|        8        |
 
 
@@ -40,7 +40,7 @@ You can use a range of IDEs (for example, Eclipse) with the Genesis platform, bu
 
 ## Requirements
 
-* NodeJS (16 LTS+) - https://nodejs.org/en/
+* NodeJS (16 LTS) - https://nodejs.dev/en/
 * npm 8 (installed with NodeJS)
 
 ## Access to the Genesis repository

--- a/docs/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/docs/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -36,7 +36,7 @@ Please follow these instructions very carefully to ensure your environment is re
 | Kotlin| 1.7.10|
 | Chrome | 88.0|
 | Postman	| 8|
-| NodeJS  | 16 LTS+|
+| NodeJS  | 16 LTS|
 | npm | 8 |
 | Gradle | 7.5 |
 | Windows Subsystem for Linux (WSL) | WSL 2 |

--- a/versioned_docs/version-2022.3/01_getting-started/02_quick-start/01_hardware-and-software.md
+++ b/versioned_docs/version-2022.3/01_getting-started/02_quick-start/01_hardware-and-software.md
@@ -31,7 +31,7 @@ This page gives you the hardware and software requirements needed in order to ru
 | [IntelliJ](https://www.jetbrains.com/idea/download/?fromIDE=#section=windows)	| 2021.2.3 and above  |
 |[Visual Studio Code](https://code.visualstudio.com/Download)	|     1.52.1      |
 |[Java SDK](https://www.oracle.com/java/technologies/downloads/)|       11        |
-| [NodeJS](https://nodejs.org/en/download/)  |     16 LTS+     |
+| [NodeJS](https://nodejs.org/download/release/latest-gallium/)  |     16 LTS     |
 | [Postman](https://www.postman.com/downloads/) (optional)	|        8        |
 
 
@@ -39,7 +39,7 @@ You can use a range of IDEs (for example, Eclipse) with the Genesis platform, bu
 
 ## Requirements
 
-* NodeJS (16 LTS+) - https://nodejs.org/en/
+* NodeJS (16 LTS) - https://nodejs.dev/en/
 * npm 8 (installed with NodeJS)
 
 ## Access to the Genesis repository

--- a/versioned_docs/version-2022.3/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/versioned_docs/version-2022.3/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -36,7 +36,7 @@ Please follow these instructions very carefully to ensure your environment is re
 | Kotlin| 1.7.10|
 | Chrome | 88.0|
 | Postman	| 8|
-| NodeJS  | 16 LTS+|
+| NodeJS  | 16 LTS|
 | npm | 8 |
 | Gradle | 7.5 |
 | Windows Subsystem for Linux (WSL) | WSL 2 |


### PR DESCRIPTION
**Related JIRA**

[PTF-410](https://genesisglobal.atlassian.net/browse/PTF-410)

**What does this PR do?**

- Update `Node` version to be fixed at `16 LTS` (without the `+`, as it indicates that we could use the others when it would result in build errors/etc)
- Update links related to `Node`
  - download link to go to the latest releases of 16 LTS
  - general node website to the "non-org" one
