### PR TITLE
feat: add JWT config example to SSO page, mark passordRetry as deprecated (PTL-730)

### DIFF
--- a/docs/03_server/05_access-control/03_password_authentication.md
+++ b/docs/03_server/05_access-control/03_password_authentication.md
@@ -73,6 +73,9 @@ The following variables are used to configure an LDAP connection; these are only
 
 For more information about the various authentication types, please see the [Authentication overview](../../../server/access-control/authentication-overview/).
 
+### passwordRetry
+The `passwordRetry` function has been deprecated in favour of the `retry` function within the `genesisPassword` configuration.
+
 ### genesisPassword
 
 The `genesisPassword` groups all configuration options when using `type = AuthType.INTERNAL`. 
@@ -256,7 +259,6 @@ security {
 
     sso {
         enabled = false
-        newUserMode = NewUserMode.REJECT
     }
 
     mfa {

--- a/docs/03_server/05_access-control/04_sso_jwt.md
+++ b/docs/03_server/05_access-control/04_sso_jwt.md
@@ -80,26 +80,41 @@ To enable SSO, you need to configure it in your _application-name_**-auth-prefer
 
 The following options are available from within the `security` function. For a more detailed look at the **auth-preferences.kts** file, visit the [Password Authentication section](../../../server/access-control/password-authentication/).
 
-### sso
-The `sso` function enables you to configure and enable SSO options. You can set the following variables:
+### SSO
+The `sso` function allows you to configure and enable SSO options. It has the following variables to set:
 
-* `enabled` is a boolean value that defines whether the SSO functionality is enabled. Default: `true` when the `sso` function is invoked, otherwise `false`.
+* `enabled` is a boolean value that defines whether the SSO functionality is enabled. Default: true when the `sso` function is invoked, otherwise false.
 * `onFirstLogin` is a function that is called when a user has been authenticated for the first time and doesn't yet exist in the database. Here you can define two things:
   * how a `User` and its `UserAttributes` will be created from the token after the user has been authenticated using the `createUser` function
   * which user permissions are allocated using `createUserPermissions`
-* `onLoginSuccess` is a function that is called each time the user is authenticated. Inside the function, you have access to the actual token that was used for authentication and database access.
-* `newUserMode` **is now deprecated** in favour of `onFirstLogin` and `onLoginSuccess`. This property defines behaviour for processing users the first time they log in with SSO. This can take the values of `NewUserMode.REJECT`, `NewUserMode.CREATE_ENABLED`, `NewUserMode.CREATE_DISABLED`. Default `NewUserMode.REJECT`.
-  * In the case of `NewUserMode.REJECT`, when a user logs in for the first time with SSO, if they do not already have a user account, they are rejected.
-  * In the case of `NewUserMode.CREATE_ENABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, an active account is created for them.
-  * In the case of `NewUserMode.CREATE_DISABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, a disabled account is created for them. This will need to be activated before it can be used.
+* `onLoginSuccess` is a function that is called each time the user gets authenticated. Inside the function you have access to the actual token that was used for authentication and database access.
+* `newUserMode` is now deprecated in favour of `onFirstLogin` and `onLoginSuccess`.
 
-### passwordRetry
-The `passwordRetry` function enables you to configure settings for limiting the rate at which a user can retry passwords and SSO tokens. It allows the following variables to be set:
+### SSO Example
+```kotlin
+// applicationName-auth-preferences.kts:
+sso {
+    enabled = true
+    onFirstLogin {
+        createUser { jwtSuccessOutcome ->
+            val userName = jwtSuccessOutcome.id
+            User(userName, domain = jwtSuccessOutcome.domain) to UserAttributes(userName)
+        }
 
-* `maxAttempts` defines the maximum number of attempts allowed if a user enters an incorrect SSO token. Default: 3
-* `waitTimeMins` specifies the time to wait when the maximum number of incorrect attempts is reached. Default: 5.
+        createUserPermissions {
+            userProfiles("default")
+        }
+    }
 
-
+    onLoginSuccess { entityDb, jwtLoginRequestToken ->
+        // Valid token received from SSO provider
+    }
+}
+```
+:::note
+When using a JWT the `maxAttempts` property in the [password retry config](./03_password_authentication.md#retry) 
+refers to the maximum number of attempts allowed if a user enters an incorrect SSO token.
+:::
 
 ## Revalidating the token
 

--- a/versioned_docs/version-2022.3/03_server/05_access-control/04_sso_authentication.md
+++ b/versioned_docs/version-2022.3/03_server/05_access-control/04_sso_authentication.md
@@ -35,11 +35,10 @@ The `sso` function allows you to configure and enable SSO options. It has the fo
   * In the case of `NewUserMode.CREATE_ENABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, an active account is created for them.
   * In the case of `NewUserMode.CREATE_DISABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, a disabled account is created for them. This will be need to be activated before it can be used.
 
-### passwordRetry
-The `passwordRetry` function allows you to configure settings for limiting the rate at which a user can retry passwords and SSO tokens. It allows the following variables to be set:
-
-* `maxAttempts` defines the maximum number of attempts allowed if a user enters an incorrect SSO token. Default: 3
-* `waitTimeMins` specifies the time to wait when the maximum number of incorrect attempts is reached. Default: 5.
+:::note
+When using a JWT the `maxAttempts` property in the [password retry config](./03_password_authentication.md#passwordretry) 
+refers to the maximum number of attempts allowed if a user enters an incorrect SSO token.
+:::
 
 
 ## JWT SSO

--- a/versioned_docs/version-2022.4/03_server/05_access-control/04_sso_authentication.md
+++ b/versioned_docs/version-2022.4/03_server/05_access-control/04_sso_authentication.md
@@ -35,11 +35,10 @@ The `sso` function allows you to configure and enable SSO options. It has the fo
   * In the case of `NewUserMode.CREATE_ENABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, an active account is created for them.
   * In the case of `NewUserMode.CREATE_DISABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, a disabled account is created for them. This will be need to be activated before it can be used.
 
-### passwordRetry
-The `passwordRetry` function allows you to configure settings for limiting the rate at which a user can retry passwords and SSO tokens. It allows the following variables to be set:
-
-* `maxAttempts` defines the maximum number of attempts allowed if a user enters an incorrect SSO token. Default: 3
-* `waitTimeMins` specifies the time to wait when the maximum number of incorrect attempts is reached. Default: 5.
+:::note
+When using a JWT the `maxAttempts` property in the [password retry config](./03_password_authentication.md#passwordretry) 
+refers to the maximum number of attempts allowed if a user enters an incorrect SSO token.
+:::
 
 
 ## JWT SSO

--- a/versioned_docs/version-2023.1/03_server/05_access-control/03_password_authentication.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/03_password_authentication.md
@@ -70,6 +70,9 @@ The following variables are used to configure an LDAP connection; these are only
 
 For more information about the various authentication types, please see the [Authentication overview](../../../server/access-control/authentication-overview/).
 
+### passwordRetry
+The `passwordRetry` function has been deprecated in favour of the `retry` function within the `genesisPassword` configuration.
+
 ### genesisPassword
 
 The `genesisPassword` groups all configuration options when using `type = AuthType.INTERNAL`. 

--- a/versioned_docs/version-2023.1/03_server/05_access-control/04_sso_authentication.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/04_sso_authentication.md
@@ -35,11 +35,10 @@ The `sso` function allows you to configure and enable SSO options. It has the fo
   * In the case of `NewUserMode.CREATE_ENABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, an active account is created for them.
   * In the case of `NewUserMode.CREATE_DISABLED`, when a user logs in for the first time with SSO, if they do not already have a user account, a disabled account is created for them. This will be need to be activated before it can be used.
 
-### passwordRetry
-The `passwordRetry` function allows you to configure settings for limiting the rate at which a user can retry passwords and SSO tokens. It allows the following variables to be set:
-
-* `maxAttempts` defines the maximum number of attempts allowed if a user enters an incorrect SSO token. Default: 3
-* `waitTimeMins` specifies the time to wait when the maximum number of incorrect attempts is reached. Default: 5.
+:::note
+When using a JWT the `maxAttempts` property in the [password retry config](./03_password_authentication.md#retry) 
+refers to the maximum number of attempts allowed if a user enters an incorrect SSO token.
+:::
 
 
 ## JWT SSO


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
[PTL-730](https://genesisglobal.atlassian.net/browse/PTL-730)

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

