### PR TITLE
fix: Correct package name in Camel configurating runtime PA-480

### DIFF
--- a/docs/03_server/10_integration/10_apache-camel/05_configuring-runtime.md
+++ b/docs/03_server/10_integration/10_apache-camel/05_configuring-runtime.md
@@ -29,7 +29,7 @@ The process definition may look similar to the following:
     <start>true</start>
     <options>-Xmx256m -DRedirectStreamsToLog=true -DXSD_VALIDATE=false</options>
     <module>genesis-pal-camel</module>
-    <package>global.genesis.pal.camel</package>
+    <package>global.genesis.camel.pal</package>
     <script>position-camel.kts</script>
     <description>Camel integrations</description>
     <classpath>position-messages*,position-camel*,position-camel-libs*.jar</classpath>


### PR DESCRIPTION
PA-480
**Related JIRA**

https://genesisglobal.atlassian.net/browse/PA-480

**What does this PR do?**
Corrects the package name in the configuring runtime section for Camel
- Add bullets..

**Where should the reviewer start?**

Add file / directory pointers.
