### PR TITLE
GSF-5943: Added caution box to Cache doc regarding indices

### DIFF
--- a/docs/03_server/01_configuring-runtime/06_cache.md
+++ b/docs/03_server/01_configuring-runtime/06_cache.md
@@ -37,6 +37,10 @@ The options for both XML and GPAL are:
   * **loadOnStart**, **update** and **insertNewEntries** options are also available at this level. The behaviour and default values have the same effect as their global settings counterparty described above, but apply at the specific table level.
   * The **indices** setting allows you to provide a set of unique indices to be cached as part of the **update** and **loadOnStart** operations.
 
+:::caution
+Choosing the right index definition is paramount to improving view query performance. If you define a view on database tables, and you are joining on an index that is not part of the cache configuration, the cache will not accelerate your database read operations.
+:::
+
 ### XML example
 ```xml
         <cacheConfig>

--- a/versioned_docs/version-2022.3/03_server/01_configuring-runtime/06_cache.md
+++ b/versioned_docs/version-2022.3/03_server/01_configuring-runtime/06_cache.md
@@ -37,6 +37,10 @@ The options for both XML and GPAL are:
   * **loadOnStart**, **update** and **insertNewEntries** options are also available at this level. The behaviour and default values have the same effect as their global settings counterparty described above, but apply at the specific table level.
   * The **indices** setting allows you to provide a set of unique indices to be cached as part of the **update** and **loadOnStart** operations.
 
+:::caution
+Choosing the right index definition is paramount to improving view query performance. If you define a view on database tables, and you are joining on an index that is not part of the cache configuration, the cache will not accelerate your database read operations.
+:::
+
 ### XML example
 ```xml
         <cacheConfig>

--- a/versioned_docs/version-2022.4/03_server/01_configuring-runtime/06_cache.md
+++ b/versioned_docs/version-2022.4/03_server/01_configuring-runtime/06_cache.md
@@ -37,6 +37,10 @@ The options for both XML and GPAL are:
   * **loadOnStart**, **update** and **insertNewEntries** options are also available at this level. The behaviour and default values have the same effect as their global settings counterparty described above, but apply at the specific table level.
   * The **indices** setting allows you to provide a set of unique indices to be cached as part of the **update** and **loadOnStart** operations.
 
+:::caution
+Choosing the right index definition is paramount to improving view query performance. If you define a view on database tables, and you are joining on an index that is not part of the cache configuration, the cache will not accelerate your database read operations.
+:::
+
 ### XML example
 ```xml
         <cacheConfig>

--- a/versioned_docs/version-2023.1/03_server/01_configuring-runtime/06_cache.md
+++ b/versioned_docs/version-2023.1/03_server/01_configuring-runtime/06_cache.md
@@ -37,6 +37,10 @@ The options for both XML and GPAL are:
   * **loadOnStart**, **update** and **insertNewEntries** options are also available at this level. The behaviour and default values have the same effect as their global settings counterparty described above, but apply at the specific table level.
   * The **indices** setting allows you to provide a set of unique indices to be cached as part of the **update** and **loadOnStart** operations.
 
+:::caution
+Choosing the right index definition is paramount to improving view query performance. If you define a view on database tables, and you are joining on an index that is not part of the cache configuration, the cache will not accelerate your database read operations.
+:::
+
 ### XML example
 ```xml
         <cacheConfig>


### PR DESCRIPTION
…ct indicies

Thank you for contributing to the documentation.

Your Jira ticket is:
(https://genesisglobal.atlassian.net/jira/software/c/projects/PLAT/boards/388?modal=detail&selectedIssue=GSF-5943)

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes -->

Have you checked all new or changed links?
<!--- Yes -->

Is there anything else you would like us to know?
<!--- Yes -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

