### PR TITLE
Changed Standard to Quartz Cron and updated links refence

### DIFF
--- a/docs/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -14,7 +14,7 @@ tags:
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, to change a field in the database if another field has a certain value, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
 - [Dynamic Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#setting-up-the-dynamic-rules), also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
-- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rules in a table in the database: `DYNAMIC_RULES` for dynamic rules and `CRON_RULES` for static rules. We're going start with dynamic rules.
 
@@ -318,7 +318,7 @@ This section showed how to trigger events based on a condition in the database. 
 
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html). 
 - __Dynamic Rules__, also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: `CRON_RULES` for static rules and `DYNAMIC_RULES` for dynamic rules. In this section, we're going to use `CRON_RULES`.
@@ -345,7 +345,7 @@ Let's look at the most important fields:
 * **MESSAGE_TYPE** is the message that needs to be sent to the specified **PROCESS_NAME**.
 * **RESULT_EXPRESSION** is the value or values that will be sent as part of the transaction to the target PROCESS_NAME; we can leave RESULT_EXPRESSION empty, as we are going to generate a report for all positions anyway.
 
-:::info
+:::caution
 We use [Quartz](http://www.quartz-scheduler.org/) to manage our cron expression. All cron expression formats should match that of Quartz specification.
 :::
 

--- a/docs/01_getting-started/06_developer-training/05_training-content-day5.md
+++ b/docs/01_getting-started/06_developer-training/05_training-content-day5.md
@@ -27,7 +27,7 @@ You can use the Evaluator to schedule the production of EOD reports (for example
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules):
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.ht.
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: CRON_RULES for static rules and DYNAMIC_RULES for dynamic rules. In this training, we're going to use Cron Rules, but if you're interested in the Dynamic Rules please look at [Defining a dynamic rule](../../../server/evaluator/basics/#defining-a-dynamic-rule).

--- a/docs/01_getting-started/09_server_training/02_ssdt-day2.md
+++ b/docs/01_getting-started/09_server_training/02_ssdt-day2.md
@@ -118,7 +118,7 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis p
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: 

--- a/docs/03_server/08_evaluator/01_introduction.md
+++ b/docs/03_server/08_evaluator/01_introduction.md
@@ -15,6 +15,6 @@ It is often useful to run tasks periodically - for example to schedule the produ
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules).
 
 - **Dynamic Rules**, which are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries, and
-- **Cron Rules**, which are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- **Cron Rules**, which are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rule in a table in the database: DYNAMIC_RULES for dynamic rules and CRON_RULES for static rules. 

--- a/docs/03_server/08_evaluator/02_basics.md
+++ b/docs/03_server/08_evaluator/02_basics.md
@@ -112,7 +112,7 @@ MESSAGE_TYPE fields define the Java/Kotlin class that is instantiated and set by
 To load a static (Cron) rule into the database, create a csv file with the rule in the above format. Call the file **CRON_RULE.csv**.
 ```csv
 CRON_EXPRESSION,DESCRIPTION,TIME_ZONE,RULE_STATUS,NAME,USER_NAME,PROCESS_NAME,MESSAGE_TYPE
-"0 * * * * *","It’s a rule","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
+"* 15 7 ? * MON-FRI *","Week days at 7.15","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
 ```
 
 Load the cron rule **CRON_RULE.csv** file into the `CRON_RULE`  [table](../../../server/evaluator/configuring-runtime/#cron_rule-table).

--- a/docs/03_server/08_evaluator/02_basics.md
+++ b/docs/03_server/08_evaluator/02_basics.md
@@ -97,7 +97,7 @@ To define a scheduled event, you need to insert a row into the `CRON_RULE` table
 | Field Name | Usage |
 | --- | --- |
 | NAME | Name of the rule |
-| CRON_EXPRESSION | [Standard Cron Expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) |
+| CRON_EXPRESSION | [Quartz Cron Expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).|
 | DESCRIPTION | Simple description of the function of the rule |
 | TIME_ZONE | eg Europe/London |
 | RULE_STATUS | This is either "ENABLED" or "DISABLED", respectively enables or disables the rule  |

--- a/versioned_docs/version-2022.3/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/versioned_docs/version-2022.3/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -14,7 +14,7 @@ tags:
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
 - [Dynamic Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#setting-up-the-dynamic-rules), also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
-- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rules in a table in the database: `DYNAMIC_RULES` for dynamic rules and `CRON_RULES` for static rules. We're going start with dynamic rules.
 
@@ -318,7 +318,7 @@ This section showed how to trigger events based on a condition in the database. 
 
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html). 
 - __Dynamic Rules__, also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: `CRON_RULES` for static rules and `DYNAMIC_RULES` for dynamic rules. In this section, we're going to use `CRON_RULES`.
@@ -345,7 +345,7 @@ Let's look at the most important fields:
 * **MESSAGE_TYPE** is the message that needs to be sent to the specified **PROCESS_NAME**.
 * **RESULT_EXPRESSION** is the value or values that will be sent as part of the transaction to the target PROCESS_NAME; we can leave RESULT_EXPRESSION empty, as we are going to generate a report for all positions anyway.
 
-:::info
+:::caution
 We use [Quartz](http://www.quartz-scheduler.org/) to manage our cron expression. All cron expression formats should match that of Quartz specification.
 :::
 

--- a/versioned_docs/version-2022.3/01_getting-started/06_developer-training/05_training-content-day5.md
+++ b/versioned_docs/version-2022.3/01_getting-started/06_developer-training/05_training-content-day5.md
@@ -27,7 +27,7 @@ You can use the Evaluator to schedule the production of EOD reports (for example
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: CRON_RULES for static rules and DYNAMIC_RULES for dynamic rules. In this training, we're going to use Cron Rules, but if you're interested in the Dynamic Rules please look at [Defining a dynamic rule](../../../server/evaluator/basics/#defining-a-dynamic-rule).

--- a/versioned_docs/version-2022.3/01_getting-started/09_server_training/02_ssdt-day2.md
+++ b/versioned_docs/version-2022.3/01_getting-started/09_server_training/02_ssdt-day2.md
@@ -118,7 +118,7 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis p
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: 

--- a/versioned_docs/version-2022.3/03_server/08_evaluator/01_introduction.md
+++ b/versioned_docs/version-2022.3/03_server/08_evaluator/01_introduction.md
@@ -16,6 +16,6 @@ It is often useful to run tasks periodically - for example to schedule the produ
 In system terms, evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules).
 
 - **Dynamic Rules**, which are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries, and
-- **Cron Rules**, which are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- **Cron Rules**, which are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rule in a table in the database: DYNAMIC_RULES for dynamic rules and CRON_RULES for static rules. 

--- a/versioned_docs/version-2022.3/03_server/08_evaluator/02_basics.md
+++ b/versioned_docs/version-2022.3/03_server/08_evaluator/02_basics.md
@@ -98,7 +98,8 @@ To define a scheduled event, you need to insert a row into the `CRON_RULE` table
 | Field Name | Usage |
 | --- | --- |
 | NAME | Name of the rule |
-| CRON_EXPRESSION | [Standard Cron Expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) |
+| CRON_EXPRESSION | [Quartz Cron Expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
+ |
 | DESCRIPTION | Simple description of the function of the rule |
 | TIME_ZONE | eg Europe/London |
 | RULE_STATUS | This is either "ENABLED" or "DISABLED", respectively enables or disables the rule  |

--- a/versioned_docs/version-2022.3/03_server/08_evaluator/02_basics.md
+++ b/versioned_docs/version-2022.3/03_server/08_evaluator/02_basics.md
@@ -114,7 +114,7 @@ MESSAGE_TYPE fields define the Java/Kotlin class that is instantiated and set by
 To load a static (Cron) rule into the database, create a csv file with the rule in the above format. Call the file **CRON_RULE.csv**.
 ```csv
 CRON_EXPRESSION,DESCRIPTION,TIME_ZONE,RULE_STATUS,NAME,USER_NAME,PROCESS_NAME,MESSAGE_TYPE
-"0 * * * * *","It’s a rule","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
+"* 15 7 ? * MON-FRI *","Week days at 7.15","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
 ```
 
 Load the cron rule **CRON_RULE.csv** file into the `CRON_RULE`  [table](../../../server/evaluator/configuring-runtime/#cron_rule-table).

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -14,7 +14,7 @@ tags:
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, to change a field in the database if another field has a certain value, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
 - [Dynamic Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#setting-up-the-dynamic-rules), also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
-- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rules in a table in the database: `DYNAMIC_RULES` for dynamic rules and `CRON_RULES` for static rules. We're going start with dynamic rules.
 
@@ -318,7 +318,7 @@ This section showed how to trigger events based on a condition in the database. 
 
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html). 
 - __Dynamic Rules__, also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: `CRON_RULES` for static rules and `DYNAMIC_RULES` for dynamic rules. In this section, we're going to use `CRON_RULES`.
@@ -345,7 +345,7 @@ Let's look at the most important fields:
 * **MESSAGE_TYPE** is the message that needs to be sent to the specified **PROCESS_NAME**.
 * **RESULT_EXPRESSION** is the value or values that will be sent as part of the transaction to the target PROCESS_NAME; we can leave RESULT_EXPRESSION empty, as we are going to generate a report for all positions anyway.
 
-:::info
+:::caution
 We use [Quartz](http://www.quartz-scheduler.org/) to manage our cron expression. All cron expression formats should match that of Quartz specification.
 :::
 

--- a/versioned_docs/version-2022.4/01_getting-started/06_developer-training/05_training-content-day5.md
+++ b/versioned_docs/version-2022.4/01_getting-started/06_developer-training/05_training-content-day5.md
@@ -27,7 +27,7 @@ You can use the Evaluator to schedule the production of EOD reports (for example
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules):
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: CRON_RULES for static rules and DYNAMIC_RULES for dynamic rules. In this training, we're going to use Cron Rules, but if you're interested in the Dynamic Rules please look at [Defining a dynamic rule](../../../server/evaluator/basics/#defining-a-dynamic-rule).

--- a/versioned_docs/version-2022.4/01_getting-started/09_server_training/02_ssdt-day2.md
+++ b/versioned_docs/version-2022.4/01_getting-started/09_server_training/02_ssdt-day2.md
@@ -118,7 +118,7 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis p
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: 

--- a/versioned_docs/version-2022.4/03_server/08_evaluator/01_introduction.md
+++ b/versioned_docs/version-2022.4/03_server/08_evaluator/01_introduction.md
@@ -15,6 +15,6 @@ It is often useful to run tasks periodically - for example to schedule the produ
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules).
 
 - **Dynamic Rules**, which are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries, and
-- **Cron Rules**, which are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- **Cron Rules**, which are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rule in a table in the database: DYNAMIC_RULES for dynamic rules and CRON_RULES for static rules. 

--- a/versioned_docs/version-2022.4/03_server/08_evaluator/02_basics.md
+++ b/versioned_docs/version-2022.4/03_server/08_evaluator/02_basics.md
@@ -112,7 +112,7 @@ MESSAGE_TYPE fields define the Java/Kotlin class that is instantiated and set by
 To load a static (Cron) rule into the database, create a csv file with the rule in the above format. Call the file **CRON_RULE.csv**.
 ```csv
 CRON_EXPRESSION,DESCRIPTION,TIME_ZONE,RULE_STATUS,NAME,USER_NAME,PROCESS_NAME,MESSAGE_TYPE
-"0 * * * * *","It’s a rule","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
+"* 15 7 ? * MON-FRI *","Week days at 7.15","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
 ```
 
 Load the cron rule **CRON_RULE.csv** file into the `CRON_RULE`  [table](../../../server/evaluator/configuring-runtime/#cron_rule-table).

--- a/versioned_docs/version-2022.4/03_server/08_evaluator/02_basics.md
+++ b/versioned_docs/version-2022.4/03_server/08_evaluator/02_basics.md
@@ -97,7 +97,7 @@ To define a scheduled event, you need to insert a row into the `CRON_RULE` table
 | Field Name | Usage |
 | --- | --- |
 | NAME | Name of the rule |
-| CRON_EXPRESSION | [Standard Cron Expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) |
+| CRON_EXPRESSION | [Quartz Cron Expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html)|
 | DESCRIPTION | Simple description of the function of the rule |
 | TIME_ZONE | eg Europe/London |
 | RULE_STATUS | This is either "ENABLED" or "DISABLED", respectively enables or disables the rule  |

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -14,7 +14,7 @@ tags:
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, to change a field in the database if another field has a certain value, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
 - [Dynamic Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#setting-up-the-dynamic-rules), also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
-- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- [Static Rules](../../../getting-started/go-to-the-next-level/setting-genesis-evaluator-rules/#static-rules-cron-rules) are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rules in a table in the database: `DYNAMIC_RULES` for dynamic rules and `CRON_RULES` for static rules. We're going start with dynamic rules.
 
@@ -318,7 +318,7 @@ This section showed how to trigger events based on a condition in the database. 
 
 It is often useful to run tasks periodically - for example, to schedule the production of EOD reports, or to send a warning when a defined limit is reached. For such purposes, the Genesis low-code platform provides a feature called the [Evaluator](../../../server/evaluator/introduction/). In system terms, Evaluators enable you to connect [Event Handlers](../../../server/event-handler/introduction/) to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are static events, defined as [standard cron expressions](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are static events, defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as dynamic events, are defined as [groovy expressions](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: `CRON_RULES` for static rules and `DYNAMIC_RULES` for dynamic rules. In this section, we're going to use `CRON_RULES`.
@@ -345,7 +345,7 @@ Let's look at the most important fields:
 * **MESSAGE_TYPE** is the message that needs to be sent to the specified **PROCESS_NAME**.
 * **RESULT_EXPRESSION** is the value or values that will be sent as part of the transaction to the target PROCESS_NAME; we can leave RESULT_EXPRESSION empty, as we are going to generate a report for all positions anyway.
 
-:::info
+:::caution
 We use [Quartz](http://www.quartz-scheduler.org/) to manage our cron expression. All cron expression formats should match that of Quartz specification.
 :::
 

--- a/versioned_docs/version-2023.1/01_getting-started/06_developer-training/05_training-content-day5.md
+++ b/versioned_docs/version-2023.1/01_getting-started/06_developer-training/05_training-content-day5.md
@@ -27,7 +27,7 @@ You can use the Evaluator to schedule the production of EOD reports (for example
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules):
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: CRON_RULES for static rules and DYNAMIC_RULES for dynamic rules. In this training, we're going to use Cron Rules, but if you're interested in the Dynamic Rules please look at [Defining a dynamic rule](../../../server/evaluator/basics/#defining-a-dynamic-rule).

--- a/versioned_docs/version-2023.1/01_getting-started/09_server_training/02_ssdt-day2.md
+++ b/versioned_docs/version-2023.1/01_getting-started/09_server_training/02_ssdt-day2.md
@@ -118,7 +118,7 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis p
 
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules): 
 
-- __Cron Rules__  are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression). 
+- __Cron Rules__  are scheduling rules; these are defined as [quartz cron expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 - __Dynamic Rules__, also known as Dynamic Events, are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries.
 
 In both cases, you define the rule in a table in the database: 

--- a/versioned_docs/version-2023.1/03_server/08_evaluator/01_introduction.md
+++ b/versioned_docs/version-2023.1/03_server/08_evaluator/01_introduction.md
@@ -15,6 +15,6 @@ It is often useful to run tasks periodically - for example to schedule the produ
 In system terms, Evaluators enable you to connect Event Handlers to two different kinds of event: dynamic and static (cron rules).
 
 - **Dynamic Rules**, which are defined as [groovy expression](https://groovy-lang.org/syntax.html), which respond to changes to database table entries, and
-- **Cron Rules**, which are scheduling rules; these are defined as [standard cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+- **Cron Rules**, which are scheduling rules; these are defined as [quartz cron expression](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 
 In both cases, you define the rule in a table in the database: DYNAMIC_RULES for dynamic rules and CRON_RULES for static rules. 

--- a/versioned_docs/version-2023.1/03_server/08_evaluator/02_basics.md
+++ b/versioned_docs/version-2023.1/03_server/08_evaluator/02_basics.md
@@ -97,7 +97,7 @@ To define a scheduled event, you need to insert a row into the `CRON_RULE` table
 | Field Name | Usage |
 | --- | --- |
 | NAME | Name of the rule |
-| CRON_EXPRESSION | [Standard Cron Expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) |
+| CRON_EXPRESSION | [Quartz Cron Expression](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) |
 | DESCRIPTION | Simple description of the function of the rule |
 | TIME_ZONE | eg Europe/London |
 | RULE_STATUS | This is either "ENABLED" or "DISABLED", respectively enables or disables the rule  |

--- a/versioned_docs/version-2023.1/03_server/08_evaluator/02_basics.md
+++ b/versioned_docs/version-2023.1/03_server/08_evaluator/02_basics.md
@@ -112,7 +112,7 @@ MESSAGE_TYPE fields define the Java/Kotlin class that is instantiated and set by
 To load a static (Cron) rule into the database, create a csv file with the rule in the above format. Call the file **CRON_RULE.csv**.
 ```csv
 CRON_EXPRESSION,DESCRIPTION,TIME_ZONE,RULE_STATUS,NAME,USER_NAME,PROCESS_NAME,MESSAGE_TYPE
-"0 * * * * *","It’s a rule","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
+"* 15 7 ? * MON-FRI *","Week days at 7.15","Europe/London","ENABLED","A rule","JaneDee","ALPHA_EVENT_HANDLER","EVENT_POSITION_REPORT"
 ```
 
 Load the cron rule **CRON_RULE.csv** file into the `CRON_RULE`  [table](../../../server/evaluator/configuring-runtime/#cron_rule-table).


### PR DESCRIPTION
Changed all reference from standard cron expression to quartz cron expression and updated all reference links previously pointing to wiki, not pointing to quartz.

Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-570

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes, all of them, including docs

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
All our headings are in sentence case. For example:
- Really important information    **correct**
- Really Important Information    **not correct**

