### PR TITLE
fix: temporarily pin CSS minimizer webpack plugin to address build (PTL-659)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.6",
     "classnames": "^2.3.2",
-    "css-minimizer-webpack-plugin": "^4.1.0",
+    "css-minimizer-webpack-plugin": "^5.0.0",
     "dayjs": "1.10.7",
     "docusaurus-gtm-plugin": "^0.0.2",
     "docusaurus-plugin-matomo": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.6",
     "classnames": "^2.3.2",
-    "css-minimizer-webpack-plugin": "^5.0.0",
+    "webpack":"^5.83.1",
     "dayjs": "1.10.7",
     "docusaurus-gtm-plugin": "^0.0.2",
     "docusaurus-plugin-matomo": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.6",
     "classnames": "^2.3.2",
+    "css-minimizer-webpack-plugin": "^4.1.0",
     "dayjs": "1.10.7",
     "docusaurus-gtm-plugin": "^0.0.2",
     "docusaurus-plugin-matomo": "^0.0.6",


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-659

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

