### PR TITLE
feat: Added documentation for allowedSkewClockSeconds PTC-938

### DIFF
--- a/docs/03_server/05_access-control/04_sso_authentication.md
+++ b/docs/03_server/05_access-control/04_sso_authentication.md
@@ -546,13 +546,14 @@ Each `config` configuration has the following properties:
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
 | endpoints | Holds the token and authorization endpoints | Yes | No default value | Object |
-| verification | Holds configuration for the public key of the JWT issuer | No | No JWT verification | Object |
+| verification | Holds configuration for the public key of the JWT issuer, the allowed clock skew and whether validation is enabled | No | No JWT verification | Object |
 
 Each `remoteConfig` configuration has the following properties:
 
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
 | url | The OIDC provider configuration endpoint. | Yes | No default value | String |
+| verification | Holds configuration for the allowed clock skew and whether validation is enabled | No | No JWT verification | Object |
 
 Each `client` configuration has the following properties:
 
@@ -574,6 +575,8 @@ Each `verification` configuration has the following properties:
 | --- | ------ | --- | --- | --- |
 | publicKey  | The public key to be used to validate the JWT | No | No default value | String |
 | publicKeyUrl | URL to the public key to be used to validate the JWT | No | No default value | String |
+| enabled | Enables/disables the validation of the JWT | No | True | Boolean |
+| allowedClockSkewSeconds | The amount of clock skew in seconds to tolerate when verifying the local time against the `nbf` claim  | No | 0 | Long |
 
 :::note
 If `verification` is defined either `publicKey` or `publicKeyUrl` must be defined.
@@ -586,7 +589,7 @@ If `verification` is defined either `publicKey` or `publicKeyUrl` must be define
 ```kotlin
 oidc{
   loginEndpoint = "http://uat-host/login"
-  identityProvider("uat-oidc"){
+  identityProvider("uatOidc"){
     client{
       id = "appplication-id"
       secret = "application-secret"
@@ -611,7 +614,7 @@ oidc{
 ```kotlin
 oidc{
   loginEndpoint = "http://uat-host/login"
-  identityProvider("uat-oidc"){
+  identityProvider("uatOidc"){
     client{
       id = "appplication-id"
       secret = "application-secret"
@@ -633,7 +636,7 @@ oidc{
 ```kotlin
 oidc{
   loginEndpoint = "http://uat-host/login"
-  identityProvider("uat-oidc"){
+  identityProvider("uatOidc"){
     client{
       id = "appplication-id"
       secret = "application-secret"

--- a/versioned_docs/version-2022.4/03_server/05_access-control/04_sso_authentication.md
+++ b/versioned_docs/version-2022.4/03_server/05_access-control/04_sso_authentication.md
@@ -546,13 +546,14 @@ Each `config` configuration has the following properties:
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
 | endpoints | Holds the token and authorization endpoints | Yes | No default value | Object |
-| verification | Holds configuration for the public key of the JWT issuer | No | No JWT verification | Object |
+| verification | Holds configuration for the public key of the JWT issuer, the allowed clock skew and whether validation is enabled | No | No JWT verification | Object |
 
 Each `remoteConfig` configuration has the following properties:
 
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
 | url | The OIDC provider configuration endpoint. | Yes | No default value | String |
+| verification | Holds configuration for the allowed clock skew and whether validation is enabled | No | No JWT verification | Object |
 
 Each `client` configuration has the following properties:
 
@@ -574,6 +575,8 @@ Each `verification` configuration has the following properties:
 | --- | ------ | --- | --- | --- |
 | publicKey  | The public key to be used to validate the JWT | No | No default value | String |
 | publicKeyUrl | URL to the public key to be used to validate the JWT | No | No default value | String |
+| enabled | Enables/disables the validation of the JWT | No | True | Boolean |
+| allowedClockSkewSeconds | The amount of clock skew in seconds to tolerate when verifying the local time against the `nbf` claim  | No | 0 | Long |
 
 :::note
 If `verification` is defined either `publicKey` or `publicKeyUrl` must be defined.
@@ -586,7 +589,7 @@ If `verification` is defined either `publicKey` or `publicKeyUrl` must be define
 ```kotlin
 oidc{
   loginEndpoint = "http://uat-host/login"
-  identityProvider("uat-oidc"){
+  identityProvider("uatOidc"){
     client{
       id = "appplication-id"
       secret = "application-secret"
@@ -611,7 +614,7 @@ oidc{
 ```kotlin
 oidc{
   loginEndpoint = "http://uat-host/login"
-  identityProvider("uat-oidc"){
+  identityProvider("uatOidc"){
     client{
       id = "appplication-id"
       secret = "application-secret"
@@ -634,7 +637,7 @@ oidc{
 ```kotlin
 oidc{
   loginEndpoint = "http://uat-host/login"
-  identityProvider("uat-oidc"){
+  identityProvider("uatOidc"){
     client{
       id = "appplication-id"
       secret = "application-secret"


### PR DESCRIPTION
**Related JIRA ticket**

https://genesisglobal.atlassian.net/browse/PTC-938


**Versions affected by this change**

<!--- Please place an x inside all boxes that apply, with no surrounding spaces, like so: [x] -->
<!--- Once you've opened the PR you can tick and untick these boxes using the GitHub UI, so don't worry if you miss one at this stage. -->

- [x] Next (I've made changes to the `docs/` directory)
- [x] 2022.4 (I've made changes to the `versioned_docs/version-2022.4` directory)
- [ ] 2022.3 (I've made changes to the `versioned_docs/version-2022.3` directory)
- [ ] None (I've changed something else and explained what in the summary above)

<!--- Based on your answers above, feel free to delete either or both of these next two questions if they do not apply -->

If the PR _only_ changes the 'Next' version of the documentation:

- [ ] I confirm that these changes do not apply to the live or previous versions of documentation

If the PR does _not_ change the 'Next' version of the documentation:

- [ ] I confirm that these changes do not apply to the forthcoming version of the documentation

**Additional details**

<!--- Please place an x inside all boxes that apply, with no surrounding spaces, like so: [x] -->

- [ ] I have followed the writing style guide linked in the contribution guidelines
- [ ] I have ensured all links altered or added in this PR follow the contribution guidelines
- [ ] I have made changes to all relevant versions of the documentation
