### PR TITLE
PTL-611: Changed the connection-indicator

### DIFF
--- a/docs/04_web/02_web-components/04_presentation/06_connection-indicator.md
+++ b/docs/04_web/02_web-components/04_presentation/06_connection-indicator.md
@@ -1,4 +1,4 @@
----
+img---
 title: 'Web Components - Connection Indicator'
 sidebar_label: 'Connection Indicator'
 id: connection-indicator
@@ -16,8 +16,8 @@ The *optional* label (enabled by the setting `show-label` attribute to `true`) d
 
 ## Basic Usage
 
-```html
-<zero-connection-indicator show-label="true" />
+```html live
+<alpha-connection-indicator show-label="true"/>
 ```
 
 ## Enabling the connection indicator on the login page


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-611

Have you provided changes for all the relevant versions: next, 2022.3, 2022.4, etc?
No

Have you checked all new or changed links?
No

Is there anything else you would like us to know?
Changed the Zero to Alpha component as it seems to be the standard to Docs and added a visualization to the component.  

For reference: 

- We have a [contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) 
- We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpt from the style guide**
All our headings are in sentence case. For example:
- Really important information    **correct**
- Really Important Information    **not correct**

