### PR TITLE
[PTL-566] - part two - always show version selector dropdown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches:
       - master
-      - uat
-      - developer-training
-      - low-code
 
 jobs:
   build:
@@ -46,4 +43,5 @@ jobs:
       run: npm run build
       env:
           NODE_AUTH_TOKEN: ${{secrets.GPR_READ_TOKEN}}
-          BASE_URL: /secure/
+          BRANCH: ${{ github.base_ref }}
+          BASE_URL: /docs/

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,38 +7,14 @@ const GTM_ID = process.env.GTM_ID || 'GTM-5GTR43J'; // default to uat GTM_ID, pr
 
 /**
  * For local / debug purposes.
- * If truthy it will include the current version (labeled as Next).
- * Adds the version dropdown to the navbar as needed.
+ * If truthy it will include the current version (labeled as Next) in the version selector dropdown.
 **/
-const SHOW_NEXT = !!process.env.SHOW_NEXT;
-
-const NAVBAR_ITEMS = [
-  { to: "getting-started", label: "Learning" },
-  { to: "database", label: "Database" },
-  { to: "server", label: "Server" },
-  { to: "web", label: "Web" },
-  { to: "operations", label: "Operations" },
-  { to: "gpalx", label: "Early access" },
-  {
-    type: "html",
-    position: "right",
-    value: '<a class="feedback" data-feedback-fish>Give us Feedback</a>',
-  },
-  {
-    href: "/resource/stackoverflow-onboarding",
-    className: "so-icon",
-    "aria-label": "StackOverflow",
-    position: "right",
-  },
-];
-
-//  Will not have to do this as soon as we have 2+ versions, for now only add the dropdown when SHOW_NEXT == true.
-if (SHOW_NEXT) {
-  NAVBAR_ITEMS.unshift({
-    type: "docsVersionDropdown",
-    className: "version-menu",
-  });
-}
+const SHOW_NEXT = !!process.env.SHOW_NEXT
+/**
+ * The above controls whether the user can see 'Next' in the dropdown, but this controls whether we actually build
+ * the Next version of the docs at all. We do *not* want Next available on the live site, but do everywhere else
+**/
+const BUILD_NEXT = SHOW_NEXT || process.env.BRANCH === undefined || process.env.BRANCH !== 'master'
 
 module.exports = {
   title: 'Low-code Platform For Financial Markets',
@@ -46,8 +22,8 @@ module.exports = {
   url: 'https://genesis.global/',
   baseUrl,
   favicon: 'img/favicon.ico',
-  organizationName: 'genesislcap', // Usually your GitHub org/user name.
-  projectName: 'docs', // Usually your repo name.
+  organizationName: 'genesislcap',
+  projectName: 'docs',
   trailingSlash: true,
   onBrokenLinks: 'throw', // please do NOT change this to 'warn', fix or remove your broken links instead
   onDuplicateRoutes: 'throw',
@@ -122,7 +98,15 @@ module.exports = {
           routeBasePath,
           sidebarPath: require.resolve('./sidebars.js'),
           remarkPlugins: [require('mdx-mermaid')],
-          includeCurrentVersion: true, // should be SHOW_NEXT but we need to fix the broken links for that first
+          includeCurrentVersion: BUILD_NEXT,
+          versions: {
+            '2022.4': {
+              'banner': 'none'
+            },
+            '2022.3': {
+              'banner': 'none'
+            },
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -136,7 +120,26 @@ module.exports = {
       disableSwitch: true
     },
     navbar: {
-      items: [...NAVBAR_ITEMS], // preconfigured as we need to conditionally add docsVersionDropdown
+      items: [
+        { type: 'docsVersionDropdown', className: 'version-menu ' + (BUILD_NEXT && !SHOW_NEXT ? 'version-menu--hide-next' : '') },
+        { type: 'doc', docId: 'getting-started/introduction', label: 'Learning' },
+        { type: 'doc', docId: 'database/database-landing', label: 'Database' },
+        { type: 'doc', docId: 'server/server-modules', label: 'Server' },
+        { type: 'doc', docId: 'web/front-end', label: 'Web' },
+        { type: 'doc', docId: 'operations/operations', label: 'Operations' },
+        { type: 'doc', docId: 'gpalx/intro', label: 'Early access' },
+        {
+          type: "html",
+          position: "right",
+          value: '<a class="feedback" data-feedback-fish>Give us Feedback</a>',
+        },
+        {
+          href: "/resource/stackoverflow-onboarding",
+          className: "so-icon",
+          "aria-label": "StackOverflow",
+          position: "right",
+        },
+      ],
       logo: {
         alt: 'Genesis Documentation',
         src: 'img/logo-icon--light.svg',

--- a/infra/README.md
+++ b/infra/README.md
@@ -13,6 +13,12 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 * `cdk synth`       emits the synthesized CloudFormation template
 * `npm test`        tests your infrastructure chagnes
 
+## Pre-requisites
+
+Ensure you have the CDK toolkit available:
+
+* `npm install -g aws-cdk`
+
 ## Environment variables
 
 Note that you'll need to set three mandatory environment variables in order to run any of the above commands. Those environment variables are:

--- a/infra/lib/amplify-docs-stack.ts
+++ b/infra/lib/amplify-docs-stack.ts
@@ -51,7 +51,7 @@ export class AmplifyDocsStack extends cdk.Stack {
             },
             build: {
               commands: [
-                'BASE_URL=/docs/ GTM_ID=$GTM_ID npm run build',
+                'BASE_URL=/docs/ GTM_ID=$GTM_ID BRANCH=$AWS_BRANCH npm run build',
                 'mkdir output',
                 'mv build output/docs',
               ],
@@ -62,7 +62,11 @@ export class AmplifyDocsStack extends cdk.Stack {
             files: ['**/*'],
           },
         },
-      })
+      }),
+      environmentVariables: {
+        // With versioning enabled our Docusaurus builds are getting big, slow, and memory-hungry
+        'NODE_OPTIONS': '--max_old_space_size=6144'
+      }
     });
 
     // Add our custom domain to the application. As long as the domain resolves to a locally

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "docusaurus build",
     "build:next": "SHOW_NEXT=true docusaurus build",
     "build:base_url": "BASE_URL=/secure/ docusaurus build",
