### PR TITLE
fix: Backing PR Preview again (PTL-648)

### DIFF
--- a/infra/lib/amplify-docs-stack.ts
+++ b/infra/lib/amplify-docs-stack.ts
@@ -19,7 +19,7 @@ export class AmplifyDocsStack extends cdk.Stack {
       sourceCodeProvider: new amplify.GitHubSourceCodeProvider({
         owner: 'genesiscommunitysuccess',
         repository: 'docs',
-        // We got to use a Personal Access Token to authenticate with GitHub. Currently
+        // We use a Personal Access Token to authenticate with GitHub. Currently
         // the token used here is generated from Nick Payne's (@makeusabrew on GitHub) account
         // The account needs admin privileges on the repository to set up a one-time read-only
         // deploy key (to clone the repo) and webhook (for PR previews). Due to this association

--- a/infra/lib/amplify-docs-stack.ts
+++ b/infra/lib/amplify-docs-stack.ts
@@ -19,7 +19,7 @@ export class AmplifyDocsStack extends cdk.Stack {
       sourceCodeProvider: new amplify.GitHubSourceCodeProvider({
         owner: 'genesiscommunitysuccess',
         repository: 'docs',
-        // We have to use a Personal Access Token to authenticate with GitHub. Currently
+        // We got to use a Personal Access Token to authenticate with GitHub. Currently
         // the token used here is generated from Nick Payne's (@makeusabrew on GitHub) account
         // The account needs admin privileges on the repository to set up a one-time read-only
         // deploy key (to clone the repo) and webhook (for PR previews). Due to this association


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-648

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

