### PR TITLE
feat: Add onCompletion block to Data Pipelines file sources

### DIFF
--- a/docs/03_server/10_integration/08_data-pipeline/02_basics.md
+++ b/docs/03_server/10_integration/08_data-pipeline/02_basics.md
@@ -79,7 +79,7 @@ pipelines {
 
 Genesis currently supports CSV, JSON and XML file sources.
 
-In addition to the configuration properties, each file type also has an optional `onCompletion` block which can be used to specify what to do after the file has been processed. In scope is `entityDb`, plus `result` which contains information
+In addition to the configuration properties explained below, each file type also has an optional `onCompletion` block which can be used to specify what to do after the file has been processed. In scope is `entityDb`, plus `result` which contains information
 about which lines were processed successfully and which failed.
 
 Below, you can see what options are available for each:

--- a/docs/03_server/10_integration/08_data-pipeline/02_basics.md
+++ b/docs/03_server/10_integration/08_data-pipeline/02_basics.md
@@ -16,6 +16,15 @@ You can configure data pipelines in a file called _pipeline-name_**-data-pipelin
 
 A pipeline configuration contains a collection of `sources`, one or many `map` functions and one or many `sink` functions.
 
+## Script properties
+
+The following properties are available to be used within the script:
+
+```kotlin
+val systemDefinition: SystemDefinitionService
+val serviceDiscovery: ServiceDiscovery
+```
+
 ## How to define a source
 
 Each data pipeline source contains the configuration specifying how to access the data and the associated mapping and sink functionality.

--- a/docs/03_server/10_integration/08_data-pipeline/02_basics.md
+++ b/docs/03_server/10_integration/08_data-pipeline/02_basics.md
@@ -77,7 +77,12 @@ pipelines {
 
 ### File
 
-Genesis currently supports CSV, JSON and XML file sources. Below, you can see what options are available for each:
+Genesis currently supports CSV, JSON and XML file sources.
+
+In addition to the configuration properties, each file type also has an optional `onCompletion` block which can be used to specify what to do after the file has been processed. In scope is `entityDb`, plus `result` which contains information
+about which lines were processed successfully and which failed.
+
+Below, you can see what options are available for each:
 
 #### CSV
 
@@ -89,9 +94,6 @@ Genesis currently supports CSV, JSON and XML file sources. Below, you can see wh
 | hasHeader | true | `hasHeader = true` | Boolean | Set whether the file has headers  |
 | headerOverrides | null | `headerOverrides = arrayListOf("id", "name")` | List | Set the column names to be used. If the file has a header, it is ignored and the specified names are used  |
 | readLazily | false | `readLazily = true` | Boolean | Set lazy reading  |
-
-CSV also has an `onCompletion` block which can be used to specify what to do after the file has been processed. In scope is `entityDb`, plus `result` which contains information
-about which lines were processed successfully and which failed.
 
 ```kotlin
 pipelines {
@@ -128,6 +130,10 @@ pipelines {
 
     map("mapper-name", TABLE) {
 
+    }
+
+    onCompletion {
+      // ...
     }
   }
 

--- a/docs/03_server/10_integration/08_data-pipeline/02_basics.md
+++ b/docs/03_server/10_integration/08_data-pipeline/02_basics.md
@@ -90,6 +90,9 @@ Genesis currently supports CSV, JSON and XML file sources. Below, you can see wh
 | headerOverrides | null | `headerOverrides = arrayListOf("id", "name")` | List | Set the column names to be used. If the file has a header, it is ignored and the specified names are used  |
 | readLazily | false | `readLazily = true` | Boolean | Set lazy reading  |
 
+CSV also has an `onCompletion` block which can be used to specify what to do after the file has been processed. In scope is `entityDb`, plus `result` which contains information
+about which lines were processed successfully and which failed.
+
 ```kotlin
 pipelines {
   csvSource("csv-cdc-test") {
@@ -98,6 +101,13 @@ pipelines {
     map("mapper-name", TABLE) {
 
     }
+    
+    onCompletion {
+        val successfulRows = result.successfulRows
+        val failedRows = result.failedRows
+        val existingRecords = entityDb.getBulk(TABLE).toList()
+        // ...
+    }
   }
 }
 ```
@@ -105,11 +115,11 @@ pipelines {
 #### XML and JSON
 
 | Parameter | Default value | Sample usage | Value type | Description |
-|---|---|---|---|---|
-| name | N/A | `xmlSource("xml-cdc-test")` | String | Name for the source |
-| location | N/A | `location = "file://runtime/testFiles?fileName=trades_array.json"` | String | Set the location of the XML or Json file. See details below |
-| Tag Name | N/A | `tagName = "Trade"` | String | Set the root tag of the XML (does not apply to Json) |
-| rootAt | "$.[*]" | `rootAt = "$.[*]"` | String | Set the root of the Json/XML tree |
+|-----------|---|---|---|---|
+| name      | N/A | `xmlSource("xml-cdc-test")` | String | Name for the source |
+| location  | N/A | `location = "file://runtime/testFiles?fileName=trades_array.json"` | String | Set the location of the XML or Json file. See details below |
+| tagName   | N/A | `tagName = "Trade"` | String | Set the root tag of the XML (does not apply to Json) |
+| rootAt    | "$.[*]" | `rootAt = "$.[*]"` | String | Set the root of the Json/XML tree |
 
 ```kotlin
 pipelines {


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
https://genesisglobal.atlassian.net/browse/GSF-6053

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

