### PR TITLE
docs: update headings on entity-management FUI-1134

### DIFF
--- a/docs/04_web/05_micro-front-ends/04_foundation-entity-management/04_foundation-entity-management.md
+++ b/docs/04_web/05_micro-front-ends/04_foundation-entity-management/04_foundation-entity-management.md
@@ -13,13 +13,13 @@ tags:
   - web
 ---
 
-# Foundation Entity Management
+## Foundation Entity Management
 
 Our [API](./docs/api/index.md) documentation is separate. Click on the link if you want to view it.
 
-# Entity Management
+## Entity Management
 
-## Introduction
+### Introduction
 
 The Entity Management micro-front-end is used to connect to a resource on the back end and manage it from the front end. Handlers can be set up for create, update, and delete events; after adding an event, a button appears to perform the action. There is a list of pre-defined events and resources to manage, but you can manage custom resources that you create on the back-end too.
 
@@ -35,7 +35,7 @@ Example grid used to manage counterparties
 The other component is the form, and this is used to update an existing entity or create a new one. An example form is shown here.
 ![Example entity management form](./docs/img/foundation-entity-management-form.png)
 
-## Set-up
+### Set-up
 
 To enable this micro-front-end in your application, follow the steps below.
 
@@ -89,34 +89,34 @@ export const AdminTemplate: ViewTemplate = html`
 `;
 ```
 
-## Config
+### Config
 
 The functionality of the Entity Manager is customised through the properties you set on it in the HTML. This section covers the main properties that you need to customise. For a full list of all of the properties, [see here](./docs/api/foundation-entity-management.md#properties).
 
-### Title
+#### Title
 
 `title` customises the title of the entity list so that the user can see what resource they are managing.
 
-### Resource
+#### Resource
 
 `resourceName` refers to the name of either a `DATASERVER` query, a `ReqRep` definition or a specific `EVENT_HANDLER`. This essentially is the resource to be managed. In the [above example](#set-up), we use `ALL_COUNTERPARTYS` which is a `SDATASERVER` query, as, by convention, they all start with `ALL_`.
 
-### Events
+#### Events
 
 `createEvent`, `updateEvent`, `deleteEvent` are set to be the events on the back end that handle the specific actions, such as deleting counterparty data. For the create and update functionality, these also define the resource in which the form is populated when the user is creating or updating an entity. After adding an event, a button for performing the selected action appears.
 
-### Datasource configuration
+#### Datasource configuration
 
 Set this object to configure how the Entity Manager interacts with the resource. [See here](./docs/api/foundation-entity-management.datasourceconfiguration/#example).
 
-### Persist column state
+#### Persist column state
 `persist-column-state-key` is a string value. It is used to control how the column states are persisted through actions such as page changes or refreshes. If no `persist-column-state-key` property is set, then the behaviour will be to _not_ persist the column state, and  the grid will revert back to its default state every time the user navigates away from it.
 
 :::warning
 The string defines the key in which the serialised state of the columns is stored in an object in [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Therefore, if you are setting multiple Entity Managers in your application to persist the state you need to use unique keys or you will get undefined behaviour.
 :::
 
-# User Management
+## User Management
 
 The User Management micro front-end is used to manage the users on the front end. Two core components are used to manage the entities:
 - the grid
@@ -131,7 +131,7 @@ User Management is a concrete use case of the [Entity Management](#entity-manage
 Here is an example grid view for managing users:
 ![Example user management grid](./docs/img/foundation-user-management.png)
 
-## Set-up
+### Set-up
 
 To enable this micro-front-end in your application, follow the steps below:
 
@@ -169,11 +169,11 @@ export const AdminTemplate: ViewTemplate = html`
 `;
 ```
 
-## Config
+### Config
 
 You can customise the functionality of User Management through the properties you set in the html. This section covers the main properties that you can customise. For a full list of all of the properties, [see here](./docs/api/foundation-entity-management.users.md).
 
-### Columns
+#### Columns
 
 The primary way to configure the User Management functionality is via the columns that are displayed on the grid.
 ```javascript
@@ -195,7 +195,7 @@ To configure the columns yourself, set the `columns` attribute when you define t
 ```
 To see a more verbose version of this example, [see the second example here](./docs/api/foundation-entity-management.users.md).
 
-### Permissions
+#### Permissions
 
 In contrast to Entity Management, we have a different way of displaying buttons and performing actions here. In this case, they are displayed if the user has the appropriate permissions from the server.
 
@@ -203,14 +203,14 @@ In contrast to Entity Management, we have a different way of displaying buttons 
 - `DELETE_USER` - the user can delete users
 - `AMEND_USER` - the user can update existing users
 
