### PR TITLE
PTL717: web landing page now cards

### DIFF
--- a/docs/04_web/04_integrations/01_introduction.md
+++ b/docs/04_web/04_integrations/01_introduction.md
@@ -1,5 +1,5 @@
 ---
-title: 'Foundation UI - Introduction'
+title: 'Foundation UI - integration'
 sidebar_label: 'Introduction'
 id: introduction
 keywords: [web, foundation ui, introduction]
@@ -9,7 +9,7 @@ tags:
     - introduction
 ---
 
-Genesis Foundation UI libraries can be used on their own to build modern web sites and applications, but they are also designed to be used in combination with a wide variety of existing technologies. This section of our documentation is dedicated to helping you get Genesis Foundation UI working with your existing or preferred stack.
+Our FoundationUI libraries can be used on their own to build web sites and applications, but they are also designed to be used in combination with a wide variety of existing technologies. This section of our documentation is dedicated to helping you get FoundationUI working with your existing or preferred stack.
 
 :::note
 Not seeing an integration for your preferred technology? We'd be happy to work with you to add it. Feel free to [contact us](mailto:support@genesis.global?subject=Web%20Intro%20-%20Preferred%20Stack)

--- a/docs/04_web/04_integrations/02_angular.md
+++ b/docs/04_web/04_integrations/02_angular.md
@@ -9,7 +9,7 @@ tags:
     - angular
 ---
 
-Genesis Foundation integrates nicely with Angular. Let's take a look at how you can set up an Angular project, starting from scratch.
+FoundationUI integrates nicely with Angular. Let's take a look at how you can set up an Angular project, starting from scratch.
 
 ## Setting up the Angular project
 

--- a/docs/04_web/04_integrations/03_react.md
+++ b/docs/04_web/04_integrations/03_react.md
@@ -9,7 +9,7 @@ tags:
     - angular
 ---
 
-Genesis Foundation can be used in React applications. Let's take a look at how you can set up a project, starting from scratch.
+FoundationUI can be used in React applications. Let's take a look at how you can set up a project, starting from scratch.
 
 ## Setting up the React project
 

--- a/docs/04_web/04_integrations/04_vue.md
+++ b/docs/04_web/04_integrations/04_vue.md
@@ -9,7 +9,7 @@ tags:
     - angular
 ---
 
-Genesis Foundation works great with Vue. Let's take a look at how you can set up a Vue project, starting from scratch.
+FoundationUI works well with Vue. Let's take a look at how you can set up a Vue project, starting from scratch.
 
 ## Setting up the Vue project
 

--- a/docs/04_web/04_integrations/05_webpack.md
+++ b/docs/04_web/04_integrations/05_webpack.md
@@ -8,7 +8,7 @@ tags:
     - webpack
 ---
 
-Genesis Foundation works great with TypeScript and Webpack, using a fairly standard set-up. Let's take a look at how you can set up such a project, starting from scratch.
+FoundationUI works well with TypeScript and Webpack, using a fairly standard set-up. Let's take a look at how you can set up such a project, starting from scratch.
 
 ## Setting up the package
 

--- a/docs/04_web/index.md
+++ b/docs/04_web/index.md
@@ -5,14 +5,63 @@ sidebar_position: 1
 id: front-end
 ---
 
+import QuickCard from '@site/src/components/Card';
+import { Grid } from '@mui/material'
+
 Welcome to our reference documentation on the web (front end) of your application. Here, you can find all the information you need to build a front end for your Genesis application.
 
-- [Basics](../web/basics/prerequisites/) - find a useful checklist of links to background information for front-end skills and knowledge. See the key concepts and files you can work with to create a front end.
+## Basics
+<Grid container>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Basics" link="../web/basics/prerequisites/" text="We have a useful checklist of technologies you need to know about to become a front-end developer, along with links.">
+        </QuickCard>
+    </Grid>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Web Components" link="../web/web-components/overview/" text="Explore and examine in detail all the components you can use and extend to create vivid front ends for great usability.">
+        </QuickCard>
+    </Grid>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Design systems" link="../web/design-systems/introduction/" text="Use a design system to specify things like typography, colour and sizing. There is a great Preview page where you can actively change different settings and see the effect on screen - and change them immediately.">
+        </QuickCard>
+    </Grid>
+</Grid>
 
-- [Web components](../web/web-components/overview/) - explore and examine in detail all the components you can use and extend to create vivid front ends for great usability.
+## User and Profile Management
 
-- [Design systems](../web/design-systems/introduction/) - use a design system to specify things like typography, colour and sizing. There is a great Preview page where you can actively change different settings and see the effect on screen - and change them immediately.
+<Grid container>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="User Management" link="../web/micro-front-ends/foundation-entity-management/#user-management" text="Examine the core components for managing users on the front end.">
+        </QuickCard>
+    </Grid>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Profile Management" link="../web/micro-front-ends/foundation-entity-management/#profile-management/" text="Manage profiles on the front end using grids and forms.">
+        </QuickCard>
+    </Grid>
+</Grid>
 
-- [Micro front-end](../web/micro-front-ends/introduction/) - see our range of micro front-ends that enable you to put sophisticated components such as reporting into your user interface without complex coding.
+## Integrating
+Use FoundationUI alongside your existing or preferred stack.
 
-- [Deployment](../web/deploying/introduction/) - look at the details you'll need to consider for deploying your completed front end.
+<Grid container>
+    <Grid item xs={12} md={12} sx={{padding: '1%'}}>
+        <QuickCard heading="Integrating" link="../web/integrations/introduction/" text="Find details about how to integrate with Angular, React, Vue and Webpack.">
+        </QuickCard>
+    </Grid>
+</Grid>
+
+## Testing, deployment and more
+
+<Grid container>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Testing" link="../web/testing/foundation-testing/" text="Find out about testing using UVU and Playwright. Check out or testing API.">
+        </QuickCard>
+    </Grid>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Deployment" link="../web/deploying/introduction/" text="Learn about the default web-server set-up, and manual and automated deployment options.">
+        </QuickCard>
+    </Grid>
+    <Grid item xs={12} md={6} sx={{padding: '1%'}}>
+        <QuickCard heading="Layout" link="../web/dynamic-layout/foundation-layout/" text="Registering elements, APIs and more">
+        </QuickCard>
+    </Grid>
+</Grid>


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-717

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
NOT YET: This only covers Next until ut has been checked

Have you checked all new or changed links?
Yes. There are two that I need help on:
../web/micro-front-ends/foundation-entity-management/#user-management
../web/micro-front-ends/foundation-entity-management/#profile-management
Why do these not go to the relevant headings??

Is there anything else you would like us to know?
Daniel is the Master

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

