### PR TITLE
PTL-744 follow-up/PTL-748

### DIFF
--- a/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
+++ b/docs/01_getting-started/02_quick-start/00_hardware-and-software.md
@@ -38,7 +38,7 @@ import MinimunRequirement from '/snippet/_minimun_requirement.md'
 </details>
 
 ## gradle.properties file
-You must create or edit a **gradle.properties** file inside a **.gradle** folder on your user directory. This file must contain your Genesis Artifactory password in clear text, for example:
+You must create or edit a **gradle.properties** file inside a **.gradle** folder on your user directory. This file must contain your Genesis Artifactory password in [encrypted base 64](https://www.base64decode.org/) text, for example:
 
 ```shell
 genesisArtifactoryUser=<JaneDee>

--- a/versioned_docs/version-2023.1/01_getting-started/02_quick-start/00_hardware-and-software.md
+++ b/versioned_docs/version-2023.1/01_getting-started/02_quick-start/00_hardware-and-software.md
@@ -41,7 +41,7 @@ import MinimunRequirement from '/snippet/_minimun_requirement.md'
 From version **10.3.0**, Foundation UI libraries are published to the [public NPM registry](https://www.npmjs.com/~genesisnpm?activeTab=packages), so a custom **npmrc** file is no longer required.
 
 ## gradle.properties file
-You must create or edit a **gradle.properties** file inside a **.gradle** folder on your user directory. This file must contain your Genesis Artifactory password in clear text, for example:
+You must create or edit a **gradle.properties** file inside a **.gradle** folder on your user directory. This file must contain your Genesis Artifactory password in [encrypted base 64](https://www.base64decode.org/) text, for example:
 
 
 ```shell


### PR DESCRIPTION
we must refer to encrypted text for our password.
We need to understand what is going on in terms of security here. If users can have unencrypted passwords for gradle passwords (and for the Quick Start, they can), what are the security implications for the platform - if any?

Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-748

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
two are relevant

Have you checked all new or changed links?
None changed. Build worked

Is there anything else you would like us to know?
no

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

