### PR TITLE
PLAT-659 quick changes to language and punctuation in server commands

### DIFF
--- a/docs/05_operations/02_commands/01_server-commands.md
+++ b/docs/05_operations/02_commands/01_server-commands.md
@@ -42,7 +42,7 @@ genesisInstall [--ignore]
 |          | --ignoreHooks      | no        | If supplied, will ignore any install hooks found                                                                                      | No                |
 |          | --compactProcesses | no        | When set to `true`, combines compatible services into a single process, which reduces the number of services running in the container | No                |
 |          | --repeatedHooks    | no        | If supplied, will repeat the specified install hooks                                                                                      | No                |
-|          | --hostDiff         | no        | If supplied, will compare all the files in all the Genesis servers in the cluster to make sure the files are in sync  | No                |
+|          | --hostDiff         | no        | If supplied, will compare all the files in every Genesis server in the cluster to make sure that the files are in sync  | No                |
 
 Once complete, all configuration files will be copied and, where necessary, merged into the **~/run/generated/cfg** file, which we alias as **$GC**.
 
@@ -142,10 +142,10 @@ remap [-c | --commit]
 | -c       | --commit               | no        | Applies dictionary changes to the database                                             | No                |
 |          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                     | No                |
 |          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                      | No                |
-|          | --ask-db-password      | no        | Prompt for a DB user password to be manually entered                                   | No                |
-| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db.           | No                |
-| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes.    | No                |
-|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present.  | No                |
+|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                   | No                |
+| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db          | No                |
+| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes    | No                |
+|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present  | No                |
 If you run remap with no arguments, it simply gives a report of changes that exist in the configuration.
 
 For example:

--- a/versioned_docs/version-2023.1/05_operations/02_commands/01_server-commands.md
+++ b/versioned_docs/version-2023.1/05_operations/02_commands/01_server-commands.md
@@ -41,8 +41,8 @@ genesisInstall [--ignore]
 |          | --ignore           | no        | If supplied, will ignore errors in the configuration files                                                                            | No                |
 |          | --ignoreHooks      | no        | If supplied, will ignore any install hooks found                                                                                      | No                |
 |          | --compactProcesses | no        | When set to `true`, combines compatible services into a single process, which reduces the number of services running in the container | No                |
-|          | --repeatedHooks    | no        | If supplied, will repeat mentioned install hooks                                                                                      | No                |
-|          | --hostDiff         | no        | If supplied, will compare all the files in all the Genesis servers in the cluster to make sure the files are in sync  | No                |
+|          | --repeatedHooks    | no        | If supplied, will repeat specified install hooks                                                                                      | No                |
+|          | --hostDiff         | no        | If supplied, will compare all the files in every Genesis server in the cluster to make sure that the files are in sync  | No                |
 
 Once complete, all configuration files will be copied and, where necessary, merged into the **~/run/generated/cfg** file, which we alias as **$GC**.
 
@@ -142,10 +142,11 @@ remap [-c | --commit]
 | -c       | --commit               | no        | Applies dictionary changes to the database                                             | No                |
 |          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                     | No                |
 |          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                      | No                |
-|          | --ask-db-password      | no        | Prompt for a DB user password to be manually entered                                   | No                |
-| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db.           | No                |
-| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes.    | No                |
-|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present.  | No                |
+|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                   | No                |
+| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db           | No                |
+| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes    | No                |
+|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present  | No                |
+
 If you run remap with no arguments, it simply gives a report of changes that exist in the configuration.
 
 For example:


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PLAT-659

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
ONLY AFFECTS NEXT AND 23.1

Have you checked all new or changed links?
YES

Is there anything else you would like us to know?
NO

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