+    "build:production": "BASE_URL=/docs/ BRANCH=master docusaurus build",
     "clear": "docusaurus clear",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -567,6 +567,14 @@ a.table-of-contents__link--active {
   color: var(--ifm-navbar-link-color);
 }
 
+/*
+ * Less than ideal: hide the 'Next' link in the dropdown if we don't want users to see it. Doesn't remove it from the
+ * markup and won't stop the link being crawled or indexed
+ */
+.version-menu--hide-next + .dropdown__menu > li:first-child {
+  display:none;
+}
+
 /* Styles for the 404 page */
 .heading-404 {
   font-size: 32px;


### PR DESCRIPTION
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PTL-566

**What does this PR do?**

**TL;DR:**

* Always show the version selector dropdown
* Conditionally add the 'Next' option to the dropdown if building with `SHOW_NEXT=true`
* No longer build the next version of the documentation in production - faster build times, better bad link detection, no ability to 'hack' the URL on the live site
* Don't show unmaintained banner warnings on old versions of the docs

**Too long, read it anyway**

The version selector dropdown is now **always shown** in the navigation menu, because we have more than one officially released version of the documentation and want customers to be able to choose between them:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/278461/209164241-45ea7e82-8621-4d01-a38c-489d8c1249da.png">

At a high level, that's it. Except it's not quite that simple.

The first two commits of the three fix a lot links: they weren't broken, but they were pointing to the wrong place - to the 'next' version of the documentation. While relative links should keep the visitor in the next section if they were already there, we should _never_ be explicitly linking to the 'next' version from somewhere else. There is never a scenario where a user is looking at a page on, say, 2022.4 one minute and then find themselves linked to the 'next' section the next. I've opened a separate PR which contains these first two commits in isolation which I'd prefer is merged separately: that lets us separate the very necessary issue of bad links on the live site without having to take the rest of this PR logic in just before Christmas. That PR is #891. _Edit: that PR is now merged. Left this paragraph in for context though_.

The fact that our build process didn't detect these bad links bothered me. It didn't detect them because despite not showing the dropdown, we always built the 'next' version of the docs anyway (which is why you could URL hack your way to find it even on the live website). Because of this, explicitly linking a page in the next section was perfectly valid. I felt it would be less surprising if instead we no longer built the next version of the docs at all when running a production build, and in order to detect such a build I've added the concept of an optional `BRANCH` environment variable to `docusaurus.config.js`. If this is present and is set to `master`, the build is considered to be a production one. The next version of the docs won't be built, and thus anything linking to it will fail the build. I've updated the GitHub build action to reflect this.

The upside of this change is that production builds will be faster since they're building one less version now. The downside is that it means the configuration is starting to drift a little between production and all other environments. For example, PR previews deliberately *do* still build the next version of the dropdown, so URL hackery still works. I'm also a bit nervous that this introduces the possibility where `npm run build` works locally for someone who's accidentally linked to the 'next' version of the docs which will then fail its PR build. I've tried to address this by adding an `npm run build:production` helper which can be run locally, but we'll need to encourage usage of this which will take time. I think not building the next version of the docs for production is the right thing to do, but it might be biting off more than this ticket should chew.

Passing in the `BRANCH` environment variable required some small CDK changes, which I've run against production from this branch this afternoon successfully. This was the diff (note that I also backported @nick-genesis's changes he made directly via the console, so we now have the `NODE_OPTIONS` env var set in CDK):

![image](https://user-images.githubusercontent.com/278461/209167251-254e73d3-7a7c-4036-8648-d151fbca31c0.png)

The upshot of these changes is that we now have three slightly different states the site can be depending on environment configuration:

1. Dropdown visible, only showing 2022.3 and 2022.4 as selectable options, but 'next' is available via URL hackery - this is what you'll get on each PR preview link
2. Dropdown visible, only showing 2022.3 and 2022.4 as selectable options, *next* does not exist and URL hacks won't work - this is what you'll get on live deployments (which will now be approximately 2x as fast, or as fast as they were before we versioned 2022.4)
3. Dropdown visible, showing 2022.3, 2022.4 and 'Next' as selectable options - this is what you'll get if you run `npm start:next` which was implemented in PTL-419

**Where should the reviewer start?**

Firstly, please review the updated links in isolation in PR #891. This pull request will be a lot 'cleaner' if that one is merged first. The rest of this pull request is mainly technical changes to support the essay I've explained above. You can see the dropdown on the preview link for this PR here: https://pr-893.d3i6ahf2flvvg.amplifyapp.com/ and note that as this is build configuration (1) as discussed above, you can URL hack your way to 'Next' even though it's not shown in the dropdown, e.g. https://pr-893.d3i6ahf2flvvg.amplifyapp.com/docs/next/getting-started/
