### PR TITLE
fix: update documentation-components package - PTF-472

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/theme-live-codeblock": "^2.1.0",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
-    "@genesislcap/documentation-components": "5.0.2-alpha-37e13b7.0+37e13b7",
+    "@genesislcap/documentation-components": "6.0.1-alpha-8c81145.0+8c81145",
     "@genesislcap/foundation-entity-management": "5.0.1-docs.19",
     "@genesislcap/foundation-filters": "5.0.1-docs.19",
     "@genesislcap/foundation-header": "5.0.1-docs.19",


### PR DESCRIPTION
**Related JIRA**

[PTF-472](https://genesisglobal.atlassian.net/browse/PTF-472)

**What does this PR do?**

- Update `@genesislcap/documentation-components` pre-release to latest version with new reference to `zero` Design System
   - This addresses lots of breaking examples in GPALX section (mainly layouts)

*Before:*

![image](https://user-images.githubusercontent.com/1767830/209403303-16c40fa7-8eb5-444b-82ee-fced1da32b70.png)

*After:*

![image](https://user-images.githubusercontent.com/1767830/209403255-365e6e74-9140-4e64-b0ab-0b92d1da40d4.png)
