### PR TITLE
fix: fix the link transformer now the docs have moved domain FUI-1031

### DIFF
--- a/plugins/api-docs/streamTransformers.js
+++ b/plugins/api-docs/streamTransformers.js
@@ -2,7 +2,7 @@ const { Transform } = require("stream");
 const { StringDecoder } = require("string_decoder");
 
 const GENESIS_DOC_URL_HOST_REGEX =
-  /https?:\/\/docs\.genesis\.global\/secure\//g;
+  /https?:\/\/learn\.genesis\.global\/secure\//g;
 
 const createUrlTransformerSteam = (manifestSettings) =>
   new Transform({


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
FUI-1031

Have you provided changes for all the relevant versions: next, 2022.3, 2022.4, etc?
<!--- Yes / No -->
N/A

Have you checked all new or changed links?
<!--- Yes / No -->
N/A

Is there anything else you would like us to know?
<!--- Yes / No -->
Now the docs have been moved domain I needed to change the links upstream, and then update the script which proceses the docs. 
We don't need to make any other changes for now as the docs are already copied with the correct relative links - we just need to make this change for future times that we copy the docs.

For reference: 

- We have a [contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) 
- We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpt from the style guide**
All our headings are in sentence case. For example:
- Really important information    **correct**
- Really Important Information    **not correct**

