### PR TITLE
PTL-719: change `routing` link

### DIFF
--- a/docs/01_getting-started/10_web-training/01_web-training-day1.md
+++ b/docs/01_getting-started/10_web-training/01_web-training-day1.md
@@ -246,7 +246,7 @@ We usually follow the pattern of creating **.template.ts**, **.ts** and **.style
 
 Realistically, any application will require multiple pages and routes.
 
-If you're not familiar with the concept of [routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
+If you're not familiar with the concept of [routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
 
 In our case, there's a `home` route pointing to the `Home` component which is the home page. The routes are set in the `config.ts` and we'll get into more details soon.
 

--- a/docs/04_web/01_basics/00_prerequisites.md
+++ b/docs/04_web/01_basics/00_prerequisites.md
@@ -52,7 +52,7 @@ If you get confused by any of the terminology we use in this section, we are pro
 <!-- TODO: link to foundation-ui example when we have one -->
 
 ### General Front-end concepts
-- [Routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/)
+- [Routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e)
 - [Websockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 - [Micro front-ends](https://martinfowler.com/articles/micro-frontends.html)
 - [State management](https://dev.to/snickdx/the-frontend-hitchhikers-guide-state-management-30ji) 

--- a/versioned_docs/version-2022.3/01_getting-started/10_web-training/01_web-training-day1.md
+++ b/versioned_docs/version-2022.3/01_getting-started/10_web-training/01_web-training-day1.md
@@ -236,7 +236,7 @@ We usually follow the pattern of creating a `.template.ts`, `.ts` and `.styles.t
 
 Realistically, any application will require multiple pages and routes. 
 
-If you're not familiar with the concept of [routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
+If you're not familiar with the concept of [routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
 
 In our case, there's a `home` route pointing to the `Home` component which is the home page. The routes are set in the `config.ts` and we'll get into more details soon. 
 

--- a/versioned_docs/version-2022.3/04_web/01_basics/00_prerequisites.md
+++ b/versioned_docs/version-2022.3/04_web/01_basics/00_prerequisites.md
@@ -52,7 +52,7 @@ If you get confused by any of the terminology we use in this section, we are pro
 <!-- TODO: link to foundation-ui example when we have one -->
 
 ### General Front-end concepts
-- [Routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/)
+- [Routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e)
 - [Websockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 - [Micro front-ends](https://martinfowler.com/articles/micro-frontends.html)
 - [State management](https://dev.to/snickdx/the-frontend-hitchhikers-guide-state-management-30ji) 

--- a/versioned_docs/version-2022.4/01_getting-started/10_web-training/01_web-training-day1.md
+++ b/versioned_docs/version-2022.4/01_getting-started/10_web-training/01_web-training-day1.md
@@ -234,7 +234,7 @@ We usually follow the pattern of creating a `.template.ts`, `.ts` and `.styles.t
 
 Realistically, any application will require multiple pages and routes. 
 
-If you're not familiar with the concept of [routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
+If you're not familiar with the concept of [routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
 
 In our case, there's a `home` route pointing to the `Home` component which is the home page. The routes are set in the `config.ts` and we'll get into more details soon. 
 

--- a/versioned_docs/version-2022.4/04_web/01_basics/00_prerequisites.md
+++ b/versioned_docs/version-2022.4/04_web/01_basics/00_prerequisites.md
@@ -52,7 +52,7 @@ If you get confused by any of the terminology we use in this section, we are pro
 <!-- TODO: link to foundation-ui example when we have one -->
 
 ### General Front-end concepts
-- [Routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/)
+- [Routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e)
 - [Websockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 - [Micro front-ends](https://martinfowler.com/articles/micro-frontends.html)
 - [State management](https://dev.to/snickdx/the-frontend-hitchhikers-guide-state-management-30ji) 

--- a/versioned_docs/version-2023.1/01_getting-started/10_web-training/01_web-training-day1.md
+++ b/versioned_docs/version-2023.1/01_getting-started/10_web-training/01_web-training-day1.md
@@ -246,7 +246,7 @@ We usually follow the pattern of creating **.template.ts**, **.ts** and **.style
 
 Realistically, any application will require multiple pages and routes.
 
-If you're not familiar with the concept of [routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
+If you're not familiar with the concept of [routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e), it's basically displaying different content or pages according to different URL addresses. In this context, it means that different routes correspond to different contents or pages on the front end; this is implemented by the server returning different pages according to the different URLs. In single-page applications, most pages are structurally unchanged and only part of the content is changed.
 
 In our case, there's a `home` route pointing to the `Home` component which is the home page. The routes are set in the `config.ts` and we'll get into more details soon.
 

--- a/versioned_docs/version-2023.1/04_web/01_basics/00_prerequisites.md
+++ b/versioned_docs/version-2023.1/04_web/01_basics/00_prerequisites.md
@@ -52,7 +52,7 @@ If you get confused by any of the terminology we use in this section, we are pro
 <!-- TODO: link to foundation-ui example when we have one -->
 
 ### General Front-end concepts
-- [Routing](https://developpaper.com/question/what-is-front-end-routing-when-is-front-end-routing-appropriate-what-are-the-advantages-and-disadvantages-of-front-end-routing/)
+- [Routing](https://javascript.plainenglish.io/take-a-look-at-how-front-end-routing-works-dd28d5bcc15e)
 - [Websockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
 - [Micro front-ends](https://martinfowler.com/articles/micro-frontends.html)
 - [State management](https://dev.to/snickdx/the-frontend-hitchhikers-guide-state-management-30ji) 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-719

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

