### PR TITLE
Add info about deploy-plugin-mode gradle property for intellij plugin

### DIFF
--- a/docs/01_getting-started/04_prerequisites/03_gradle-deploy-plugin.md
+++ b/docs/01_getting-started/04_prerequisites/03_gradle-deploy-plugin.md
@@ -113,7 +113,7 @@ locally.
 To configure this, open `gradle.properties` from the server/jvm folder and add the following entries:
 
 ```properties
-genesis-home=<path-to-genesis-distribution-on-wsl>
+genesis-home=<path-to-genesis-home-on-wsl>
 wsl-distro=<name-of-the-wsl-distro>
 wsl-user=<wsl-username>
 ```
@@ -139,7 +139,7 @@ This is the easiest set-up, and applies if your development workstation is on a 
 To configure this, open `gradle.properties` from the server/jvm folder and add the following entry:
 
 ```properties
-genesis-home=<path-to-genesis-distribution-on-wsl>
+genesis-home=<path-to-genesis-home>
 ```
 
 The set-up task will create the folder (if it doesn't exist) and set up the Genesis platform there.
@@ -152,7 +152,7 @@ supported.
 To configure this, open `gradle.properties` from the server/jvm folder and add the following entries:
 
 ```properties
-genesis-home=<path-to-genesis-distribution-on-wsl>
+genesis-home=<path-to-genesis-home>
 ssh-username=<remote-host-username>
 ssh-password=<remote-host-password>
 ssh-host=<remote-host>

--- a/docs/01_getting-started/04_prerequisites/03_gradle-deploy-plugin.md
+++ b/docs/01_getting-started/04_prerequisites/03_gradle-deploy-plugin.md
@@ -139,7 +139,7 @@ This is the easiest set-up, and applies if your development workstation is on a 
 To configure this, open `gradle.properties` from the server/jvm folder and add the following entry:
 
 ```properties
-genesis-home=<path-to-genesis-home>
+genesis-home=<path-to-local-genesis-home>
 ```
 
 The set-up task will create the folder (if it doesn't exist) and set up the Genesis platform there.
@@ -152,7 +152,7 @@ supported.
 To configure this, open `gradle.properties` from the server/jvm folder and add the following entries:
 
 ```properties
-genesis-home=<path-to-genesis-home>
+genesis-home=<path-to-remote-host-genesis-home>
 ssh-username=<remote-host-username>
 ssh-password=<remote-host-password>
 ssh-host=<remote-host>

--- a/versioned_docs/version-2023.1/03_server/11_tooling/02_intellij-plugin.md
+++ b/versioned_docs/version-2023.1/03_server/11_tooling/02_intellij-plugin.md
@@ -38,6 +38,14 @@ After installing **Genesis Platform Support** plugin, make sure you add it to be
 
 ![Genesis Platform Support on Tool window](/img/genesis-plugin-intellij-toolwindow.png)
 
+:::info
+When using the plugin, ensure you have specified the `deploy-plugin-mode` gradle property as `local`. This can be done by adding the below to the `gradle.properties` file in the server/jvm folder:
+
+```
+deploy-plugin-mode=local
+```
+:::
+
 ## The Tools window
 
 ### Settings

--- a/versioned_docs/version-2023.1/03_server/11_tooling/02_intellij-plugin.md
+++ b/versioned_docs/version-2023.1/03_server/11_tooling/02_intellij-plugin.md
@@ -39,7 +39,7 @@ After installing **Genesis Platform Support** plugin, make sure you add it to be
 ![Genesis Platform Support on Tool window](/img/genesis-plugin-intellij-toolwindow.png)
 
 :::info
-When using the plugin, ensure you have specified the `deploy-plugin-mode` gradle property as `local`. This can be done by adding the below to the `gradle.properties` file in the server/jvm folder:
+When using the plugin, ensure you have specified the `deploy-plugin-mode` gradle property as `local`. You can do this by adding the line below to the `gradle.properties` file in the server/jvm folder:
 
 ```
 deploy-plugin-mode=local


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
https://genesisglobal.atlassian.net/browse/PTL-745

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

