### PR TITLE
fix: design system editor now showing

### DIFF
--- a/docs/04_web/03_design-systems/03_preview.md
+++ b/docs/04_web/03_design-systems/03_preview.md
@@ -9,6 +9,6 @@ tags:
   - preview
 ---
 
-<design-system-configurator>
+<design-system-editor>
     <design-system-preview></design-system-preview>
-</design-system-configurator>
+</design-system-editor>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@docusaurus/theme-live-codeblock": "^2.2.0",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@genesislcap/documentation-components": "10.3.1",
+    "@genesislcap/documentation-components": "10.5.1",
     "@genesislcap/foundation-entity-management": "10.3.1",
     "@genesislcap/foundation-filters": "10.3.1",
     "@genesislcap/foundation-header": "10.3.1",

--- a/versioned_docs/version-2022.3/04_web/03_design-systems/03_preview.md
+++ b/versioned_docs/version-2022.3/04_web/03_design-systems/03_preview.md
@@ -9,6 +9,6 @@ tags:
   - preview
 ---
 
-<design-system-configurator>
+<design-system-editor>
     <design-system-preview></design-system-preview>
-</design-system-configurator>
+</design-system-editor>

--- a/versioned_docs/version-2022.4/04_web/03_design-systems/03_preview.md
+++ b/versioned_docs/version-2022.4/04_web/03_design-systems/03_preview.md
@@ -9,6 +9,6 @@ tags:
   - preview
 ---
 
-<design-system-configurator>
+<design-system-editor>
     <design-system-preview></design-system-preview>
-</design-system-configurator>
+</design-system-editor>


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
P********
Spotted an issue with the live version where design-system-editor is not showing due to the name change in documentation-components
current live version:
![image](https://user-images.githubusercontent.com/102529447/223431146-3f0111f2-fc5b-49b8-80cb-4e3fae477497.png)

It should look like this:
![image](https://user-images.githubusercontent.com/102529447/223430984-0ed47539-15c3-449e-ac91-450a62125bd1.png)


Have you provided changes for all the relevant versions: next, 2022.3, 2022.4, etc?
yes
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- We have a [contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) 
- We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpt from the style guide**
All our headings are in sentence case. For example:
- Really important information    **correct**
- Really Important Information    **not correct**

