### PR TITLE
fix: Fixing WebDevTraining foundation-forms and new compatibilities (PTL-707)

### DIFF
--- a/docs/01_getting-started/10_web-training/01_web-training-day1.md
+++ b/docs/01_getting-started/10_web-training/01_web-training-day1.md
@@ -241,7 +241,7 @@ In the Developer Training, we amended these files in the **client/web/src/routes
 - **home.styles.ts**
 
 :::tip
-We usually follow the pattern of creating  **.template.ts**, **.ts** and **.styles.ts** files. But it doesn't have to be that way; it could be a single file, for example, as we're going to see next.
+We usually follow the pattern of creating **.template.ts**, **.ts** and **.styles.ts** files. But it doesn't have to be that way; it could be a single file, for example, as we're going to see next.
 :::
 
 Realistically, any application will require multiple pages and routes.
@@ -286,7 +286,7 @@ Let's add a route pointing to **playground** so we can access it from the menu.
 
 1. Edit file `client\web\src\routes\config.ts` and add **playground** to **allRoutes** and **routes.map** so we'll be able to access playground from the menu:
 
-   ````ts {1,5,14} title='config.ts'
+   ````ts {1,5,16} title='config.ts'
    import { MarketdataComponent } from './playground/playground';
    ...
    	public allRoutes = [
@@ -300,7 +300,9 @@ Let's add a route pointing to **playground** so we can access it from the menu.
    		...
    		this.routes.map(
    		...
-   		{path: 'playground', element: MarketdataComponent, title: 'Playground', name: 'playground', settings: commonSettings},
+        { path: 'home', element: Home, title: 'Home', name: 'home' },
+        { path: 'not-found', element: NotFound, title: 'Not Found', name: 'not-found' },
+        {path: 'playground', element: MarketdataComponent, title: 'Playground', name: 'playground', settings: commonSettings},
    		);
    	```
    ````
@@ -311,7 +313,7 @@ You should see the **Playground** menu item now.
 
 To create an HTML template for our element, we have to import and use the html-tagged template helper and pass the template to the @customElement decorator.
 
-```ts {1,3,9} title='playground.ts'
+```ts {1,3-7,9} title='playground.ts'
 import { FASTElement, customElement, html } from "@microsoft/fast-element";
 
 const myTemplate = html<MarketdataComponent>`
@@ -328,6 +330,7 @@ As you see, we're defining a const called `myTemplate`, which contains the HTML 
 
 Try it now!
 
+<!-- Here we want IntelliJ only due to Genesis plugin
 :::tip code editors
 You're free to use any IDE or code editor you feel most comfortable with. Some of them, however, do not support syntax highlighting and IntelliSense for html inside JavaScript and TypeScript tagged template strings - like our HTML code in the `html<MarketdataComponent>` template.
 
@@ -341,6 +344,7 @@ As a tip, search for extensions in your IDE to support that. That's usually call
 
 [eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) to get static analysis before building
 :::
+-->
 
 ### Adding attributes to the component
 
@@ -362,7 +366,7 @@ export class MarketdataComponent extends FASTElement {
 
 Having the lastPrice always as zero doesn't make our MarketdataComponent very useful. Let's change the HTML template to display the price in real time and add some behaviour to the component, so that it gets the price in real time (in this example, we're simulating the exchange behaviour with a Math.random function):
 
-```typescript {6,14-20} title='playground.ts'
+```typescript {8-13,19-25} title='playground.ts'
 import {
   FASTElement,
   customElement,
@@ -456,8 +460,14 @@ FASTElement provides a **css** tagged template helper that allows for the creati
 
 Add this code:
 
-```typescript {1,3,4,5,6,7} title='playground.ts'
-import { FASTElement, customElement, html, attr, css } from "@microsoft/fast-element";
+```typescript {6,9-13} title='playground.ts'
+import {
+  FASTElement,
+  customElement,
+  html,
+  attr,
+  css,
+} from "@microsoft/fast-element";
 ...
 const marketdataComponentCSS = css`
   h4 {
@@ -525,7 +535,7 @@ By now, you should have a good understanding of how to build Web Components base
 :::info estimated time
 30min
 :::
-Let's change the MarkedataComponent so that it can work with multiple instruments and a fixed price for each of one them (instead of random). This is roughly what it'd look like:
+Let's change the MarketdataComponent so that it can work with multiple instruments and a fixed price for each of one them (instead of random). This is roughly what it'd look like:
 
 ```
 My Marketdata component
@@ -535,7 +545,7 @@ Instrument AAPL 227.12
 
 Steps:
 
-- import _observable_ and _repeat_ from `@microsoft/fast-element`
+- import _observable_ and _repeat_ from from `@microsoft/fast-element`
 - add a list called **_instruments_** to the MarketdataComponent. Feel free to initialize it with a few instruments, such as `@observable instruments: String[] = ["MSFT", "AAPL"];`
 - change the `lastPrice` attribute to a list of prices. Feel free to initialize it with corresponding prices, such as `@observable lastPrices: number[] = [101.23, 227.12];`
 - change `getLastPriceRealTime` to receive the instrument name and return the corresponding price;
@@ -600,20 +610,22 @@ In this next example, we have put a set of example options set in the flyout men
 
 To enable this micro front-end in our application, we'd have to follow the steps below.
 
-- Make sure you have `@genesislcap/foundation-header` as a dependency in your **client/web/package.json** file.
+- Make sure you have `@genesislcap/foundation-header` as a dependency in your _client/web/package.json_ file.
 
-```js {4} title='package.json'
+```js {5} title='package.json'
 {
   ...
   "dependencies": {
-    "@genesislcap/foundation-header": "^5.0.0"
+    ...
+    "@genesislcap/foundation-header": "14.7.0",
+    ...
   },
   ...
 }
 ```
 
 :::tip
-Whenever you change the dependencies of your project, ensure you run the bootstrap command again - from the **client** folder:
+Whenever you change the dependencies of your project, ensure you run the bootstrap command again - from the _client_ folder:
 
 ```shell
 npm run bootstrap
@@ -653,8 +665,9 @@ export const MainTemplate: ViewTemplate<MainApplication> = html`
 ```js {3} title='client/web/src/layouts/default.ts'
 export const defaultLayout = new FASTElementLayout(html`
 <div class="container">
-	<foundation-header></foundation-header>
-	<!-- Other markup -->
+  <alpha-button>Alpha</alpha-button>
+  <foundation-header
+  ...
 </div>`);
 
 export class MainRouterConfig extends RouterConfiguration<LoginSettings> {
@@ -804,18 +817,6 @@ const MainTemplate: ViewTemplate<MainApplication> = html`
 `;
 ```
 
-### Exercise 1.3: adding the light and dark mode toggle
-
-:::info estimated time
-15min
-:::
-
-Add the Moon control button to the header that, when clicked, calls the `onDarkModeToggle`. This function is already defined in **main.ts**.
-
-:::tip
-In the last example we showed how to add the Misc Control button. Now you need to do this considering the Moon one.
-:::
-
 ##### Menu contents
 
 To set the content of the flyout menu, add the content in the html within an element that has the `slot="menu-contents"` attribute.
@@ -850,7 +851,7 @@ To set the content of the flyout menu, add the content in the html within an ele
 </foundation-header>
 ```
 
-### Exercise 1.4: adding items to the flyout menu
+### Exercise 1.3: adding items to the flyout menu
 
 :::info estimated time
 10 min
@@ -870,7 +871,7 @@ Playground
 By the way, we're using by default the Zero Design Systems. We are going to talk more about Design Systems later in this course.
 :::
 
-### Exercise 1.5: adding new routes
+### Exercise 1.4: adding new routes
 
 :::info estimated time
 30 min

--- a/docs/01_getting-started/10_web-training/02_web-training-day2.md
+++ b/docs/01_getting-started/10_web-training/02_web-training-day2.md
@@ -48,7 +48,7 @@ Insert, edit and cancel.
 
 ### Adding the new Order modal
 
-Let's start with the simplest way to create a form, using the `zero-form` component:
+Let's start with the simplest way to create a form, using the `foundation-form` component:
 
 ```ts {5-9} title='order.template.ts'
 import {html} from '@microsoft/fast-element';
@@ -67,10 +67,10 @@ This component is able to retrieve the meta-data from the `EVENT_ORDER_INSERT` b
 
 Try to run it now and you'll notice that, even though the form is displayed, nothing happens when you click on Submit. We have to bind the submit button to a function, like this:
 ```html {3} title='order.template.ts'
-<zero-form
-  resource-Name="EVENT_ORDER_INSERT"
+<foundation-form
+  resource-name="EVENT_ORDER_INSERT"
   @submit=${(x, c) => x.insertOrder(c.event as CustomEvent)}
-></zero-form>
+></foundation-form>
 ```
 :::tip what is the @submit=${(x, c)} ?
 This is related to binding as we briefly explained in the previous day. If it's still unclear, make sure to check [Understanding bindings](https://www.fast.design/docs/fast-element/declaring-templates#understanding-bindings) and [Events](https://www.fast.design/docs/fast-element/declaring-templates#events)
@@ -123,7 +123,7 @@ connects to the server through a web socket (when WS is available or http as fal
 - `commitEvent`: 
 use it to call event handlers on the server. You must pass the name of the event and an object with the input data required by the event. This data must be in JSON format with key **DETAILS**. See the example above of the `insertOrder` function.
 
-- `getMetadata`: it retrieves the metadata of a resource, that can be an event handler, data server query or a request server. When we used the **zero-form** component previously, for example, it used internally getMetadata passing the event handler name to get all the input fields of the event.
+- `getMetadata`: it retrieves the metadata of a resource, that can be an event handler, data server query or a request server. When we used the **foundation-form** component previously, for example, it used internally getMetadata passing the event handler name to get all the input fields of the event.
 
 - `request`: use it to call a [request server](../../../server/request-server/introduction/) resource. You must pass the request server resource name.
 
@@ -133,7 +133,7 @@ Those are the most common features from Foundation Comms you will use. We're goi
 
 ### Creating a custom form
 
-Using `zero-form` is good for simple forms or prototyping, but we might realise that it is not enough for our use case, and we require much more customisation.
+Using `foundation-form` is good for simple forms or prototyping, but we might realise that it is not enough for our use case, and we require much more customisation.
 
 To enable that you will create each form element manually and take care of storing user inputted data.
 

--- a/docs/01_getting-started/10_web-training/03_web-training-day3.md
+++ b/docs/01_getting-started/10_web-training/03_web-training-day3.md
@@ -280,7 +280,7 @@ The way we have been using grid-pro so far is encapsulating a Genesis datasource
 
 - **`criteria: string`**: a Groovy expression to perform filters on the query server; these remain active for the life of the subscription. For example: Expr.dateIsBefore(TRADE_DATE,'20150518') or QUANTITY > 10000.
 
-- **`orderBy: string`**: This option can be used to select a [Data Server index](../../../database/data-types/index-entities/) (defined in tables-dictionary.kts), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
+- **`order-by: string`**: This option can be used to select a [Data Server index](../../../database/data-types/index-entities/) (defined in tables-dictionary.kts), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
 
 - **`resource-name: string`**: The target [Data Server](../../../server/data-server/introduction/) or [Request Server](../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
 

--- a/docs/01_getting-started/10_web-training/0b_web-environment-setup.md
+++ b/docs/01_getting-started/10_web-training/0b_web-environment-setup.md
@@ -22,7 +22,7 @@ You're not going to change any backend code, but we must have the server running
 
 Just follow the [build and deploy steps](../../../getting-started/developer-training/training-content-day1/#5-the-build-and-deploy-process), and then double-check if you can see the processes running properly as [explained](../../../server/tooling/intellij-plugin/#starting-processes). You must see all processes up and running or in standby mode.
 
-## Running the frontend
+### Running the frontend
 Next, [run the web application locally](../../../getting-started/developer-training/training-content-day2/#running-the-application-locally).
 
 If you don't get any errors, you're all set!

--- a/versioned_docs/version-2023.1/01_getting-started/10_web-training/02_web-training-day2.md
+++ b/versioned_docs/version-2023.1/01_getting-started/10_web-training/02_web-training-day2.md
@@ -48,7 +48,7 @@ Insert, edit and cancel.
 
 ### Adding the new Order modal
 
-Let's start with the simplest way to create a form, using the `zero-form` component:
+Let's start with the simplest way to create a form, using the `foundation-form` component:
 
 ```ts {5-9} title='order.template.ts'
 import {html} from '@microsoft/fast-element';
@@ -67,10 +67,10 @@ This component is able to retrieve the meta-data from the `EVENT_ORDER_INSERT` b
 
 Try to run it now and you'll notice that, even though the form is displayed, nothing happens when you click on Submit. We have to bind the submit button to a function, like this:
 ```html {3} title='order.template.ts'
-<zero-form
+<foundation-form
   resource-name="EVENT_ORDER_INSERT"
   @submit=${(x, c) => x.insertOrder(c.event as CustomEvent)}
-></zero-form>
+></foundation-form>
 ```
 :::tip what is the @submit=${(x, c)} ?
 This is related to binding as we briefly explained in the previous day. If it's still unclear, make sure to check [Understanding bindings](https://www.fast.design/docs/fast-element/declaring-templates#understanding-bindings) and [Events](https://www.fast.design/docs/fast-element/declaring-templates#events)
@@ -123,7 +123,7 @@ connects to the server through a web socket (when WS is available or http as fal
 - `commitEvent`: 
 use it to call event handlers on the server. You must pass the name of the event and an object with the input data required by the event. This data must be in JSON format with key **DETAILS**. See the example above of the `insertOrder` function.
 
-- `getMetadata`: it retrieves the metadata of a resource, that can be an event handler, data server query or a request server. When we used the **zero-form** component previously, for example, it used internally getMetadata passing the event handler name to get all the input fields of the event.
+- `getMetadata`: it retrieves the metadata of a resource, that can be an event handler, data server query or a request server. When we used the **foundation-form** component previously, for example, it used internally getMetadata passing the event handler name to get all the input fields of the event.
 
 - `request`: use it to call a [request server](../../../server/request-server/introduction/) resource. You must pass the request server resource name.
 
@@ -133,7 +133,7 @@ Those are the most common features from Foundation Comms you will use. We're goi
 
 ### Creating a custom form
 
-Using `zero-form` is good for simple forms or prototyping, but we might realise that it is not enough for our use case, and we require much more customisation.
+Using `foundation-form` is good for simple forms or prototyping, but we might realise that it is not enough for our use case, and we require much more customisation.
 
 To enable that you will create each form element manually and take care of storing user inputted data.
 

--- a/versioned_docs/version-2023.1/01_getting-started/10_web-training/03_web-training-day3.md
+++ b/versioned_docs/version-2023.1/01_getting-started/10_web-training/03_web-training-day3.md
@@ -29,8 +29,8 @@ export const OrderTemplate = html<Order>`
   ...
 <zero-grid-pro>
     <grid-pro-genesis-datasource
-            resourceName="ALL_ORDERS"
-            orderBy="ORDER_ID">
+            resource-name="ALL_ORDERS"
+            order-by="ORDER_ID">
     </grid-pro-genesis-datasource>
     <grid-pro-column :definition="${x => x.singleOrderActionColDef}" />
 </zero-grid-pro>
@@ -104,8 +104,8 @@ export const OrderTemplate = html<Order>`
     only-template-col-defs
     >
     <grid-pro-genesis-datasource
-        resourceName="ALL_ORDERS"
-        orderBy="ORDER_ID">
+        resource-name="ALL_ORDERS"
+        order-by="ORDER_ID">
     </grid-pro-genesis-datasource>
     ${repeat(() => orderColumnDefs, html`
     <grid-pro-column :definition="${x => x}" />
@@ -280,18 +280,18 @@ The way we have been using grid-pro so far is encapsulating a Genesis datasource
 
 - **`criteria: string`**: a Groovy expression to perform filters on the query server; these remain active for the life of the subscription. For example: Expr.dateIsBefore(TRADE_DATE,'20150518') or QUANTITY > 10000.
 
-- **`orderBy: string`**: This option can be used to select a [Data Server index](../../../database/data-types/index-entities/) (defined in tables-dictionary.kts), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
+- **`order-by: string`**: This option can be used to select a [Data Server index](../../../database/data-types/index-entities/) (defined in tables-dictionary.kts), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
 
-- **`resourceName: string`**: The target [Data Server](../../../server/data-server/introduction/) or [Request Server](../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
+- **`resource-name: string`**: The target [Data Server](../../../server/data-server/introduction/) or [Request Server](../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
 
-As you may have noticed, we've already used `resourceName` and `orderBy` when we used the grid-pro-genesis-datasource for the first time. 
+As you may have noticed, we've already used `resource-name` and `order-by` when we used the grid-pro-genesis-datasource for the first time. 
 
 Now, let's see how we'd use `criteria` to add some filters to the data grid. In the example below, only orders whose side is BUY would be displayed:
 
 ```ts {4} title='order.template.ts'
 <grid-pro-genesis-datasource
-    resourceName="ALL_ORDERS"
-    orderBy="ORDER_ID"
+    resource-name="ALL_ORDERS"
+    order-by="ORDER_ID"
     criteria="SIDE == 'BUY'"
 >
 </grid-pro-genesis-datasource>
@@ -303,8 +303,8 @@ Having a static filter like that is not always very useful though. Let's make it
 <zero-button @click=${x=> x.toggleSideFilter()}>Toggle SIDE filter</zero-button>
 
 <grid-pro-genesis-datasource
-        resourceName="ALL_ORDERS"
-        orderBy="ORDER_ID"
+        resource-name="ALL_ORDERS"
+        order-by="ORDER_ID"
         criteria="SIDE == '${x=>x.sideFilter}'">
 </grid-pro-genesis-datasource>
 ```
@@ -325,8 +325,8 @@ Ultimately, we can use something like the [ref directive](https://www.fast.desig
 <zero-button @click=${x=> x.customFilter()}>No filters</zero-button>
 
 <grid-pro-genesis-datasource ${ref('ordersGrid')}
-        resourceName="ALL_ORDERS"
-        orderBy="ORDER_ID"
+        resource-name="ALL_ORDERS"
+        order-by="ORDER_ID"
         criteria="SIDE == '${x=>x.sideFilter}'">
     </grid-pro-genesis-datasource>
 ```

--- a/versioned_docs/version-2023.1/01_getting-started/10_web-training/0b_web-environment-setup.md
+++ b/versioned_docs/version-2023.1/01_getting-started/10_web-training/0b_web-environment-setup.md
@@ -22,7 +22,7 @@ You're not going to change any backend code, but we must have the server running
 
 Just follow the [build and deploy steps](../../../getting-started/developer-training/training-content-day1/#5-the-build-and-deploy-process), and then double-check if you can see the processes running properly as [explained](../../../server/tooling/intellij-plugin/#starting-processes). You must see all processes up and running or in standby mode.
 
-## Running the frontend
+### Running the frontend
 Next, [run the web application locally](../../../getting-started/developer-training/training-content-day2/#running-the-application-locally).
 
 If you don't get any errors, you're all set!


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
[PTL-707](https://genesisglobal.atlassian.net/browse/PTL-707)

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

