### PR TITLE
Added new dump mode and user commands to remap scripts sections

### DIFF
--- a/docs/05_operations/02_commands/01_server-commands.md
+++ b/docs/05_operations/02_commands/01_server-commands.md
@@ -136,19 +136,19 @@ If the database crashes during a `remap` and the database remains locked (or if 
 remap [-c | --commit]
 ```
 
-| Argument | Argument long name     | Mandatory | Description                                                                            | Restricted values |
-|----------|------------------------|-----------|----------------------------------------------------------------------------------------|-------------------|
-| -f       | --force                | no        | Forces the unlocking of a locked database                                              | No                |
-| -c       | --commit               | no        | Applies dictionary changes to the database                                             | No                |
-|          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                     | No                |
-|          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                      | No                |
-|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                   | No                |
-| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db          | No                |
-| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes    | No                |
-|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present  | No                |
-| -dm      | --dumpMode             | no        | Determines the DDL statements are outputted when using --dumpSQL. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
-|          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                  | No                 |
-|          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                  | No                 |
+| Argument | Argument long name     | Mandatory | Description                                                                                                                                     | Restricted values |
+|----------|------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| -f       | --force                | no        | Forces the unlocking of a locked database                                                                                                       | No                |
+| -c       | --commit               | no        | Applies dictionary changes to the database                                                                                                      | No                |
+|          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                                                                              | No                |
+|          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                                                                               | No                |
+|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                                                                           | No                |
+| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db                                                                     | No                |
+| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes                                                              | No                |
+|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present                                                            | No                |
+| -dm      | --dumpMode             | no        | Determines where the DDL statements are outputted when using --dumpSQL. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
+|          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
+|          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
 
 If you run remap with no arguments, it simply gives a report of changes that exist in the configuration.
 

--- a/docs/05_operations/02_commands/01_server-commands.md
+++ b/docs/05_operations/02_commands/01_server-commands.md
@@ -136,16 +136,16 @@ If the database crashes during a `remap` and the database remains locked (or if 
 remap [-c | --commit]
 ```
 
-| Argument | Argument long name     | Mandatory | Description                                                                                                                                     | Restricted values |
-|----------|------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| -f       | --force                | no        | Forces the unlocking of a locked database                                                                                                       | No                |
-| -c       | --commit               | no        | Applies dictionary changes to the database                                                                                                      | No                |
-|          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                                                                              | No                |
-|          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                                                                               | No                |
-|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                                                                           | No                |
-| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db                                                                     | No                |
-| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes                                                              | No                |
-|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present                                                            | No                |
+| Argument | Argument long name     | Mandatory | Description                                                                                                                                     | Restricted values  |
+|----------|------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| -f       | --force                | no        | Forces the unlocking of a locked database                                                                                                       | No                 |
+| -c       | --commit               | no        | Applies dictionary changes to the database                                                                                                      | No                 |
+|          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                                                                              | No                 |
+|          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                                                                               | No                 |
+|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                                                                           | No                 |
+| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db                                                                     | No                 |
+| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes                                                              | No                 |
+|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present                                                            | No                 |
 | -dm      | --dumpMode             | no        | Determines where the DDL statements are outputted when using --dumpSQL. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
 |          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
 |          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |

--- a/docs/05_operations/02_commands/01_server-commands.md
+++ b/docs/05_operations/02_commands/01_server-commands.md
@@ -146,7 +146,7 @@ remap [-c | --commit]
 | -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db                                                                     | No                 |
 | -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes                                                              | No                 |
 |          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present                                                            | No                 |
-| -dm      | --dumpMode             | no        | Determines where the DDL statements are outputted when using --dumpSQL. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
+| -dm      | --dumpMode             | no        | Determines where the DDL statements are outputted when using `--dumpSQL`. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
 |          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
 |          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
 

--- a/docs/05_operations/02_commands/01_server-commands.md
+++ b/docs/05_operations/02_commands/01_server-commands.md
@@ -136,19 +136,19 @@ If the database crashes during a `remap` and the database remains locked (or if 
 remap [-c | --commit]
 ```
 
-| Argument | Argument long name     | Mandatory | Description                                                                                                                                     | Restricted values  |
-|----------|------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
-| -f       | --force                | no        | Forces the unlocking of a locked database                                                                                                       | No                 |
-| -c       | --commit               | no        | Applies dictionary changes to the database                                                                                                      | No                 |
-|          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                                                                              | No                 |
-|          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                                                                               | No                 |
-|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                                                                           | No                 |
-| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db                                                                     | No                 |
-| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes                                                              | No                 |
-|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present                                                            | No                 |
+| Argument | Argument long name     | Mandatory | Description                                                                                                                                       | Restricted values  |
+|----------|------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| -f       | --force                | no        | Forces the unlocking of a locked database                                                                                                         | No                 |
+| -c       | --commit               | no        | Applies dictionary changes to the database                                                                                                        | No                 |
+|          | --force-dao-generation | no        | Forces the re-generation of DAOs on the given host                                                                                                | No                 |
+|          | --skip-dao-generation  | no        | Skips the re-generation of DAOs on the given host                                                                                                 | No                 |
+|          | --ask-db-password      | no        | Prompts for a DB user password to be manually entered                                                                                             | No                 |
+| -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db                                                                       | No                 |
+| -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes                                                                | No                 |
+|          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present                                                              | No                 |
 | -dm      | --dumpMode             | no        | Determines where the DDL statements are outputted when using `--dumpSQL`. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
-|          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
-|          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                             | No                 |
+|          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                               | No                 |
+|          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                               | No                 |
 
 If you run remap with no arguments, it simply gives a report of changes that exist in the configuration.
 

--- a/docs/05_operations/02_commands/01_server-commands.md
+++ b/docs/05_operations/02_commands/01_server-commands.md
@@ -146,6 +146,10 @@ remap [-c | --commit]
 | -d       | --dumpSQL              | no        | Outputs the SQL DDL statements to the console instead of applying to the db          | No                |
 | -m       | --metadataOnly         | no        | Only updates the GSF dictionary and alias stores, does not apply any table changes    | No                |
 |          | --skip-unchanged       | no        | Forces remap to fail if the `--commit` option is used and schema changes are present  | No                |
+| -dm      | --dumpMode             | no        | Determines the DDL statements are outputted when using --dumpSQL. The user will have the option of specifying the CONSOLE or a .sql file. | Yes: CONSOLE, FILE |
+|          | --db-username          | no        | Allows the user to enter the username for override credentials via the cli. This command works with fdb and Oracle.                  | No                 |
+|          | --db-password          | no        | Allows the user to enter the password for override credentials via the cli. This command works with fdb and Oracle.                  | No                 |
+
 If you run remap with no arguments, it simply gives a report of changes that exist in the configuration.
 
 For example:


### PR DESCRIPTION

Thank you for contributing to the documentation.

Your Jira ticket is:
[GSF-6025](https://genesisglobal.atlassian.net/browse/GSF-6025)

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes -->

Have you checked all new or changed links?
<!--- Yes-->

Is there anything else you would like us to know?
<!---No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