-### Persist column state
+#### Persist column state
 `persist-column-state-key` is a string value, which is used to control how the column states are persisted through actions such as page changes or refreshes. When using this micro front-end, it is set to `entity_profiles_management`.
 
 :::info
 For more info on `persist-column-state-key` see [the section in the entity management.](#persist-column-state)
 :::
 
-# Profile Management
+## Profile Management
 
 The Profile Management micro-front-end is used to manage the profiles on the front end. Two core components are used to manage the profiles - the grid and the form.
 
@@ -221,7 +221,7 @@ Profile Management is a concrete use case of the [Entity Management](#entity-man
 Example grid view when managing profiles.
 ![Example profile management grid](./docs/img/foundation-profile-management.png)
 
-## Set-up
+### Set-up
 
 To enable this micro-front-end in your application, follow the steps below.
 
@@ -257,11 +257,11 @@ export const AdminTemplate: ViewTemplate = html`
 `;
 ```
 
-## Config
+### Config
 
 The functionality of the profile manager is customised through the properties you set in the html. This section covers the main properties that you will want to customise. For a full list of all of the properties, [see here](./docs/api/foundation-entity-management.profiles.md).
 
-### Permissions
+#### Permissions
 
 In contrast to Entity Management, we have a different way of displaying buttons and performing actions here. In this case, they are displayed if the user has the appropriate permissions from the server.
 
@@ -269,13 +269,13 @@ In contrast to Entity Management, we have a different way of displaying buttons 
 - `DELETE_PROFILE` - the user can delete profiles
 - `AMEND_PROFILE` - the user can update existing profiles
 
-### Persist column state
+#### Persist column state
 `persist-column-state-key` is a string value which is used to control how the column states are persisted through actions such as page changes or refreshes. If no `persist-column-state-key` property is set, then the behaviour will be to _not_ persist the column state, and  the grid will revert back to its default state every time the user navigates away from it.
 
 :::info
 For more information on `persist-column-state-key` see [the section in the Entity Management](#persist-column-state) page.
 :::
 
-## License
+### License
 
 Note: this project provides front end dependencies and uses licensed components listed in the next section, thus licenses for those components are required during development. Contact [Genesis Global](https://genesis.global/contact-us/) for more details.

--- a/versioned_docs/version-2022.4/04_web/05_micro-front-ends/04_foundation-entity-management/04_foundation-entity-management.md
+++ b/versioned_docs/version-2022.4/04_web/05_micro-front-ends/04_foundation-entity-management/04_foundation-entity-management.md
@@ -13,13 +13,13 @@ tags:
   - web
 ---
 
-# Foundation Entity Management
+## Foundation Entity Management
 
 Our [API](./docs/api) documentation is separate. Click on the link if you want to view it.
 
-# Entity Management
+## Entity Management
 
-## Introduction
+### Introduction
 
 The Entity Management micro-front-end is used to connect to a resource on the back end and manage it from the front end. Handlers can be set up for create, update, and delete events; after adding an event, a button appears to perform the action. There is a list of pre-defined events and resources to manage, but you can manage custom resources that you create on the back-end too.
 
@@ -35,7 +35,7 @@ Example grid used to manage counterparties
 The other component is the form, and this is used to update an existing entity or create a new one. An example form is shown here.
 ![Example entity management form](./docs/img/foundation-entity-management-form.png)
 
-## Set-up
+### Set-up
 
 To enable this micro-front-end in your application, follow the steps below.
 
@@ -89,34 +89,34 @@ export const AdminTemplate: ViewTemplate = html`
 `;
 ```
 
-## Config
+### Config
 
 The functionality of the Entity Manager is customised through the properties you set on it in the HTML. This section covers the main properties that you need to customise. For a full list of all of the properties, [see here](./docs/api/foundation-entity-management.md#properties).
 
-### Title
+#### Title
 
 `title` customises the title of the entity list so that the user can see what resource they are managing.
 
-### Resource
+#### Resource
 
 `resourceName` refers to the name of either a `DATASERVER` query, a `ReqRep` definition or a specific `EVENT_HANDLER`. This essentially is the resource to be managed. In the [above example](#set-up), we use `ALL_COUNTERPARTYS` which is a `SDATASERVER` query, as, by convention, they all start with `ALL_`.
 
-### Events
+#### Events
 
 `createEvent`, `updateEvent`, `deleteEvent` are set to be the events on the back end that handle the specific actions, such as deleting counterparty data. For the create and update functionality, these also define the resource in which the form is populated when the user is creating or updating an entity. After adding an event, a button for performing the selected action appears.
 
-### Datasource configuration
+#### Datasource configuration
 
 Set this object to configure how the Entity Manager interacts with the resource. [See here](./docs/api/foundation-entity-management.datasourceconfiguration/#example).
 
-### Persist column state
+#### Persist column state
 `persist-column-state-key` is a string value. It is used to control how the column states are persisted through actions such as page changes or refreshes. If no `persist-column-state-key` property is set, then the behaviour will be to _not_ persist the column state, and  the grid will revert back to its default state every time the user navigates away from it.
 
 :::warning
 The string defines the key in which the serialised state of the columns is stored in an object in [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Therefore, if you are setting multiple Entity Managers in your application to persist the state you need to use unique keys or you will get undefined behaviour.
 :::
 
-# User Management
+## User Management
 
 The User Management micro front-end is used to manage the users on the front end. Two core components are used to manage the entities:
 - the grid
@@ -131,7 +131,7 @@ User Management is a concrete use case of the [Entity Management](#entity-manage
 Here is an example grid view for managing users:
 ![Example user management grid](./docs/img/foundation-user-management.png)
 
-## Set-up
+### Set-up
 
 To enable this micro-front-end in your application, follow the steps below:
 
@@ -169,11 +169,11 @@ export const AdminTemplate: ViewTemplate = html`
 `;
 ```
 
-## Config
+### Config
 
 You can customise the functionality of User Management through the properties you set in the html. This section covers the main properties that you can customise. For a full list of all of the properties, [see here](./docs/api/foundation-entity-management.users.md).
 
-### Columns
+#### Columns
 
 The primary way to configure the User Management functionality is via the columns that are displayed on the grid.
 ```javascript
@@ -195,7 +195,7 @@ To configure the columns yourself, set the `columns` attribute when you define t
 ```
 To see a more verbose version of this example, [see the second example here](./docs/api/foundation-entity-management.users.md).
 
-### Permissions
+#### Permissions
 
 In contrast to Entity Management, we have a different way of displaying buttons and performing actions here. In this case, they are displayed if the user has the appropriate permissions from the server.
 
@@ -203,14 +203,14 @@ In contrast to Entity Management, we have a different way of displaying buttons 
 - `DELETE_USER` - the user can delete users
 - `AMEND_USER` - the user can update existing users
 
-### Persist column state
+#### Persist column state
 `persist-column-state-key` is a string value, which is used to control how the column states are persisted through actions such as page changes or refreshes. When using this micro front-end, it is set to `entity_profiles_management`.
 
 :::info
 For more info on `persist-column-state-key` see [the section in the entity management.](#persist-column-state)
 :::
 
-# Profile Management
+## Profile Management
 
 The Profile Management micro-front-end is used to manage the profiles on the front end. Two core components are used to manage the profiles - the grid and the form.
 
@@ -221,7 +221,7 @@ Profile Management is a concrete use case of the [Entity Management](#entity-man
 Example grid view when managing profiles.
 ![Example profile management grid](./docs/img/foundation-profile-management.png)
 
-## Set-up
+### Set-up
 
 To enable this micro-front-end in your application, follow the steps below.
 
@@ -257,11 +257,11 @@ export const AdminTemplate: ViewTemplate = html`
 `;
 ```
 
-## Config
+### Config
 
 The functionality of the profile manager is customised through the properties you set in the html. This section covers the main properties that you will want to customise. For a full list of all of the properties, [see here](./docs/api/foundation-entity-management.profiles.md).
 
-### Permissions
+#### Permissions
 
 In contrast to Entity Management, we have a different way of displaying buttons and performing actions here. In this case, they are displayed if the user has the appropriate permissions from the server.
 
@@ -269,7 +269,7 @@ In contrast to Entity Management, we have a different way of displaying buttons 
 - `DELETE_PROFILE` - the user can delete profiles
 - `AMEND_PROFILE` - the user can update existing profiles
 
-### Persist column state
+#### Persist column state
 `persist-column-state-key` is a string value which is used to control how the column states are persisted through actions such as page changes or refreshes. If no `persist-column-state-key` property is set, then the behaviour will be to _not_ persist the column state, and  the grid will revert back to its default state every time the user navigates away from it.
 
 :::info


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
FUI-1134

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->
For the next and 2022.4, the versions which have the three entity-management related MF merged

Have you checked all new or changed links?
<!--- Yes / No -->
N/A

Is there anything else you would like us to know?
<!--- Yes / No -->
No

Clients have asked about where user and profile management pages are since they've been merged with entity management. Long term we might sepeate these back out, but for now this PR changes the markdown title usage so they're clearly show in the sidebar

Before: 
![Screenshot 2023-04-11 at 16 02 01](https://user-images.githubusercontent.com/43502076/231205632-df917102-b73d-49b5-b532-8e5f67336cb5.png)

After:
![Screenshot 2023-04-11 at 15 58 04](https://user-images.githubusercontent.com/43502076/231205666-224bb6a3-eeb7-4c45-81b3-e0437bc4e2ae.png)


For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

