### PR TITLE
fix: Get rid of _authToken params as frontend packages are public now (PTL-739)

### DIFF
--- a/infra/lib/amplify-docs-stack.ts
+++ b/infra/lib/amplify-docs-stack.ts
@@ -37,16 +37,6 @@ export class AmplifyDocsStack extends cdk.Stack {
           phases: {
             preBuild: {
               commands: [
-                'npm config set @genesislcap:registry https://npm.pkg.github.com',
-                // this isn't ideal, but the only rights this token has are packages:read. No amount of
-                // indirection gymnastics gets us away from the fact Amplify doesn't have the concept of
-                // environmental secrets, so however we pass this token value in, it will ultimately be visible
-                // in plaintext in the AWS Amplify console. We accept that because:
-                // 1. it's a *lot* better than leaking the token in code
-                // 2. it's a token we will rotate frequently
-                // 3. it's a token which only grants read-only access to our private npm packages (@genesislcap stuff)
-                // 4. it's only visible in the AWS console to authenticated users, just as normal secrets are
-                'npm config set //npm.pkg.github.com/:_authToken ' + SecretValue.secretsManager('npm-package-manager').unsafeUnwrap(),
                 'npm install',
               ],
             },


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
[PTL-739](https://genesisglobal.atlassian.net/browse/PTL-739)

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
No

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

