### PR TITLE
PTL-736: added a note for positions-app reference

### DIFF
--- a/docs/01_getting-started/03_go-to-the-next-level/01_introduction.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/01_introduction.md
@@ -56,5 +56,5 @@ If this is the first time you are using the GenX CLI tool, check the [Quick Star
 :::info
 This project is not a direct copy of the positions app but will contain most of its functionality.
 
-The [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial) can be used as a reference point for this tutorial. 
+The [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial) is a complete application that can be used as a reference point for this tutorial. 
 :::

--- a/docs/01_getting-started/03_go-to-the-next-level/02_data-model.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/02_data-model.md
@@ -228,7 +228,7 @@ During code generation, [view](../../../database/data-structures/views/) and [in
 
 
 ## Conclusion
-With this, our data model is defined. You can use the [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference.
+With this, our data model is defined. As a next step, we shall add some data to the tables in the database.
 
-As a next step, we shall add some data to the tables in the database.
+You can use the [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/docs/01_getting-started/03_go-to-the-next-level/04_events.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/04_events.md
@@ -134,6 +134,6 @@ From the Gradle menu on the right of Intellij, this is: **genesisproduct-positio
 ## Conclusion
 Data Server and Event Handler are the main components to interact with the server. Now that we have built our back end, we have something to interact with. Once you have deployed it, if you want to test what you've done so far, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/).
 
-For a reference point for these components checkout the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts). 
+For a reference point for these components checkout the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts). Note that this repo is a complete application and may not reflect the changes made in this page.
 
 Otherwise, you can continue to the [next section](../../../getting-started/go-to-the-next-level/data-grid/) and deploy and test the whole application at later time.

--- a/docs/01_getting-started/03_go-to-the-next-level/05_data-grid.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/05_data-grid.md
@@ -182,4 +182,4 @@ You can add the `persist-column-state-key` to the zero-grid-pro to persist user 
 [//]: # (link to zero-grid-pro tsdocs)
 
 ## Conclusion
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the grids.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the grids. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/06_forms.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/06_forms.md
@@ -435,4 +435,4 @@ import { mustMatch } from '@genesislcap/foundation-forms';
 ```
 
 ## Conclusion
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the forms.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the forms. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/07_calculated-data.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/07_calculated-data.md
@@ -64,5 +64,5 @@ views {
 ## Conclusion
 We just added a derived field. To see it in action, follow the steps on the next page that will show you how to glue the consolidator and view together.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference point for the view. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference point for the view. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/docs/01_getting-started/03_go-to-the-next-level/08_consolidators.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/08_consolidators.md
@@ -171,4 +171,4 @@ When you finish, remember to run `generateDao` (if you made changes to the table
 ## Conclusion
 This shows a quick example of a Consolidator. If you want to see it in action, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/) for information on testing the back end.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the consolidators. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the consolidators. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/09_state_management.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/09_state_management.md
@@ -281,4 +281,4 @@ To test it, you can try to modify a `TRADE` (assuming you already have at least 
 ## Conclusion
 With this, we finish showing how an application can add state management. If you want to see it in action, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/) for information about testing the back end.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the event handlers. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the event handlers. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/10_audit.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/10_audit.md
@@ -121,4 +121,4 @@ Finally we can run `generateDao`, `assemble` and `deploy-genesisproduct-position
 ### Conclusion
 With this, any changes made to `TRADE` are tracked to `TRADE_AUDIT`. To try it out, insert a new `TRADE` and see what's stored in the `TRADE_AUDIT` table via `DbMon`. Go to your terminal and run `DbMon`, `table TRADE_AUDIT` and `search 1`. For more information on testing, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -478,5 +478,5 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis l
 ### Conclusion
 This concludes generating reports for the positions application. In the next section you will see how to trigger based on a condition in the database.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/docs/01_getting-started/03_go-to-the-next-level/12_data-pipeline.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/12_data-pipeline.md
@@ -140,4 +140,4 @@ In this section, we have created a working data pipeline. Given everything is wo
 
 ![DbMon screenshot](/img/dbmon-datapipeline.PNG)
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/13_charting.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/13_charting.md
@@ -146,4 +146,4 @@ If you have been following along the entire tutorial your page should look somet
 
 ![](/img/charts-whole-page.png)
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/14_customise-look-and-feel.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/14_customise-look-and-feel.md
@@ -98,4 +98,4 @@ In the [next section](./15_dynamic_layout.md) you'll have the option to add a dy
 ## Styling other parts of application
 This was only a small part of the platform's capabilities in terms of styling. You can read more about design-system configuration [here](web/design-systems/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/16_micro-frontends.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/16_micro-frontends.md
@@ -53,4 +53,4 @@ Now you can visit `/users` in your browser, and it should take you to the **user
 
 Read more about available micro front-ends and the different ways of including them in your application in our pages on [micro front-ends](web/micro-front-ends/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/01_getting-started/03_go-to-the-next-level/17_camel-integrations.md
+++ b/docs/01_getting-started/03_go-to-the-next-level/17_camel-integrations.md
@@ -106,4 +106,4 @@ You should now see "Hello World" returned.
 There are a countless number of choices when it comes to [Camel components](https://camel.apache.org/components/3.16.x/index.html). Take a look at the list to see if there is something that works with your own use cases.
 
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/docs/02_database/01_fields-tables-views/02_tables/02_tables-advanced.md
+++ b/docs/02_database/01_fields-tables-views/02_tables/02_tables-advanced.md
@@ -181,7 +181,7 @@ Now you must update the **alpha-eventhandler.kts** in order to pass the `entityD
 ### Conclusion
 With this, any changes made to `TRADE` are tracked to `TRADE_AUDIT`. To try it out, insert a new `TRADE` and see what's stored in the `TRADE_AUDIT` table via `DbMon`. Go to your terminal and run `DbMon`, `table TRADE_AUDIT` and `search 1`. For more information on testing, go to [Endpoints](../../../03_server/10_integration/01_rest-endpoints/01_introduction.md).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this. Note that this repo is a complete application and may not reflect the changes made in this page.
 
 
 

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/01_introduction.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/01_introduction.md
@@ -55,5 +55,5 @@ If this is the first time you are using the GenX CLI tool, check the [Quick Star
 :::info
 This project is not a direct copy of the positions app but will contain most of its functionality.
 
-The [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial) can be used as a reference point for this tutorial. 
+The [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial) is a complete application that can be used as a reference point for this tutorial. 
 :::

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/02_data-model.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/02_data-model.md
@@ -228,7 +228,7 @@ During code generation, [view](../../../database/data-structures/views/) and [in
 
 
 ## Conclusion
-With this, our data model is defined. You can use the [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference.
+With this, our data model is defined. You can use the [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference. Note that this repo is a complete application and may not reflect the changes made in this page.
 
 As a next step, we shall add some data to the tables in the database.
 

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/04_events.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/04_events.md
@@ -134,6 +134,6 @@ From the Gradle menu on the right of Intellij, this is: **genesisproduct-positio
 ## Conclusion
 Data Server and Event Handler are the main components to interact with the server. Now that we have built our back end, we have something to interact with. Once you have deployed it, if you want to test what you've done so far, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/).
 
-For a reference point for these components checkout the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts). 
+For a reference point for these components checkout the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts). Note that this repo is a complete application and may not reflect the changes made in this page.
 
 Otherwise, you can continue to the [next section](../../../getting-started/go-to-the-next-level/data-grid/) and deploy and test the whole application at later time.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/05_data-grid.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/05_data-grid.md
@@ -182,4 +182,4 @@ You can add the `persist-column-state-key` to the zero-grid-pro to persist user 
 [//]: # (link to zero-grid-pro tsdocs)
 
 ## Conclusion
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the grids. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the grids. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/06_forms.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/06_forms.md
@@ -213,4 +213,4 @@ Now if everything has worked, you can go to your browser, insert the data for a 
 
 
 ## Conclusion
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the forms. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the forms. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/07_calculated-data.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/07_calculated-data.md
@@ -64,5 +64,5 @@ views {
 ## Conclusion
 We just added a derived field. To see it in action, follow the steps on the next page that will show you how to glue the consolidator and view together.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference point for the view. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference point for the view. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/08_consolidators.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/08_consolidators.md
@@ -171,4 +171,4 @@ When you finish, remember to run `generateDao` (if you made changes to the table
 ## Conclusion
 This shows a quick example of a Consolidator. If you want to see it in action, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/) for information on testing the back end.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the consolidators. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the consolidators. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/09_state_management.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/09_state_management.md
@@ -281,4 +281,4 @@ To test it, you can try to modify a `TRADE` (assuming you already have at least 
 ## Conclusion
 With this, we finish showing how an application can add state management. If you want to see it in action, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/) for information about testing the back end.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the event handlers. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the event handlers. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/10_audit.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/10_audit.md
@@ -121,4 +121,4 @@ Finally we can run `generateDao`, `assemble` and `deploy-genesisproduct-position
 ### Conclusion
 With this, any changes made to `TRADE` are tracked to `TRADE_AUDIT`. To try it out, insert a new `TRADE` and see what's stored in the `TRADE_AUDIT` table via `DbMon`. Go to your terminal and run `DbMon`, `table TRADE_AUDIT` and `search 1`. For more information on testing, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -478,5 +478,5 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis l
 ### Conclusion
 This concludes generating reports for the positions application. In the next section you will see how to trigger based on a condition in the database.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/12_data-pipeline.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/12_data-pipeline.md
@@ -140,4 +140,4 @@ In this section, we have created a working data pipeline. Given everything is wo
 
 ![DbMon screenshot](/img/dbmon-datapipeline.PNG)
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/13_charting.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/13_charting.md
@@ -83,4 +83,4 @@ You should have a data chart that resembles something like this:
 
 ![](/img/charts.png)
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/14_customise-look-and-feel.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/14_customise-look-and-feel.md
@@ -97,4 +97,4 @@ By default, all elements on screen will use `display: block`, but we can easily 
 ## Styling other parts of application
 This was only a small part of the platform's capabilities in terms of styling. You can read more about design-system configuration [here](web/design-systems/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/15_micro-frontends.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/15_micro-frontends.md
@@ -53,4 +53,4 @@ Now you can visit `/users` in your browser, and it should take you to the **user
 
 Read more about available micro front-ends and different ways of including them in your application in our pages on [micro front-ends](web/micro-front-ends/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/16_camel-integrations.md
+++ b/versioned_docs/version-2022.4/01_getting-started/03_go-to-the-next-level/16_camel-integrations.md
@@ -106,4 +106,4 @@ You should now see "Hello World" returned.
 There are a countless number of choices when it comes to [Camel components](https://camel.apache.org/components/3.16.x/index.html). Take a look at the list to see if there is something that works with your own use cases.
 
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2022.4/02_database/01_fields-tables-views/02_tables/02_tables-advanced.md
+++ b/versioned_docs/version-2022.4/02_database/01_fields-tables-views/02_tables/02_tables-advanced.md
@@ -181,7 +181,7 @@ Now you must update the **alpha-eventhandler.kts** in order to pass the `entityD
 ### Conclusion
 With this, any changes made to `TRADE` are tracked to `TRADE_AUDIT`. To try it out, insert a new `TRADE` and see what's stored in the `TRADE_AUDIT` table via `DbMon`. Go to your terminal and run `DbMon`, `table TRADE_AUDIT` and `search 1`. For more information on testing, go to [Endpoints](../../../03_server/10_integration/01_rest-endpoints/01_introduction.md).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this. Note that this repo is a complete application and may not reflect the changes made in this page.
 
 
 

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/02_data-model.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/02_data-model.md
@@ -228,7 +228,7 @@ During code generation, [view](../../../database/data-structures/views/) and [in
 
 
 ## Conclusion
-With this, our data model is defined. You can use the [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference.
+With this, our data model is defined. You can use the [positions app tutorial repository](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference. Note that this repo is a complete application and may not reflect the changes made in this page.
 
 As a next step, we shall add some data to the tables in the database.
 

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/04_events.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/04_events.md
@@ -134,6 +134,6 @@ From the Gradle menu on the right of Intellij, this is: **genesisproduct-positio
 ## Conclusion
 Data Server and Event Handler are the main components to interact with the server. Now that we have built our back end, we have something to interact with. Once you have deployed it, if you want to test what you've done so far, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/).
 
-For a reference point for these components checkout the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts). 
+For a reference point for these components checkout the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts). Note that this repo is a complete application and may not reflect the changes made in this page.
 
 Otherwise, you can continue to the [next section](../../../getting-started/go-to-the-next-level/data-grid/) and deploy and test the whole application at later time.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/05_data-grid.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/05_data-grid.md
@@ -196,4 +196,4 @@ You can add the `persist-column-state-key` to the zero-grid-pro to persist user 
 [//]: # (link to zero-grid-pro tsdocs)
 
 ## Conclusion
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the grids.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the grids. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/06_forms.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/06_forms.md
@@ -458,4 +458,4 @@ import { mustMatch } from '@genesislcap/foundation-forms';
 ```
 
 ## Conclusion
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the forms.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for the forms. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/07_calculated-data.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/07_calculated-data.md
@@ -64,5 +64,5 @@ views {
 ## Conclusion
 We just added a derived field. To see it in action, follow the steps on the next page that will show you how to glue the consolidator and view together.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference point for the view. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-config/src/main/resources/cfg) as a reference point for the view. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/08_consolidators.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/08_consolidators.md
@@ -171,4 +171,4 @@ When you finish, remember to run `generateDao` (if you made changes to the table
 ## Conclusion
 This shows a quick example of a Consolidator. If you want to see it in action, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/) for information on testing the back end.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the consolidators. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the consolidators. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/09_state_management.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/09_state_management.md
@@ -281,4 +281,4 @@ To test it, you can try to modify a `TRADE` (assuming you already have at least 
 ## Conclusion
 With this, we finish showing how an application can add state management. If you want to see it in action, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/) for information about testing the back end.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the event handlers. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for the event handlers. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/10_audit.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/10_audit.md
@@ -121,4 +121,4 @@ Finally we can run `generateDao`, `assemble` and `deploy-genesisproduct-position
 ### Conclusion
 With this, any changes made to `TRADE` are tracked to `TRADE_AUDIT`. To try it out, insert a new `TRADE` and see what's stored in the `TRADE_AUDIT` table via `DbMon`. Go to your terminal and run `DbMon`, `table TRADE_AUDIT` and `search 1`. For more information on testing, go to [Endpoints](../../../server/integration/rest-endpoints/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/11_setting_genesis_rules.md
@@ -478,5 +478,5 @@ $L is an alias to the logs folder (~/run/runtime/logs) provided by the Genesis l
 ### Conclusion
 This concludes generating reports for the positions application. In the next section you will see how to trigger based on a condition in the database.
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.
 

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/12_data-pipeline.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/12_data-pipeline.md
@@ -140,4 +140,4 @@ In this section, we have created a working data pipeline. Given everything is wo
 
 ![DbMon screenshot](/img/dbmon-datapipeline.PNG)
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/13_charting.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/13_charting.md
@@ -146,4 +146,4 @@ If you have been following along the entire tutorial your page should look somet
 
 ![](/img/charts-whole-page.png)
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/14_customise-look-and-feel.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/14_customise-look-and-feel.md
@@ -98,4 +98,4 @@ In the [next section](./15_dynamic_layout.md) you'll have the option to add a dy
 ## Styling other parts of application
 This was only a small part of the platform's capabilities in terms of styling. You can read more about design-system configuration [here](web/design-systems/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes/home) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/16_micro-frontends.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/16_micro-frontends.md
@@ -53,4 +53,4 @@ Now you can visit `/users` in your browser, and it should take you to the **user
 
 Read more about available micro front-ends and the different ways of including them in your application in our pages on [micro front-ends](web/micro-front-ends/introduction/).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/client/web/src/routes) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/17_camel-integrations.md
+++ b/versioned_docs/version-2023.1/01_getting-started/03_go-to-the-next-level/17_camel-integrations.md
@@ -106,4 +106,4 @@ You should now see "Hello World" returned.
 There are a countless number of choices when it comes to [Camel components](https://camel.apache.org/components/3.16.x/index.html). Take a look at the list to see if there is something that works with your own use cases.
 
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter.
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm/positions-app-tutorial-script-config/src/main/resources/scripts) as a reference point for this chapter. Note that this repo is a complete application and may not reflect the changes made in this page.

--- a/versioned_docs/version-2023.1/02_database/01_fields-tables-views/02_tables/02_tables-advanced.md
+++ b/versioned_docs/version-2023.1/02_database/01_fields-tables-views/02_tables/02_tables-advanced.md
@@ -181,7 +181,7 @@ Now you must update the **alpha-eventhandler.kts** in order to pass the `entityD
 ### Conclusion
 With this, any changes made to `TRADE` are tracked to `TRADE_AUDIT`. To try it out, insert a new `TRADE` and see what's stored in the `TRADE_AUDIT` table via `DbMon`. Go to your terminal and run `DbMon`, `table TRADE_AUDIT` and `search 1`. For more information on testing, go to [Endpoints](../../../03_server/10_integration/01_rest-endpoints/01_introduction.md).
 
-You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this. 
+You can use the [positions app tutorial repo](https://github.com/genesiscommunitysuccess/positions-app-tutorial/tree/Complete_positions_app/server/jvm) as a reference point for this. Note that this repo is a complete application and may not reflect the changes made in this page.
 
 
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-736

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
As Bono Vox said: it's a beautiful day

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

