### PR TITLE
chore: update genx usage instructions FUI-1178

### DIFF
--- a/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
+++ b/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
@@ -26,8 +26,6 @@ import MinimunRequirement from '/snippet/_minimun_requirement.md'
 
 <MinimunRequirement />
 
-## Installing GenX
-
 <details>
   <summary>Pre-requisite check</summary>
     <li>JDK11 - <code>java --version </code> </li>
@@ -37,11 +35,9 @@ import MinimunRequirement from '/snippet/_minimun_requirement.md'
     <p>Check if these versions are compatible with the requirements.</p>
 </details>
 
-Since version 11.3.0 of the foundation-UI, we have set our libraries public. Hence, you only need to run this simple command to start using genesis.
+## .npmrc
 
-```powershell
-npm install -g @genesislcap/foundation-cli
-```
+Starting from version **10.3.0** Foundation UI libraries are published to the [public NPM registry](https://www.npmjs.com/~genesisnpm?activeTab=packages), so a custom `.npmrc` file is no longer required.
 
 ## gradle.properties file
 You should have a **gradle.properties** file inside a **.gradle** folder on your user directory; this file must contain your Genesis Artifactory password in a [base64 encrypted text](https://www.base64encode.org/), for example:

--- a/docs/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/docs/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -18,21 +18,13 @@ Download and install all the relevant requirements.
 ## The genx script
 `genx` is a CLI tool that enables you to seed projects. In this case, you shall generate a full-stack application project; the key files will be empty so that you can define the details of the application.
 
-If you still don't have genx installed, please see the session [Installing GenX](../../../getting-started/quick-start/hardware-and-software/#installing-genx).
-
 ## Starting
 
-Once configured and installed, from the Windows terminal, run:
+Launch CLI from the terminal:
 
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
-
-:::tip
-
-If this does not work, use the command `npx genx`.
-
-:::
 
 <!-- NO EDIT (NEXT 4 LINES) -->
 import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
@@ -70,7 +62,7 @@ App seed (Use arrow keys)
   Overwrite existing files (y/N)
   ```
 
-At this point, the seed application is created and the `genx` dependencies are installed.
+At this point, the seed application is created and the seed dependencies are installed.
 
 Then there are more questions, which you can respond to as follows (we have provided some notes below):
 

--- a/docs/01_getting-started/03_go-to-the-next-level/01_introduction.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/01_introduction.md
@@ -41,7 +41,7 @@ We are going to call this example application **positions-app-tutorial**. You wi
 Using the GenX CLI tool, we want to generate a blank full-stack application project. Go to a folder where you want your project to reside, and run:
 
 ```
-npx genx
+npx @genesislcap/genx@latest
 ```
 
 <!-- NO EDIT (NEXT 4 LINES) -->

--- a/docs/01_getting-started/04_prerequisites/01_introduction.md
+++ b/docs/01_getting-started/04_prerequisites/01_introduction.md
@@ -14,5 +14,4 @@ You can run our [Quick Start](/getting-started/quick-start/hardware-and-software
 - [Hardware and software](../../../getting-started/quick-start/hardware-and-software)
 - [Installing WSL](../../../getting-started/prerequisites/installing-wsl/)
 - [Gradle deploy plugin](../../../getting-started/prerequisites/gradle-deploy-plugin/)
-- [genx](../../../getting-started/prerequisites/genx/)
 - [Manual installation](../../../getting-started/prerequisites/manual-installation/)

--- a/docs/01_getting-started/04_prerequisites/04_genx.md
+++ b/docs/01_getting-started/04_prerequisites/04_genx.md
@@ -54,54 +54,47 @@ You should ignore any other seed version listings.
 
 - Recommended Operating system : Windows 10 Pro
 - [Node.js](https://nodejs.org/en/download/) version 16
-- Before installing genx, you need to [configure the Genesis npm repository](/getting-started/quick-start/hardware-and-software/#npmrc-set-up)
 
-## Installing genx
+## Launching genx
 
-Once the repository is configured, open a terminal on your Windows machine and install the CLI tool using this:
+Open a terminal on your machine and launch the CLI tool using this:
 
-```shell title="Windows Terminal"
-npm install -g @genesislcap/foundation-cli
-```
-
-Now you're ready to use the tool, simply type `genx` to start:
-
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
 
 This command presents you with a sequence of choices for creating and configuring applications.
 
 ## Using genx
 
-First, you'll be prompted to supply your Genesis artifactory credentials [used when setting up your .npmrc](../../../getting-started/quick-start/hardware-and-software/#npmrc-set-up)
+First, you'll be prompted to supply your Genesis artifactory credentials.
 
 Next, you just need to respond to the questions, which depend on the task you initially select. For example, if you want to create a new application:
 
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Please select an option: create application - Generates a local application.
 ```
 
 Enter the local directory where you want to create the app (where relevant, the default for these options is the letter displayed in upper case; this will be applied if nothing is entered):
 
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Create a app in current directory (Y/n)
 ```
 
 ... and then give it an appropriate name (e.g. **alpha**):
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? App name alpha
 ```
 
 Next, select the Seed application you wish to base your project on:
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? App seed
 
 > Genesis Quick Start Application
 ```
 
 Choose whether to overwrite existing files. Note that the default is **No**.
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Overwrite existing files (y/N)
 ```
 
@@ -111,22 +104,22 @@ This will start the download of dependencies.
 Once that has been completed, you will be prompted for configuring the front-end part of the project.
 
 The first prompt is the package [scope](https://docs.npmjs.com/cli/v8/using-npm/scope). The default is **genesislcap**.
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Package scope (without the @) genesislcap
 ```
 
 The next question is about the package name. You can use **alpha**.
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Package name alpha
 ```
 
 The next is whether you want to create a design system. The default is **Yes**.
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Create design system (Yes/no)
 ```
 
 Finally, whether you want to set an API host. The default is **Yes**.
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Set API Host (Yes/no)
 ```
 
@@ -134,12 +127,12 @@ Finally, whether you want to set an API host. The default is **Yes**.
 The next prompts concern the back-end part of the application.
 
 The first prompt is for the [group id](https://maven.apache.org/guides/mini/guide-naming-conventions.html):
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Group Id global.genesis
 ```
 
 ... and this is followed by the application version:
-```shell title="Windows Terminal"
+```shell title="Terminal"
 ? Application Version 1.0.0-SNAPSHOT
 ```
 
@@ -191,9 +184,11 @@ This is a monorepo containing multiple packages. Each package can be released in
 
 ## CLI command-language syntax
 
+To learn about available CLI commands run `npx @genesislcap/genx@latest -h`.
+
 The command syntax is:
 
-`genx` _commandNameOrAlias requiredArg [optionalArg]_ [options]
+`npx @genesislcap/genx@latest` _commandNameOrAlias requiredArg [optionalArg]_ [options]
 
 
 ## Boolean options

--- a/docs/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
+++ b/docs/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
@@ -6,18 +6,10 @@ id: create-a-new-project
 
 The GenX CLI tool enables you to seed projects. In this case, we just want to generate a blank full-stack application project.
 
-For step-by-step instructions on how to install and use this tool, follow the guide on GenX.
-
-Once configured, install GenX using the following command:
+From the terminal, run:
 
 ```shell
-npm install -g @genesislcap/foundation-cli
-```
-
-Once installed, from the terminal, run:
-
-```shell
-genx
+npx @genesislcap/genx@latest
 ```
 
 In the `genx` script, there are a series of questions.

--- a/docs/01_getting-started/05_use-cases/postgres-data-pipeline/01_create-project.md
+++ b/docs/01_getting-started/05_use-cases/postgres-data-pipeline/01_create-project.md
@@ -12,7 +12,6 @@ tags:
 ---
 
 ## Create new Genesis project
-At this point you should have `genx` installed on your machine. If you don't, then follow this [guide](../../../../getting-started/prerequisites/genx/) to set it up.
 
 Use `genx` to create new blank project following the instructions [here](../../../../getting-started/quick-start/create-a-new-project/). For the rest of the tutorial, **datapipeline-trades** will be used for the project name, but feel free to choose any name you like.
 

--- a/docs/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/docs/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -128,16 +128,12 @@ This setup presumes you will sign in with jfrog SAML SSO. Please follow the step
 </TabItem>
 </Tabs>
 
-Install GenX CLI; this is a Genesis tool that enables you to seed projects.
+Launch GenX CLI; this is a Genesis tool that enables you to seed projects.
 ```shell
-npm install -g @genesislcap/foundation-cli
+npx @genesislcap/genx@latest
 ```
 
-Check that GenX CLI is working:
-```shell
-npx genx
-```
-and you should see this message:
+You should see this message:
 ```shell
 
 

--- a/docs/_includes/_cli-insecure-flag.md
+++ b/docs/_includes/_cli-insecure-flag.md
@@ -1,9 +1,8 @@
 :::caution Local issuer certificate errors
 
-These may be caused by running `genx` in a proxy network that uses self-signed or missing certificates.
-`genx --insecure` can be used to instruct genx to be lenient on SSL handshakes. Please
-ensure you are using the latest version by reinstalling it if the message persists:
+These may be caused by running GenX CLI in a proxy network that uses self-signed or missing certificates.
+`--insecure` flag can be used to skip SSL certificate verification:
 
-`npm un -g @genesislcap/foundation-cli && npm i -g @genesislcap/foundation-cli`
+`npx @genesislcap/genx@latest --insecure`
 
 :::

--- a/versioned_docs/version-2022.3/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2022.3/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -11,21 +11,13 @@ tags:
 
 The GenX CLI tool enables you to seed projects. In this case we want to generate a blank full-stack application project.
 
-We also have step-by-step instructions on [how to install and use genx](../../../getting-started/prerequisites/genx/).
-
 ## Starting
 
-Once configured and installed, from the Windows terminal, run:
+Launch it from the terminal:
 
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
-
-:::tip
-
-If the above command does not work, use the command `npx genx`.
-
-:::
 
 In the `genx` script, there is a series of questions.
 

--- a/versioned_docs/version-2022.3/01_getting-started/03_go-to-the-next-level/01_introduction.md
+++ b/versioned_docs/version-2022.3/01_getting-started/03_go-to-the-next-level/01_introduction.md
@@ -38,7 +38,7 @@ We are going to call this example application **positions-app-tutorial**. You wi
 Using the GenX CLI tool, we want to generate a blank full-stack application project. Go to a folder where you want your project to reside, and run:
 
 ```
-npx genx
+npx @genesislcap/genx@latest
 ```
 
 Follow through the series of questions. For `App name` enter `positions-app-tutorial` and for `App seed` enter `Quick Start Application`.

--- a/versioned_docs/version-2022.3/01_getting-started/04_prerequisites/01_introduction.md
+++ b/versioned_docs/version-2022.3/01_getting-started/04_prerequisites/01_introduction.md
@@ -14,5 +14,4 @@ To set up a full-functioning developer workstation, you need to check out the ha
 - [Hardware and software](../../../getting-started/quick-start/hardware-and-software)
 - [Installing WSL](../../../getting-started/prerequisites/installing-wsl/)
 - [Gradle deploy plugin](../../../getting-started/prerequisites/gradle-deploy-plugin/)
-- [genx](../../../getting-started/prerequisites/genx/)
 - [Manual installation](../../../getting-started/prerequisites/manual-installation/)

--- a/versioned_docs/version-2022.3/01_getting-started/04_prerequisites/04_genx.md
+++ b/versioned_docs/version-2022.3/01_getting-started/04_prerequisites/04_genx.md
@@ -20,27 +20,20 @@ With GenX, you can pull seed projects that adhere to best practices for developm
 
 - Recommended Operating system : Windows 10 Pro
 - [Node.js](https://nodejs.org/en/download/) version 16
-- Before installing GenX, you need to [configure the Genesis npm repository](../../../getting-started/quick-start/hardware-and-software/#npmrc-set-up)
 
-## Installing GenX
+## Launching
 
-Once the repository is configured, open a terminal on your Windows machine and install the CLI tool using this:
+Open a terminal on your machine and launch the CLI tool:
 
-```shell title="Windows Terminal"
-npm install -g @genesislcap/foundation-cli
-```
-
-Now you're ready to use the tool, simply type `genx` to start:
-
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
 
 This command presents you with a sequence of choices for creating and configuring applications.
 
 ## Using GenX
 
-First, you'll be prompted to supply your Genesis artifactory credentials [used when setting up your .npmrc](../../../getting-started/quick-start/hardware-and-software/#npmrc-set-up)
+First, you'll be prompted to supply your Genesis artifactory credentials.
 
 Next, follow the instructions according to the task you're wishing to carry out.
 
@@ -180,9 +173,11 @@ This is a monorepo containing multiple packages. Each package can be released in
 
 ## CLI command-language syntax
 
+To learn about available CLI commands run `npx @genesislcap/genx@latest -h`.
+
 The command syntax is:
 
-`genx` _commandNameOrAlias requiredArg [optionalArg]_ [options]
+`npx @genesislcap/genx@latest` _commandNameOrAlias requiredArg [optionalArg]_ [options]
 
 
 ## Boolean options

--- a/versioned_docs/version-2022.3/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2022.3/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
@@ -6,21 +6,11 @@ id: create-a-new-project
 
 The GenX CLI tool enables you to seed projects. In this case, we just want to generate a blank full-stack application project.
 
-For step-by-step instructions on how to install and use this tool, follow the guide on GenX.
+Launch GenX using the following command:
 
-Once configured, install GenX using the following command:
-
-```shell
-npm install -g @genesislcap/foundation-cli
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
-
-Once installed, from the terminal, run:
-
-```shell
-genx
-```
-
-In the `genx` script, there are a series of questions.
 
 First, you are asked to provide your username and password - these are the credentials you use to access Genesis Artifactory.
 

--- a/versioned_docs/version-2022.3/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/versioned_docs/version-2022.3/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -149,16 +149,13 @@ This setup presumes you will sign in with jfrog SAML SSO. Please follow the step
 </Tabs>
 
 
-Install GenX CLI; this is a Genesis tool that enables you to seed projects.
+Launch GenX CLI; this is a Genesis tool that enables you to seed projects.
+
 ```shell
-npm install -g @genesislcap/foundation-cli
+npx @genesislcap/genx@latest
 ```
 
-Check that GenX CLI is working:
-```shell
-npx genx
-```
-and you should see this message:
+You should see this message:
 ```shell
 
 

--- a/versioned_docs/version-2022.4/01_getting-started/04_prerequisites/04_genx.md
+++ b/versioned_docs/version-2022.4/01_getting-started/04_prerequisites/04_genx.md
@@ -26,16 +26,10 @@ With genx, you can pull seed projects that adhere to best practices for developm
 
 ## Installing genx
 
-Once the repository is configured, open a terminal on your Windows machine and install the CLI tool using this:
+Once the repository is configured, open a terminal on your machine and launch the CLI tool using this:
 
-```shell title="Windows Terminal"
-npm install -g @genesislcap/foundation-cli
-```
-
-Now you're ready to use the tool, simply type `genx` to start:
-
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
 
 This command presents you with a sequence of choices for creating and configuring applications.
@@ -164,9 +158,11 @@ This is a monorepo containing multiple packages. Each package can be released in
 
 ## CLI command-language syntax
 
+To learn about available CLI commands run `npx @genesislcap/genx@latest -h`.
+
 The command syntax is:
 
-`genx` _commandNameOrAlias requiredArg [optionalArg]_ [options]
+`npx @genesislcap/genx@latest` _commandNameOrAlias requiredArg [optionalArg]_ [options]
 
 
 ## Boolean options

--- a/versioned_docs/version-2022.4/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2022.4/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
@@ -6,21 +6,11 @@ id: create-a-new-project
 
 The GenX CLI tool enables you to seed projects. In this case, we just want to generate a blank full-stack application project.
 
-For step-by-step instructions on how to install and use this tool, follow the guide on GenX.
-
-Once configured, install GenX using the following command:
+Launch GenX using the following command:
 
 ```shell
-npm install -g @genesislcap/foundation-cli
+npx @genesislcap/genx@latest
 ```
-
-Once installed, from the terminal, run:
-
-```shell
-genx
-```
-
-In the `genx` script, there are a series of questions.
 
 First, you are asked to provide your username and password - these are the credentials you use to access Genesis Artifactory.
 

--- a/versioned_docs/version-2022.4/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/versioned_docs/version-2022.4/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -148,16 +148,13 @@ This setup presumes you will sign in with jfrog SAML SSO. Please follow the step
 </TabItem>
 </Tabs>
 
-Install GenX CLI; this is a Genesis tool that enables you to seed projects.
+Launch GenX CLI; this is a Genesis tool that enables you to seed projects.
+
 ```shell
-npm install -g @genesislcap/foundation-cli
+npx @genesislcap/genx@latest
 ```
 
-Check that GenX CLI is working:
-```shell
-npx genx
-```
-and you should see this message:
+You should see this message:
 ```shell
 
 

--- a/versioned_docs/version-2022.4/_includes/_cli-insecure-flag.md
+++ b/versioned_docs/version-2022.4/_includes/_cli-insecure-flag.md
@@ -1,9 +1,8 @@
 :::caution Local issuer certificate errors
 
-These may be caused by running `genx` in a proxy network that uses self-signed or missing certificates.
-`genx --insecure` can be used to instruct genx to be lenient on SSL handshakes. Please
-ensure you are using the latest version by reinstalling it if the message persists:
+These may be caused by running GenX CLI in a proxy network that uses self-signed or missing certificates.
+`--insecure` flag can be used to skip SSL certificate verification:
 
-`npm un -g @genesislcap/foundation-cli && npm i -g @genesislcap/foundation-cli`
+`npx @genesislcap/genx@latest --insecure`
 
 :::

--- a/versioned_docs/version-2023.1/01_getting-started/02_quick-start/00_hardware-and-software.md
+++ b/versioned_docs/version-2023.1/01_getting-started/02_quick-start/00_hardware-and-software.md
@@ -37,11 +37,7 @@ import MinimunRequirement from '/snippet/_minimun_requirement.md'
     <p>Check if these versions are compatible with the requirements.</p>
 </details>
 
-Since version 11.3.0 of the foundation-UI, we have set our libraries public. Hence, you only need to run this simple command to start using genesis.
-
-```powershell
-npm install -g @genesislcap/foundation-cli
-```
+Starting from version **10.3.0** Foundation UI libraries are published to the [public NPM registry](https://www.npmjs.com/~genesisnpm?activeTab=packages), so a custom `.npmrc` file is no longer required.
 
 ## gradle.properties file
 You should have a **gradle.properties** file inside a **.gradle** folder on your user directory; this file must contain your Genesis Artifactory password in a [base64 encrypted text](https://www.base64encode.org/), for example:

--- a/versioned_docs/version-2023.1/01_getting-started/04_prerequisites/04_genx.md
+++ b/versioned_docs/version-2023.1/01_getting-started/04_prerequisites/04_genx.md
@@ -58,16 +58,10 @@ You should ignore any other seed version listings.
 
 ## Installing genx
 
-Once the repository is configured, open a terminal on your Windows machine and install the CLI tool using this:
+Once the repository is configured, open a terminal on your machine and launch the CLI tool using this:
 
-```shell title="Windows Terminal"
-npm install -g @genesislcap/foundation-cli
-```
-
-Now you're ready to use the tool, simply type `genx` to start:
-
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
 
 This command presents you with a sequence of choices for creating and configuring applications.
@@ -191,9 +185,11 @@ This is a monorepo containing multiple packages. Each package can be released in
 
 ## CLI command-language syntax
 
+To learn about available CLI commands run `npx @genesislcap/genx@latest -h`.
+
 The command syntax is:
 
-`genx` _commandNameOrAlias requiredArg [optionalArg]_ [options]
+`npx @genesislcap/genx@latest` _commandNameOrAlias requiredArg [optionalArg]_ [options]
 
 
 ## Boolean options

--- a/versioned_docs/version-2023.1/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2023.1/01_getting-started/05_use-cases/09_faster_quick-start/02_create-a-new-project.md
@@ -6,21 +6,11 @@ id: create-a-new-project
 
 The GenX CLI tool enables you to seed projects. In this case, we just want to generate a blank full-stack application project.
 
-For step-by-step instructions on how to install and use this tool, follow the guide on GenX.
+Launch GenX using the following command:
 
-Once configured, install GenX using the following command:
-
-```shell
-npm install -g @genesislcap/foundation-cli
+```shell title="Terminal"
+npx @genesislcap/genx@latest
 ```
-
-Once installed, from the terminal, run:
-
-```shell
-genx
-```
-
-In the `genx` script, there are a series of questions.
 
 First, you are asked to provide your username and password - these are the credentials you use to access Genesis Artifactory.
 

--- a/versioned_docs/version-2023.1/01_getting-started/05_use-cases/postgres-data-pipeline/01_create-project.md
+++ b/versioned_docs/version-2023.1/01_getting-started/05_use-cases/postgres-data-pipeline/01_create-project.md
@@ -12,7 +12,6 @@ tags:
 ---
 
 ## Create new Genesis project
-At this point you should have `genx` installed on your machine. If you don't, then follow this [guide](../../../../getting-started/prerequisites/genx/) to set it up.
 
 Use `genx` to create new blank project following the instructions [here](../../../../getting-started/quick-start/create-a-new-project/). For the rest of the tutorial, **datapipeline-trades** will be used for the project name, but feel free to choose any name you like.
 

--- a/versioned_docs/version-2023.1/01_getting-started/06_developer-training/0b_environment-setup.md
+++ b/versioned_docs/version-2023.1/01_getting-started/06_developer-training/0b_environment-setup.md
@@ -126,16 +126,13 @@ This setup presumes you will sign in with jfrog SAML SSO. Please follow the step
 </TabItem>
 </Tabs>
 
-Install GenX CLI; this is a Genesis tool that enables you to seed projects.
+Launch GenX CLI; this is a Genesis tool that enables you to seed projects.
+
 ```shell
-npm install -g @genesislcap/foundation-cli
+npx @genesislcap/genx@latest
 ```
 
-Check that GenX CLI is working:
-```shell
-npx genx
-```
-and you should see this message:
+You should see this message:
 ```shell
 
 

--- a/versioned_docs/version-2023.1/_includes/_cli-insecure-flag.md
+++ b/versioned_docs/version-2023.1/_includes/_cli-insecure-flag.md
@@ -1,9 +1,8 @@
 :::caution Local issuer certificate errors
 
-These may be caused by running `genx` in a proxy network that uses self-signed or missing certificates.
-`genx --insecure` can be used to instruct genx to be lenient on SSL handshakes. Please
-ensure you are using the latest version by reinstalling it if the message persists:
+These may be caused by running GenX CLI in a proxy network that uses self-signed or missing certificates.
+`--insecure` flag can be used to skip SSL certificate verification:
 
-`npm un -g @genesislcap/foundation-cli && npm i -g @genesislcap/foundation-cli`
+`npx @genesislcap/genx@latest --insecure`
 
 :::


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
FUI-1178

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
No link changes

Is there anything else you would like us to know?
* updating genx package name
* simplifying usage instructions - using `npx` it doesn't need to be installed in advance, so it's not a prerequisite anymore
* Using `@latest` means always using the latest version - no need to uninstall/reinstall 
* Removed a few `Windows` references where the steps themselves are platform independent

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

