### PR TITLE
feat: add 'Edit this page' functionality FUI-1267

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,6 +100,17 @@ module.exports = {
       {
         // https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs
         docs: {
+          /**
+           * Enabling edit this page functionality and making the last updated timestamp visible.
+           */
+          editUrl: 'https://github.com/genesiscommunitysuccess/docs/edit/master/',
+          showLastUpdateTime: true,
+          /**
+           * editCurrentVersion: false allows people to make changes to any version of the docs they find an issue with.
+           * Alternatively, we could direct all edits to the current version. However, with our infrequent docs releases,
+           * that would leave the default unchanged even after their edit was accepted, which may confuse contributors.
+           */
+          editCurrentVersion: false,
           breadcrumbs: false,
           routeBasePath,
           sidebarPath: require.resolve('./sidebars.js'),


### PR DESCRIPTION
Small PR to enable the Edit this page functionality and make the last updated timestamp visible. [FUI-1267](https://genesisglobal.atlassian.net/browse/FUI-1267)

**Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?**
Yes

**Have you checked all new or changed links?**
Yes 

**Is there anything else you would like us to know?**
I've set editCurrentVersion: false, which allows people to make changes to any version of the docs they find an issue with. Alternatively, we could direct all edits to the current version, however, with our infrequent docs releases, that would leave the default unchanged even after their edit was accepted, which may confuse contributors. We can review and refine it later if needed.

**Please note this feature DOES NOT bypass the review process. It simply allows anyone to offer an edit contribution, which you can accept or reject.**

## How it looks on the page:
![Screenshot 2023-05-26 at 13 38 37](https://github.com/genesiscommunitysuccess/docs/assets/190318/a5a6222c-e0dd-4db5-835e-60d52f21d520)

## How the edit screen should present to known Genesis contributors:
![Screenshot 2023-05-26 at 13 40 42](https://github.com/genesiscommunitysuccess/docs/assets/190318/1e3b0d63-92ad-4af5-a5fe-7f6693e4d6b1)

## An example of how the edit screen *MAY* present to external contributors (need to verify):
![Screenshot 2023-05-26 at 13 43 34](https://github.com/genesiscommunitysuccess/docs/assets/190318/ceea36dd-6a5e-41d1-9104-9c7210a890a0)

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

