### PR TITLE
PTL-538: Revert a number of tech writer edits and add a NO EDIT comment above includes code.

### DIFF
--- a/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
+++ b/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
@@ -74,7 +74,8 @@ Genesis Foundation UI
 https://github.com/genesislcap/foundation-ui#readme
 ```
 
-9. Import StrictSSL from '../../_includes/_strict-ssl.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import StrictSSL from '../../_includes/_strict-ssl.md'
 
 <StrictSSL />
 

--- a/docs/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/docs/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -34,7 +34,8 @@ If this does not work, use the command `npx genx`.
 
 :::
 
-Then, import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 

--- a/docs/01_getting-started/03_go-to-the-next-level/01_introduction.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/01_introduction.md
@@ -43,7 +43,8 @@ Using the GenX CLI tool, we want to generate a blank full-stack application proj
 npx genx
 ```
 
-Then, import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 

--- a/docs/01_getting-started/04_prerequisites/04_genx.md
+++ b/docs/01_getting-started/04_prerequisites/04_genx.md
@@ -44,7 +44,8 @@ This command presents you with a sequence of choices for creating and configurin
 
 First, you'll be prompted to supply your Genesis artifactory credentials [used when setting up your .npmrc](../../../getting-started/quick-start/hardware-and-software/#npmrc-set-up)
 
-Then, import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 

--- a/docs/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
+++ b/docs/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
@@ -24,7 +24,8 @@ In the `genx` script, there are a series of questions.
 
 First, you are asked to provide your username and password - these are the credentials you use to access Genesis Artifactory.
 
-Then, import InsecureFlag from '../../../_includes/_cli-insecure-flag.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import InsecureFlag from '../../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 

--- a/docs/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/docs/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -92,7 +92,8 @@ npm config set https-proxy https://proxy_host:port
 ```
 :::
 
-Then, import StrictSSL from '../../_includes/_strict-ssl.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import StrictSSL from '../../_includes/_strict-ssl.md'
 
 <StrictSSL />
 
@@ -128,7 +129,8 @@ Enter the same password you used in step 6 and then you should see this message:
 
 Feel free to abort this program for now - we'll use genx later on.
 
-Import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 

--- a/versioned_docs/version-2022.3/01_getting-started/02_quick-start/01_hardware-and-software.md
+++ b/versioned_docs/version-2022.3/01_getting-started/02_quick-start/01_hardware-and-software.md
@@ -81,7 +81,8 @@ Now you can configure the `@genesislcap` scope of `npm` to use our jfrog registr
 Genesis Foundation UI
 ```
 
-10. Import StrictSSL from '../../_includes/_strict-ssl.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import StrictSSL from '../../_includes/_strict-ssl.md'
 
 <StrictSSL />
 

--- a/versioned_docs/version-2022.3/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/versioned_docs/version-2022.3/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -92,7 +92,8 @@ npm config set https-proxy https://proxy_host:port
 ```
 :::
 
-Then, import StrictSSL from '../../_includes/_strict-ssl.md'
+<!-- NO EDIT (NEXT 4 LINES) -->
+import StrictSSL from '../../_includes/_strict-ssl.md'
 
 <StrictSSL />
 


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-538

**What does this PR do?**

Revert a number of tech writer edits and add `<!-- NO EDIT (NEXT 4 LINES) -->` comments above any document fragment include code to avoid confusion.

**Where should the reviewer start?**

Document fragment includes live in the _includes/ directory and are a way to avoid duplication across pages. Here's how it works on the two includes added:

1. **_includes/_strict-ssl.md**

Contains:
```
:::caution

If you're behind a corporate network that uses self-signed or missing certificates, you may need to turn strict-ssl off.
Please seek advice internally before doing this.

`npm config set strict-ssl false`

:::
```

Usage:
```
<!-- NO EDIT (NEXT 4 LINES) -->
import StrictSSL from '../../_includes/_strict-ssl.md'

<StrictSSL />

```

Renders:

<img width="834" alt="Screenshot 2022-12-13 at 16 35 13" src="https://user-images.githubusercontent.com/190318/207391305-508dd7e4-1cf9-44d0-9fa9-3638b6e45569.png">

2. **_includes/_cli-insecure-flag.md**

Contains:
```
:::caution Local issuer certificate errors

These may be caused by running `genx` in a proxy network that uses self-signed or missing certificates.
`genx --insecure` can be used to instruct genx to be lenient on SSL handshakes. Please
ensure you are using the latest version by reinstalling it if the message persists:

`npm un -g @genesislcap/foundation-cli && npm i -g @genesislcap/foundation-cli`

:::
```

Usage:
```
<!-- NO EDIT (NEXT 4 LINES) -->
import InsecureFlag from '../../_includes/_cli-insecure-flag.md'

<InsecureFlag />

```

Renders:

<img width="832" alt="Screenshot 2022-12-13 at 16 43 02" src="https://user-images.githubusercontent.com/190318/207392804-21ada966-a8ba-44a4-bc71-d5138d39ae9e.png">