### PR TITLE
Update 03_processes.md

### DIFF
--- a/docs/03_server/01_configuring-runtime/03_processes.md
+++ b/docs/03_server/01_configuring-runtime/03_processes.md
@@ -97,7 +97,7 @@ For each process, the tags define key information. Let's look at the tags that a
 
 ### dependency
 
-This tag defines the processes that the current process is dependent on. In the above example, the **POSITION_APP_CONSOLIDATOR** process will only start once the **POSITION_APP_EVENT_HANDLER** process is running. 
+This tag defines a comma-separated list of processes that the current process is dependent on. In the above example, the **POSITION_APP_CONSOLIDATOR** process will only start once the **POSITION_APP_EVENT_HANDLER** process is running. 
 
 When you are defining the process in your application's **process.xml**, this tag is optional.
 

--- a/versioned_docs/version-2023.1/03_server/01_configuring-runtime/03_processes.md
+++ b/versioned_docs/version-2023.1/03_server/01_configuring-runtime/03_processes.md
@@ -97,7 +97,7 @@ For each process, the tags define key information. Let's look at the tags that a
 
 ### dependency
 
-This tag defines the processes that the current process is dependent on. In the above example, the **POSITION_APP_CONSOLIDATOR** process will only start once the **POSITION_APP_EVENT_HANDLER** process is running. 
+This tag defines a comma-separated list of processes that the current process is dependent on. In the above example, the **POSITION_APP_CONSOLIDATOR** process will only start once the **POSITION_APP_EVENT_HANDLER** process is running. 
 
 When you are defining the process in your application's **process.xml**, this tag is optional.
 


### PR DESCRIPTION
Multiple dependencies can be defined with a comma-separated list

Thank you for contributing to the documentation.

Your Jira ticket is:
P********

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

