### PR TITLE
Ptl 755: clarity edit on the Access Control section

### DIFF
--- a/docs/03_server/05_access-control/01_introduction.md
+++ b/docs/03_server/05_access-control/01_introduction.md
@@ -10,16 +10,18 @@ tags:
 ---
 
 
-The Genesis low-code platform has a collection of access control mechanisms to limit usage of your application and access to specific data and functions dynamically.
+The Genesis low-code platform has a collection of access control mechanisms to ensure that:
 
-Applications built on the system use both authentication and authorisation solutions to verify user identities and their permission to interact with the application, and underlying data.
+- only authenticated users can have access to your application
+- within the application, users have access to specific data and functions, which is controlled dynamically.
 
-This is done through a variety of authentication functions, including Single Sign-On (SSO) authentication, username and password authentication, and Multi-factor authentication.
+The platform can use a variety of authentication functions, including Single Sign-On (SSO) authentication, username and password authentication, and Multi-factor authentication.
 
 The password authentication can be configured to use an internal store of users, LDAP to communicate with an external service, or a combination of both.
 
 For more information about LDAP, see [Wikipedia](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol).
 
-Once a user is authenticated, the authorisation systems allow for their access to be further restricted to particular function and items of data.
+Once a user has been authenticated, the authorisation systems allow for a user's access to be further restricted to particular function and items of data.
 
-This authorisation can be done on a group or individual basis.
+This authorisation is performed on a group basis, not on individual users; however, you can have groups with only one member.
+

--- a/docs/03_server/05_access-control/02_authentication-overview.md
+++ b/docs/03_server/05_access-control/02_authentication-overview.md
@@ -11,9 +11,9 @@ tags:
 ---
 
 
-Authentication can be performed within applications built on the Genesis low-code platform through many techniques. All of these techniques support [Multi-factor Authentication (MFA)](https://en.wikipedia.org/wiki/Multi-factor_authentication) to bring additional security.
+YOur application can perform authentication through many techniques. All these techniques support [Multi-factor Authentication (MFA)](https://en.wikipedia.org/wiki/Multi-factor_authentication) to bring additional security.
 
-Username and Password authentication can be further specified to use one of three solutions:
+You can set Username and Password authentication to use one of three solutions:
 
 * INTERNAL
 * LDAP
@@ -25,13 +25,11 @@ SSO authentication is further broken down into one of the following:
 * [SAML](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 * [OIDC](https://openid.net/connect/)
 
-Each of these requires its own configuration settings in the _application-name-_**auth-preferences.kts** file.
-
-So, if your application is called positions, then the file would conventionally be named **positions-auth-preferences.kts**.
+Each of these requires its own configuration settings in the application's _application-name-_**auth-preferences.kts** file.
 
 ## Username and password authentication
 
-Username and password authentication allows users to log in directly to the application built on the Genesis low-code platform. This requires you to choose one of the provided solutions in order control this process.
+Username and password authentication allows users to log in directly to your application. You must choose one of the provided solutions in order control this process.
 
 To specify which one to use, just edit the application's **auth-preferences.kts** file and change the `type` variable in the `authentication` block to match the required value. For example:
 
@@ -55,7 +53,7 @@ The three values that this can be set to are:
 * AuthType.LDAP
 * AuthType.HYBRID
 
-The differences between the solutions associated with each value are as detailed:
+The differences between the solutions associated with each value are detailed below:
 
 ### Internal
 
@@ -63,7 +61,7 @@ Internal authentication uses internally stored hashed credentials to authenticat
 
 - User accounts can be locked
 - Passwords can be set to expire
-- Passwords can be required to conform to configurable standard
+- Passwords can be required to conform to a configurable standard
 - Users can reset or change their password (assuming they can log in first)
 
 Internal authentication is the default authentication behaviour if you don't specify a `type` in **auth-preferences.kts**.
@@ -78,13 +76,13 @@ Internal authentication is the default authentication behaviour if you don't spe
 
 LDAP authentication uses its namesake protocol to authenticate users. 
 
-However, if you specify this, you lose control of the internal authentication functionality. This is because the authentication relies on an external party that cannot be operated from the Application. As a direct consequence, requests to change or reset passwords won't be accepted.
+LDAP authentication relies on an external party that cannot be operated from your application. So, by setting LDAP, you lose control of the internal authentication functionality. As a direct consequence, requests to change or reset passwords won't be accepted.
 
-For LDAP authentication, a username must exist inside the internal records of the application. To do this, create a user entry inside the USER table for every LDAP user of the Application. There is no password checking between this login and the Application's internal records; authentication will rely solely on LDAP.
+For LDAP authentication, a username must exist inside the internal records of the application. To do this, create a user entry inside the USER table for every LDAP user of the application. There is no password checking between this login and the application's internal records; authentication will rely solely on LDAP.
 
-To set up LDAP authentication a connection to an LDAP server must be configured in the **auth-preferences.kts** file.
+To set up LDAP authentication, a connection to an LDAP server must be configured in the **auth-preferences.kts** file.
 
-For more information on configuring LDAP authentication, please see [Username and password authentication](../../../server/access-control/password-authentication/#authentication).
+For more information on configuring LDAP authentication, see [Username and password authentication](../../../server/access-control/password-authentication/#authentication).
 
 The example below shows LDAP authentication specified, with `userIdType` set to `cn` for the search for the username.
 
@@ -110,9 +108,9 @@ The example below shows LDAP authentication specified, with `userIdType` set to 
 
 ### Hybrid
 
-As its name suggests, Hybrid mode is a mix of Internal and LDAP authentication modes, and it checks credentials against both.
+As its name suggests, hybrid mode is a mix of Internal and LDAP authentication modes, and it checks credentials against both.
 
-First, an internal authentication is performed. If the outcome is successful, another authentication against the LDAP server is performed. The login request is only successful if both authentications are successful.
+First, an internal authentication is performed. If the outcome is successful, authentication is performed against the LDAP server . The login request is only successful if both authentications are successful.
 
 This enables you to take advantage of all the available functionality of internal mode (locked accounts, expiring passwords, reset/change passwords). However, if passwords are changed or expired, they need to be changed manually in LDAP too, because authentication always happens in both services.
 
@@ -140,9 +138,9 @@ The configuration file takes the same fields as LDAP. You can see this in the ex
 
 ## SSO authentication
 
-SSO authentication allows users to use a single set of credentials to access a range of applications, including those built on the Genesis low-code platform. For more information on SSO technology, please visit the [Single-sign on Wikipedia page](https://en.wikipedia.org/wiki/Single_sign-on).
+SSO authentication enables users to use a single set of credentials to access a range of applications, including those built on the Genesis low-code platform. For more information on SSO technology, see the [Single-sign on Wikipedia page](https://en.wikipedia.org/wiki/Single_sign-on).
 
-SSO authentication is a more involved process to enable; it requires additional file changes detailed in the following pages:
+SSO authentication is a more involved process to enable; it requires additional file changes, which are detailed in the following pages:
 
 - [SSO - JWT](../../../server/access-control/SSO-jwt/)
 - [SSO - SAML](../../../server/access-control/SSO-saml/)

--- a/docs/03_server/05_access-control/03_password_authentication.md
+++ b/docs/03_server/05_access-control/03_password_authentication.md
@@ -21,7 +21,7 @@ The `security` function wraps all other variables and functions within the **aut
 
 * `sessionTimeoutMins` specifies a time out for the session. Sessions are timed out (logged out) after the value defined here. The front end of your application can monitor web movement, page changes, etc. and perform an [automatic refresh](../../../server/integration/rest-endpoints/advanced/#event_login_refresh) - in which case, the user is not aware of the logout and the start of the new session. Default: 30 minutes.
 * `expiryCheckMins` specifies the time interval (in minutes) used to check for idle sessions in the system. Default: 5 minutes.
-* `maxSimultaneousUserLogins` specifies the maximum number of concurrent active sessions a user can maintain. Once this limit has been reached, the user cannot activate additional sessions until one or more of the active sessions has been logged out. If the value zero is not defined, or is not a positive integer, then any number of sessions is permitted. Default: 0.
+* `maxSimultaneousUserLogins` specifies the maximum number of concurrent active sessions a user can maintain. Once this limit has been reached, the user cannot activate additional sessions until one or more of the active sessions has been logged out. So, a value of 1 means that only one session can be logged in at any time; a value of two allows two to be logged in concurrently, and so on. If the value is zero, is not defined, or is not a positive integer, then any number of sessions is permitted. Default: 0.
 
 ```kotlin
 security {
@@ -73,13 +73,13 @@ The following variables are used to configure an LDAP connection; these are only
 * `onFirstLogin` is a function that is called the first time a user has been authenticated who doesn't already exist in the database. Here you can define two things:
   * how the `User` and its `UserAttributes` will be created from the token after the user has been authenticated using the `createUser` function
   * which user permissions are allocated using `createUserPermissions`
-* `onLoginSuccess` this is a function which is invoked on a successful LDAP login: for example, it allows you to insert a user into the db when it exists in LDAP but not the database.
+* `onLoginSuccess` this is a function which is invoked on a successful LDAP login: for example, it allows you to insert a user into the database when it exists in LDAP but not the database.
 * `useTLS` this is a boolean value indicating whether or not to use TLS encryption on the connection to the remote LDAP server.
 
 For more information about the various authentication types, see the [Authentication overview](../../../server/access-control/authentication-overview/).
 
 ## genesisPassword
-The `genesisPassword` groups all configuration options when you are using `type = AuthType.INTERNAL`. 
+The `genesisPassword` statement groups all configuration options when you are using `type = AuthType.INTERNAL`. 
 
 ### passwordRetry
 The `passwordRetry` function has been deprecated in favour of the `retry` function within the `genesisPassword` configuration.
@@ -93,25 +93,25 @@ The following variables can be used to configure the application's password vali
 
 * `passwordStrength` can be called to set a range of configuration variables. These enable you to specify in detail the mandatory characteristics for the password. 
 
-    * `minimumLength` specifies the minimum length of password. If null or undefined this assumes there is no minimum limit. Default: null.
-    * `maximumLength` specifies the maximum length of password. If null or undefined this assumes there is no maximum limit. Default: null.
-    * `minDigits` specifies the minimum number of numerical digits required in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
+    * `minimumLength` specifies the minimum length of password. If null or undefined, this assumes there is no minimum limit. Default: null.
+    * `maximumLength` specifies the maximum length of password. If null or undefined, this assumes there is no maximum limit. Default: null.
+    * `minDigits` specifies the minimum number of numeric digits required in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
     * `maxRepeatCharacters` specifies the maximum number of the same characters across an entire password. This does not just include consecutive repeat characters, which is controlled by the `repeatCharacterRestrictSize` variable below. If null or undefined, this assumes there is no maximum limit. Default: null.
-    * `minUppercaseCharacters` specifies the minimum number of upper-case characters in a password. If null or undefined this assumes there is no minimum limit. Default: null.
-    * `minLowercaseCharacters` specifies the minimum number of lower-case characters in a password. If null or undefined this assumes there is no minimum limit. Default: null.
+    * `minUppercaseCharacters` specifies the minimum number of upper-case characters in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
+    * `minLowercaseCharacters` specifies the minimum number of lower-case characters in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
     * `minNonAlphaNumericCharacters` specifies the minimum number of non-alphanumeric characters, such as punctuation and other special characters. If null or undefined, this assumes there is no minimum limit. Default: null.
     * `restrictWhitespace` specifies if whitespace characters are prevented from being used in passwords. Default: true.
     * `restrictAlphaSequences` specifies if alphabetical sequences in passwords (e.g. abcdefg) are restricted. Sequences greater than or equal to five characters won't be permitted if this is true. Default: false.
     * `restrictQWERTY` specifies if QWERTY sequences in passwords (e.g. qwertyuiop) are restricted. Sequences greater or equal to five characters won't be permitted if this is true. Default: true.
-    * `restrictNumericalSequences` specifies if numerical sequences in passwords (e.g. 123456) are restricted. Sequences greater or equal to five numbers won't be allowed if active. Default: true.
+    * `restrictNumericalSequences` specifies if numeric sequences in passwords (e.g. 123456) are restricted. Sequences greater or equal to five numbers won't be allowed if active. Default: true.
     * `illegalCharacters` specifies which characters are not permitted in user passwords. Default: empty.
-    * `historicalCheck` specifies how many previous passwords to check against, in order to prevent password re-use. If null or undefined no historical check is performed. Default: null.
+    * `historicalCheck` specifies how many previous passwords to check against, in order to prevent password re-use. If null or undefined, no historical check is performed. Default: null.
     * `restrictPassword` specifies if the password should differ from a list of the worst passwords stored within the application. Default: false.
     * `restrictDictionarySubstring` specifies if any dictionary word of four or more characters can be included in a password (either forwards or backwards). Default: false.
     * `restrictUserName` specifies if the user's username is restricted as part of their password. Default: false.
-    * `repeatCharacterRestrictSize` specifies the number of consecutive repeated characters that make a password restricted. If null or undefined this assumes there is no limit. Default: null.
-    * `passwordExpiryDays` specifies how many days before a password expires. If null or undefined this assumes there is no limit. Default: null.
-    * `passwordExpiryNotificationDays` specifies how many days before their password expiry, a user is notified. If null or undefined, a user is not notified in advance of their password expiry. Default: null.
+    * `repeatCharacterRestrictSize` specifies the number of consecutive repeated characters that make a password restricted. If null or undefined, this assumes there is no limit. Default: null.
+    * `passwordExpiryDays` specifies how many days before a password expires. If null or undefined, this assumes there is no limit. Default: null.
+    * `passwordExpiryNotificationDays` specifies how many days before their password expiry a user is notified. If null or undefined, a user is not notified in advance of their password expiry. Default: null.
 
 ### retry
 The `retry` function enables you to configure settings for limiting the rate at which a user can retry passwords. You can set the following variables:
@@ -121,8 +121,7 @@ The `retry` function enables you to configure settings for limiting the rate at 
 
 ### selfServiceReset 
 
-The `selfServiceReset` function enables the self-service reset workflow. In this, users authenticated with the internal auth type can request an email to reset their password. For this workflow, you must have Genesis Notify configured with a working email gateway. When a user requests a reset, an email is sent to their configured 
-email address, with a link to a password reset page. This link is valid for a preconfigured timeout.
+The `selfServiceReset` function enables the self-service reset workflow for users. In this, users authenticated with the internal auth type can request an email to reset their password. For this workflow, you must have Genesis Notify configured with a working email gateway. When a user requests a reset, an email with a link to a password reset page is sent to their configured email address. This link is valid for a preconfigured timeout.
 
 :::note
 
@@ -132,8 +131,8 @@ In the interest of security, this response will always receive an ACK, even if t
 
 The `selfServiceReset` function  has the following options: 
 
-* `timeoutInMinutes` - the time in minutes that a reset link remains valid 
-* `coolDownInMinutes` - the time in minutes between before the next password reset can be made 
+* `timeoutInMinutes` - the time in minutes for which a reset link remains valid 
+* `coolDownInMinutes` - the time in minutes before the next password reset can be made 
 * `notifyTopic` - the email topic in Genesis Notify to be used 
 * `redirectUrl` - the url to use for the redirect
 * `acceptClientUrl` - boolean flag; if true, the reset will use the client provided reset url
@@ -155,7 +154,7 @@ Both the subject and the body support templating. Values surrounded by double cu
 
 * `RESET_URL` the reset url
 * `TIMEOUT` the time the url is valid for
-* `USER` the user record, properties on this record should be access using lowerCamelCase, e.g. `{{ USER.firstName }}`
+* `USER` the user record, properties on this record should be accessed using lowerCamelCase, e.g. `{{ USER.firstName }}`
 * any system definition or environment variable available
 
 ### mfa
@@ -165,8 +164,8 @@ The `mfa` function enables you to configure Multi-factor Authentication (MFA). T
 * `codePeriodDiscrepancy` specifies the allowed discrepancy to the TOTP. 1 would mean a single block of each `codePeriodSeconds` either side of the time window. Default: 1.
 * `codeDigits` specifies the number of digits used in the TOTP. Default: 6 digits.
 * `hashingAlgorithm` specifies which choice of Hashing Algorithm to use. Available choices are: `HashingFunction.SHA1`, `HashingFunction.SHA256` or `HashingFunction.SHA512`. Default: `HashingFunction.SHA1`.
-* `issuer` specifies a reference to the Organisation or Entity issuing the MFA. Default: Genesis.
-* `label` specifies a label for the MFA. This is typically an email address of the issuing Entity or Organisation. Default: genesis.global.
+* `issuer` specifies a reference to the organisation or entity issuing the MFA. Default: Genesis.
+* `label` specifies a label for the MFA. This is typically an email address of the issuing entity or organisation. Default: genesis.global.
 * `confirmWaitPeriodSecs` specifies the period of time in seconds before a secret has to be confirmed. Default: 300 seconds.
 * `secretEncryptKey` specifies the key that is used to encrypt Secrets in the database. If this is null or undefined, Secrets will not be encrypted in the database. Default: null.
 * `usernameTableLookUpSalt` specifies the salt with which a username is hashed when stored in the database with the above Secret. If this is null or undefined, the username will not be hashed in the database. Default: null.
@@ -174,21 +173,14 @@ The `mfa` function enables you to configure Multi-factor Authentication (MFA). T
 ### loginAck
 The `loginAck` function enables you to define additional values to be sent back to the client as part of the `LOGIN_ACK` message. When you call the `loginAck` function, you have to supply a table or view as a parameter. The following functions will be invoked on this table or view:
 
-#### loadRecord
-The `loadRecord` function can be invoked within the `loginAck` function to load a single record from the previously supplied table or view.
+- The `loadRecord` within the `loginAck` function loads a single record from the previously supplied table or view.
+- The `fields` function within the `loginAck` function specifies which additional fields should be sent back to the client as part of the LOGIN_ACK message.
+- The `customLoginAck` function enables you to modify the list of permissions, profiles and user preferences returned to the client as part of the `LOGIN_ACK` message. For this purpose, the `User` entity is provided as a parameter, as well as three properties:
+    * permissions - a mutable list containing all the right codes associated to the user. Given its mutability, codes can be added or removed.
+    * profiles - a mutable list containing all the profiles associated with the user.  Given its mutability, profiles can be added or removed.
+    * userPreferences - a [GenesisSet](../../../server/inter-process-messages/genesisset/) object containing additional fields provided as part of the [loginAck](#loginack) function. This `GenesisSet` can be modified to provide additional fields or remove existing ones.
 
-#### fields
-The `fields` function can be invoked within the `loginAck` function to specify which additional fields should be sent back to the client as part of the LOGIN_ACK message.
 
-#### customLoginAck
-
-The `customLoginAck` function enables you to modify the list of permissions, profiles and user preferences returned to the client as part of the `LOGIN_ACK` message. For this purpose, the `User` entity is provided as a parameter, as well as three properties:
-
-* permissions - a mutable list containing all the right codes associated to the user. Given its mutability, codes can be added or removed.
-* profiles - a mutable list containing all the profiles associated with the user.  Given its mutability, profiles can be added or removed.
-* userPreferences - a [GenesisSet](../../../server/inter-process-messages/genesisset/) object containing additional fields provided as part of the [loginAck](#loginack) function. This `GenesisSet` can be modified to provide additional fields or remove existing ones.
-
-### Example
 Here is an example configuration:
 
 ```kotlin

--- a/docs/03_server/05_access-control/04_sso_jwt.md
+++ b/docs/03_server/05_access-control/04_sso_jwt.md
@@ -70,7 +70,7 @@ Make sure that the`JWT_CONFIG` table of your application is correctly configured
 
 * The `DOMAIN` must contain the domain for which this JWT is valid.
 * The `PUBLIC_KEY` should contain the public key of the JWT key pair, (the private key is used to sign the JWT at the internal authentication service).
-* Alternatively the `PUBLIC_KEY_URL` can be set as a URL to obtain this dynamically. Public keys obtained in this way are expected to be in JSON Web Key Sets format.
+* Alternatively, the `PUBLIC_KEY_URL` can be set as a URL to obtain this dynamically. Public keys obtained in this way are expected to be in JSON Web Key Sets format.
 * The `REDIRECT_URL` must contain the URL for which the user is redirected to log in, should they not possess a valid JWT.
 * The `KEY_ALGORITHM` should be set either to `KeyAlgorithm.RSA` or `KeyAlgorithm.HMAC`.
 

--- a/docs/03_server/05_access-control/05_sso_saml.md
+++ b/docs/03_server/05_access-control/05_sso_saml.md
@@ -17,7 +17,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 SSO is a mechanism that enables a user to be authenticated against a single system, and use that authenticated id across multiple applications - including those built on the Genesis low-code platform. This has the advantage that a user is required to log in only once, rather than once per system.
 
-SAML is an SSO protocol that can be used to authenticate users on the Genesis platform. It works by connecting a Service Provider (SP) - the Genesis application in this case - and an Identity Provider (IDP), which would be an external party.
+SAML is an SSO protocol that can be used to authenticate users on the Genesis low-code platform. It works by connecting a Service Provider (SP) - the Genesis application in this case - and an Identity Provider (IDP), which would be an external party.
 
 The SP and the IDP communicate using the user's web browser, and do not need to be accessible to each other.
 
@@ -153,13 +153,14 @@ The `loginEndpoint` is the URL to which the front end is redirected once the ful
 If this URL itself is a redirect, the SSO_TOKEN query parameter could be lost.
 
 Additionally, if the web server is routing via scripts, navigating to this URL could throw a **404 Not Found** error. The remedy in this case is to add an override for 404 errors to redirect back to your application logon screen. 
+
 An example of how to do this in NGINX is here:
 ```
 error_page 404 =200 /index.html;
 ```
 :::
 
-If necessary, ou can define advanced configuration in the file **onelogin.saml.properties**. You need to use this if - for example - you need to configure a key for signing the authn request.
+If necessary, you can define advanced configuration in the file **onelogin.saml.properties**. You need to use this if - for example - you need to configure a key for signing the authn request.
 
 Once this is configured, a service provider metadata endpoint will be available on: `https://{url}/gwf/saml/metadata?idp={idp name}`.
 
@@ -189,7 +190,7 @@ To enable users to be able to sign in using SAML, you must add them to the `USER
 In the `SSO_USER` table:
 
 * `SSO_METHOD` must be set to SAML
-* `SSO_SOURCE` must be set to the identity provider name defined in the **saml-config.kts** file.
+* `SSO_SOURCE` must be set to the identity provider name defined in the **saml-config.kts** file
 
 The Genesis username should be the user’s email address.
 
@@ -197,8 +198,8 @@ The Genesis username should be the user’s email address.
 
 This section provides a more detailed description of the workflow between a Genesis application SP and an external IDP. The flow assumes the following settings:
 
-- `ssoToggle` is set to true in the Genesis application’s `config.ts`, this ensures that the ‘Enable SSO?’ checkbox is displayed on the application's login page.
-- 'Enable SSO’ is checked, either manually in the UI, or `ssoEnable` is set to true by default in the config.
+- `ssoToggle` is set to true in the Genesis application’s `config.ts`, this ensures that the **Enable SSO?** checkbox is displayed on the application's login page.
+- either **Enable SSO** is checked manually in the UI, or `ssoEnable` is set to true by default in the config.
 - In the front end, the following has been added to `src/routes/config.ts`:
 
 ```javascript
@@ -224,7 +225,7 @@ this.routes.map(
 
 ```
 
-1. The front end hits **ssoListEndpoint** - by default - this is `gwf/sso/listJWT/SSO` (This is configurable).
+1. The front end hits **ssoListEndpoint** - by default, this is `gwf/sso/listJWT/SSO` (this is configurable).
 2. **ssoListEndpoint** returns a list of identity providers:
    ```
    [
@@ -233,14 +234,12 @@ this.routes.map(
    ]
    ```
 3. Identity providers are parsed and the dropdown is populated on the login page.
-4. The user selects an identity provider using the dropdown (or keeps the preselected default). Then the user clicks the '**SSO Login**' button.
+4. The user selects an identity provider using the dropdown (or keeps the preselected default). Then the user clicks the **SSO Login** button.
 5. The browser redirects to the **ssoLoginUrl**, which might be, for example: `https://dev-position2/gwf/saml/login?idp=provider1`.
 6. The server sends the user to the identity provider’s login page.
 7. The user logs in using their SSO credentials.
-
 8. The server redirects the client back to the client-app with a new url param: `SSO_TOKEN`.
-
-9. The front end checks for the presence of an `SSO_TOKEN` url param. If found, it stores it in session storage and uses it to perform an ‘SSO Login’.
+9. The front end checks for the presence of an `SSO_TOKEN` url parameter. If found, it stores it in session storage and uses it to perform an SSO Login.
 10. The server responds with an ACK and the user is now logged in. If there is an error, a NACK is returned and the login fails.
 
 ## Testing SAML

--- a/docs/03_server/05_access-control/06_sso_oidc.md
+++ b/docs/03_server/05_access-control/06_sso_oidc.md
@@ -114,11 +114,11 @@ Each `identityProvider` configuration has the following properties:
 | client | The client id and secret | Yes | No default value | Object |
 | config | Holds the endpoint and verification configuration for the OIDC provider | Yes if `remoteConfig` is not present | No default value | Object |
 | remoteConfig | If the OIDC provider has the configuration endpoint `remoteConfig`, this can be used to point to that endpoint for automatic `endpoint` and `verification` configuration | Yes if `config` is not present | No default value | Object |
-| scopes | Requested scopes on authorization | No | `openid profile email` | Set |
+| scopes | Requested scopes on authorisation | No | `openid profile email` | Set |
 | onNewUser | Predefined action when a new user logs in. **This property is now deprecated** in favour of `onFirstLogin` and `onLoginSuccess` | No | `ALLOW_ACCESS` - add the user to the database  | Enum (ALLOW_ACCESS, DO_NOTHING) |
 | usernameClaim | The claim to be used as username in the Genesis database. | No | `email`  | String |
 | tokenLifeInSeconds | The life time of the issued SSO_TOKEN. | Yes | No default value | Int |
-| redirectUri | The URI to handle the code authorization. | Yes | No default value | String |
+| redirectUri | The URI to handle the code authorisation. | Yes | No default value | String |
 | onFirstLogin | Configuration for creating `User` and its `UserAttributes`. It's called on first successful login when the user doesn't exist in the database. | No | No default value | Object |
 | onLoginSuccess | Callback that is invoked every time after successful authentication. It has access to the database and the `DecodedIdToken` returned by the OIDC Provider | No | No default value | Object |
 
@@ -126,8 +126,8 @@ Each `config` configuration has the following properties:
 
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
-| endpoints | Holds the token and authorization endpoints | Yes | No default value | Object |
-| verification | Holds configuration for the public key of the JWT issuer, the allowed clock skew and whether validation is enabled | No | No JWT verification | Object |
+| endpoints | Holds the token and authorisation endpoints | Yes | No default value | Object |
+| verification | Holds configuration for the public key of the JWT issuer, the allowed clock skew, and whether validation is enabled | No | No JWT verification | Object |
 
 Each `remoteConfig` configuration has the following properties:
 
@@ -148,7 +148,7 @@ Each `onFirstLogin` has the following properties:
 
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
-| createUser | Returns `User` and `UserAttributes` from the `DecodedIdToken` returned by the OIDC Proider | No | No default value | Object |
+| createUser | Returns `User` and `UserAttributes` from the `DecodedIdToken` returned by the OIDC provider | No | No default value | Object |
 | createUserPermissions | Configuration for user permissions | No | No default value | Object |
 
 Each `endpoints` configuration has the following properties:
@@ -177,7 +177,7 @@ If `verification` is defined, either `publicKey` or `publicKeyUrl` must also be 
 Sometimes, applications require functionality where the user logs out of the OIDC provider. By default, this is disabled.
 
 :::note
-If a user logs out of the OIDC Provider, she or he will also be logged out of all other applications that work with that provider.
+If a user logs out of the OIDC provider, she or he will also be logged out of all other applications that work with that provider.
 :::
 
 There are several steps required to enable OIDC logout. 

--- a/docs/03_server/05_access-control/07_authorisation-overview.md
+++ b/docs/03_server/05_access-control/07_authorisation-overview.md
@@ -161,7 +161,7 @@ customPermissions { message ->
 }
 ```
 
-The `customPermissions` function acts as an additional permissions check which works in a similar way to  `permissionCodes`. If this function returns true, the user will be able to access the resource, otherwise the request will be rejected. The example above perfoms a database lookup on the "USER_ATTRIBUTES" table, and will only return "true" if the user has `AccessType.ALL`.
+The `customPermissions` function acts as an additional permissions check which works in a similar way to  `permissionCodes`. If this function returns true, the user will be able to access the resource, otherwise the request will be rejected. The example above performs a database lookup on the "USER_ATTRIBUTES" table, and will only return true if the user has `AccessType.ALL`.
 
 The main advantage of declaring a `customPermissions` function is that you can write any sort of custom code within it. This can make integration with existing entitlement systems a much easier task, as it means you can avoid replicating the correct rights and profiles hierarchy within the Genesis database.
 
@@ -177,7 +177,8 @@ All `customPermissions` functions give you access to a property called `entityDb
 Generic permissions is a term used to name the optional permissions configuration that is available for a Genesis application; this is included as part of the Genesis Auth Module.
 
 To fully activate Generic permissions, you need to add the following values to your [system definition file](../../../server/configuring-runtime/system-definitions/) before you run `genesisInstall`.
-These values specify which table column will be used to associate users to entities for fine-grained row permissions.
+
+These values specify which table column will be used to associate users with entities for fine-grained row permissions.
 
 
 ```kotlin
@@ -200,10 +201,10 @@ Note these **important** details:
 - When new users are created in the Genesis GUI Admin screens, a required field, COUNTERPARTY, is presented to the operating user. This limits users to belonging to a single counterparty.
 
 
-A user can define additional **permissions.xml** files. For example, you could define something like **order-management-permissions.xml**, with an order management system auth implementation, and it will be read by `AUTH_PERMS` process on startup.
+A user can define additional **permissions.xml** files. For example, you could define something like **order-management-permissions.xml**, with an order management system auth implementation, and it will be read by `AUTH_PERMS` process on start-up.
 
 There are two kinds of permission entity defined by Generic Permissions in the **auth-permission.templt.xml** file:
 
 - **USER_VISIBILITY** - an AuthCache that determines which user is visible to which user; this is driven by which users are associated for the entity. Using our example, if two users are both in the same counterparty, then they should be viewable to each other.
 
-- **ENTITY_VISIBILITY** - an AuthCache that determines if a user has access to particular entity; in our example, if the user is permissioned for a particular counterparty, then it will be able to see the associated row data for that counterparty.
+- **ENTITY_VISIBILITY** - an AuthCache that determines if a user has access to a particular entity; in our example, if the user is permissioned for a particular counterparty, then that user will be able to see the associated row data for that counterparty.

--- a/docs/03_server/05_access-control/08_authorisation.md
+++ b/docs/03_server/05_access-control/08_authorisation.md
@@ -11,7 +11,7 @@ tags:
 
 
 ## Types of control
-Authorisation is achieved by permissioning dynamically. This means you can control access to information in increasingly precise ways, for example:
+Authorisation controls which features and information users have access to. This is achieved by permissioning dynamically. This means you can control access to information in increasingly precise ways, for example:
 
 * An entire grid from the UI
 * An entire data server
@@ -25,7 +25,7 @@ You could hide an entire grid from the UI. So one group of users could view refe
 
 ### Entity-level
 
-This is row or column level access to information. Different users can all view the same grid, but each one sees different data. This is best explained with these simple scenarios:
+This is row- or column-level access to information. Different users can all view the same grid, but each one sees different data. This is best explained with these simple scenarios:
 
 * You can have user A, user B and user C all having the RIGHT_CODE to view a specific grid, but each one sees different trades in that grid. This enables you to separate different trading desks.
 * Each user might only have access to trades for specific clients.

--- a/docs/03_server/05_access-control/08_authorisation.md
+++ b/docs/03_server/05_access-control/08_authorisation.md
@@ -55,7 +55,7 @@ The `RIGHT_SUMMARY` table entries are automatically maintained by the system in 
 
 :::warning
 This table is only automatically maintained when profile user/right entries are maintained via `GENESIS_AUTH_MANAGER` business events. If you update the data in the tables PROFILE_USER or PROFILE_RIGHT via other means (e.g. **DbMon** or **SendIt**) then the `RIGHT_SUMMARY` table will not be maintained automatically.
-In such situations (e.g. setting up a brand new environemnt and bulk loading data into the tables) then the `~/run/auth/scripts/ConsolidateRights.sh` script must be run. This scans all entries in `PROFILE_USER` and `PROFILE_RIGHT` and populates `RIGHT_SUMMARY` withe the correct data.
+In such situations (e.g. setting up a brand new environment and bulk loading data into the tables) then the `~/run/auth/scripts/ConsolidateRights.sh` script must be run. This scans all entries in `PROFILE_USER` and `PROFILE_RIGHT` and populates `RIGHT_SUMMARY` with the the correct data.
 :::
 
 ### Sample explanation
@@ -91,7 +91,7 @@ In many cases, you want different people to have access to different functions a
 
 ## General approach
 
-On startup, the `GENESIS_AUTH_PERMS` process performs an initial scan of all entities. For each entity found, it performs authorisation against every user in the system. This builds a full map of permissioned users.
+On start-up, the `GENESIS_AUTH_PERMS` process performs an initial scan of all entities. For each entity found, it performs authorisation against every user in the system. This builds a full map of permissioned users.
 
 By default, any updates to the entity and the `USER` table will be automatically processed to permission new entities as they are entered into the database.
 
@@ -116,7 +116,7 @@ field(name = "ACCESS_TYPE", type = ENUM("ALL", "ENTITY", "MULTI_ENTITY", default
 Only `ALL` and `ENTITY` are in working condition at the moment.
 :::
 
-Users with `ACCESS_TYPE` set to `ENTITY` (e.g. the entity could be represented by COUNTERPARTY_ID) will be permissioned only to see data relating to the value stored in the x field in the `USER_ATTRIBUTES` table. The name of x field is set in the `ADMIN_PERMISSION_ENTITY_FIELD` in the system definition file, as you can see in the example below.
+Users with `ACCESS_TYPE` set to `ENTITY` (e.g. the entity could be represented by COUNTERPARTY_ID) will be permissioned to see only data relating to the value stored in the x field in the `USER_ATTRIBUTES` table. The name of x field is set in the `ADMIN_PERMISSION_ENTITY_FIELD` in the system definition file, as you can see in the example below.
 
 
 
@@ -129,7 +129,7 @@ systemDefinition {
 }
 ```
 
-These two items change the structure of **auth-tables-dictionary.kts** and **auth-permissions.templt.xml** to accomodate the defined table and field, and ensure that the table/permission data structure is built correctly.
+These two items change the structure of **auth-tables-dictionary.kts** and **auth-permissions.templt.xml** to accommodate the defined table and field, and ensure that the table/permission data structure is built correctly.
 
 Here is the `USER_ATTRIBUTES` table definition in **auth-tables-dictionary.kts**:
 
@@ -163,7 +163,7 @@ table(name = "USER_ATTRIBUTES", id = 1007, audit = details(1052, "AA")) {
 ```
 The permissions field will be added dynamically to `USER_ATTRIBUTES`, so it can be used in auth transactions to control entitlements.
 
-The following table will be created as well (ignore `MULTI_ENTITY` setup for now; this is in development). It is used by the Genesis low-code platform to manage `AUTH_PERMS` results.
+The following table will be created as well (ignore `MULTI_ENTITY` set-up for now; this is in development). It is used by the Genesis low-code platform to manage `AUTH_PERMS` results.
 
 ```kotlin
 val permissionsTable = SysDef.systemDefinition["ADMIN_PERMISSION_ENTITY_TABLE"].orElse(null)
@@ -233,7 +233,7 @@ There are two auth maps in **auth-permissions.templt.xml** to control how users 
         ]]>
 </entity>
 ```
-Here is an example of using `ENTITY_VISIBILITY` in a data server or request server:
+Here is an example of using `ENTITY_VISIBILITY` in a Data Server or Request Server:
 
 ```kotlin
 query("ALL_BID_OFFER_SELLER_DEALER", BID_OFFER_SELLER_VIEW) {
@@ -248,11 +248,11 @@ query("ALL_BID_OFFER_SELLER_DEALER", BID_OFFER_SELLER_VIEW) {
 }
 ```
 
-### Adding authorisation to the data server and request server
+### Adding authorisation to the Data Server and Request Server
 
-The code for permissioning specific queries must be inserted into your data servers and request servers.
+The code for permissioning specific queries must be inserted into your Data Servers and Data Servers.
 
-The dynamic authorisation definition in a GPAL data server or request server has 4 settings, which can be used in any combination:
+The dynamic authorisation definition in a GPAL Data Server or Data Server has 4 settings, which can be used in any combination:
 - grouping (and/or)
 - where clauses
 - hideFields
@@ -349,7 +349,7 @@ permissioning {
 
 #### enrichedAuth
 
-Our permission model could require access to client-enriched data, so data servers have an additional level of auth functionality that takes this data into account.
+Our permission model could require access to client-enriched data, so Data Servers have an additional level of auth functionality that takes this data into account.
 
 Here is an example:
 
@@ -503,7 +503,7 @@ We also define several items on the entity element:
 * **name** - The entity (and table name) we're dealing with
 * **maxEntries** - Max number of entries to read on initial scan
 * **idField** - The account ID
-* **updateOn** xml block - We want to re-evaluate the auth entries (entities and users) when the TAG table is updated, just in case we make a user sales officer/asset manager.
+* **updateOn** xml block - we want to re-evaluate the auth entries (entities and users) when the TAG table is updated, just in case we make a user sales officer/asset manager.
 
 As mentioned above, we will also refresh when either the `ENTITY`, `USER` or `USER_ATTRIBUTES` tables are updated. You will need to define `updateOnUserFields` (see further down) to ensure user data updates are triggered.
 
@@ -749,7 +749,7 @@ dynamicPermissions {
 }
 ```
 
-### Data server snippet
+### Data Server snippet
 ```kotlin
 dataServer {
   query(POSITION_VIEW) {

--- a/versioned_docs/version-2023.1/03_server/05_access-control/03_password-authentication.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/03_password-authentication.md
@@ -21,7 +21,7 @@ The `security` function wraps all other variables and functions within the **aut
 
 * `sessionTimeoutMins` specifies a time out for the session. Sessions are timed out (logged out) after the value defined here. The front end of your application can monitor web movement, page changes, etc. and perform an [automatic refresh](../../../server/integration/rest-endpoints/advanced/#event_login_refresh) - in which case, the user is not aware of the logout and the start of the new session. Default: 30 minutes.
 * `expiryCheckMins` specifies the time interval (in minutes) used to check for idle sessions in the system. Default: 5 minutes.
-* `maxSimultaneousUserLogins` specifies the maximum number of concurrent active sessions a user can maintain. Once this limit has been reached, the user cannot activate additional sessions until one or more of the active sessions has been logged out. If the value zero is not defined, or is not a positive integer, then any number of sessions is permitted. Default: 0.
+* `maxSimultaneousUserLogins` specifies the maximum number of concurrent active sessions a user can maintain. Once this limit has been reached, the user cannot activate additional sessions until one or more of the active sessions has been logged out. So, a value of 1 means that only one session can be logged in at any time; a value of two allows two to be logged in concurrently, and so on. If the value is zero, is not defined, or is not a positive integer, then any number of sessions is permitted. Default: 0.
 
 ```kotlin
 security {
@@ -71,7 +71,7 @@ The following variables are used to configure an LDAP connection; these are only
     * using the `cn` attribute (Common Name)
     * using the `sAMAccountName` in Windows
 * `bypassLoginInternalAuth` this is a boolean flag that prevents internal authorisation checks on login
-* `onLoginSuccess` this is a function which is invoked on a successful LDAP login: for example, it allows you to insert a user into the db when it exists in LDAP but not the database.
+* `onLoginSuccess` this is a function which is invoked on a successful LDAP login: for example, it allows you to insert a user into the database when it exists in LDAP but not the database.
 * `useTLS` this is a boolean value indicating whether or not to use TLS encryption on the connection to the remote LDAP server.
 
 For more information about the various authentication types, see the [Authentication overview](../../../server/access-control/authentication-overview/).
@@ -81,7 +81,7 @@ The `passwordRetry` function has been deprecated in favour of the `retry` functi
 
 ### genesisPassword
 
-The `genesisPassword` groups all configuration options when using `type = AuthType.INTERNAL`. 
+The `genesisPassword` statement groups all configuration options when using `type = AuthType.INTERNAL`. 
 
 ### validation
 The `validation` function enables password validation, and is used to set the variables relating to this validation. 
@@ -92,24 +92,24 @@ These following variables are used to configure the application's password valid
 
 * `passwordStrength` can be called within `validation` to set a range of configuration variables. These enable you to specify in detail the mandatory characteristics for the password:
 
-    * `minimumLength` specifies the minimum length of password. If null or undefined this assumes there is no minimum limit. Default: null.
-    * `maximumLength` specifies the maximum length of password. If null or undefined this assumes there is no maximum limit. Default: null.
-    * `minDigits` specifies the minimum number of numerical digits required in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
+    * `minimumLength` specifies the minimum length of password. If null or undefined, this assumes there is no minimum limit. Default: null.
+    * `maximumLength` specifies the maximum length of password. If null or undefined, this assumes there is no maximum limit. Default: null.
+    * `minDigits` specifies the minimum number of numeric digits required in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
     * `maxRepeatCharacters` specifies the maximum number of the same characters across an entire password. This does not just include consecutive repeat characters, which is controlled by the `repeatCharacterRestrictSize` variable below. If null or undefined, this assumes there is no maximum limit. Default: null.
-    * `minUppercaseCharacters` specifies the minimum number of upper-case characters in a password. If null or undefined this assumes there is no minimum limit. Default: null.
-    * `minLowercaseCharacters` specifies the minimum number of lower-case characters in a password. If null or undefined this assumes there is no minimum limit. Default: null.
+    * `minUppercaseCharacters` specifies the minimum number of upper-case characters in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
+    * `minLowercaseCharacters` specifies the minimum number of lower-case characters in a password. If null or undefined, this assumes there is no minimum limit. Default: null.
     * `minNonAlphaNumericCharacters` specifies the minimum number of non-alphanumeric characters, such as punctuation and other special characters. If null or undefined, this assumes there is no minimum limit. Default: null.
     * `restrictWhitespace` specifies if whitespace characters are prevented from being used in passwords. Default: true.
     * `restrictAlphaSequences` specifies if alphabetical sequences in passwords (e.g. abcdefg) are restricted. Sequences greater than or equal to five characters won't be permitted if this is true. Default: false.
     * `restrictQWERTY` specifies if QWERTY sequences in passwords (e.g. qwertyuiop) are restricted. Sequences greater or equal to five characters won't be permitted if this is true. Default: true.
-    * `restrictNumericalSequences` specifies if numerical sequences in passwords (e.g. 123456) are restricted. Sequences greater or equal to five numbers won't be allowed if active. Default: true.
+    * `restrictNumericalSequences` specifies if numeric sequences in passwords (e.g. 123456) are restricted. Sequences greater or equal to five numbers won't be allowed if active. Default: true.
     * `illegalCharacters` specifies which characters are not permitted in user passwords. Default: empty.
-    * `historicalCheck` specifies how many previous passwords to check against, in order to prevent password re-use. If null or undefined no historical check is performed. Default: null.
+    * `historicalCheck` specifies how many previous passwords to check against, in order to prevent password re-use. If null or undefined, no historical check is performed. Default: null.
     * `restrictPassword` specifies if the password should differ from a list of the worst passwords stored within the application. Default: false.
     * `restrictDictionarySubstring` specifies if any dictionary word of four or more characters can be included in a password (either forwards or backwards). Default: false.
     * `restrictUserName` specifies if the user's username is restricted as part of their password. Default: false.
-    * `repeatCharacterRestrictSize` specifies the number of consecutive repeated characters that make a password restricted. If null or undefined this assumes there is no limit. Default: null.
-    * `passwordExpiryDays` specifies how many days before a password expires. If null or undefined this assumes there is no limit. Default: null.
+    * `repeatCharacterRestrictSize` specifies the number of consecutive repeated characters that make a password restricted. If null or undefined, this assumes there is no limit. Default: null.
+    * `passwordExpiryDays` specifies how many days before a password expires. If null or undefined, this assumes there is no limit. Default: null.
     * `passwordExpiryNotificationDays` specifies how many days before their password expiry a user is notified. If null or undefined, a user is not notified in advance of their password expiry. Default: null.
 
 ### retry
@@ -120,7 +120,7 @@ The `retry` function enables you to configure settings for limiting the rate at 
 
 ### selfServiceReset 
 
-The `selfServiceReset` function enables the self-service reset workflow. In this, users authenticated with the internal auth type, can request an email to reset their password. This workflow requires Genesis Notify to be configured with a working email gateway. When a user requests a reset, an email is sent to their configured email address, with a link to a password reset page. This link is valid for a preconfigured timeout.
+The `selfServiceReset` function enables the self-service reset workflow for the user. In this, users authenticated with the internal auth type, can request an email to reset their password. This workflow requires Genesis Notify to be configured with a working email gateway. When a user requests a reset, an email with a link to a password reset page is sent to their configured email address. This link is valid for a preconfigured timeout.
 
 :::note
 
@@ -130,8 +130,8 @@ In the interest of security, this response will always receive an ACK, even if t
 
 The `selfServiceReset` function  has the following options: 
 
-* `timeoutInMinutes` - the time in minutes that a reset link remains valid 
-* `coolDownInMinutes` - the time in minutes between before the next password reset can be made 
+* `timeoutInMinutes` - the time in minutes for which a reset link remains valid 
+* `coolDownInMinutes` - the time in minutes before the next password reset can be made 
 * `notifyTopic` - the email topic in Genesis Notify to be used
 * `redirectUrl` - the url to use for the redirect
 * `acceptClientUrl` - boolean flag; if true, it will use the client provided reset url
@@ -153,7 +153,7 @@ Both the subject and the body support templating. Values surrounded by double cu
 
 * `RESET_URL` the reset url
 * `TIMEOUT` the time the url is valid for
-* `USER` the user record, properties on this record should be access using lowerCamelCase, e.g. `{{ USER.firstName }}`
+* `USER` the user record, properties on this record should be accessed using lowerCamelCase, e.g. `{{ USER.firstName }}`
 * any system definition or environment variable available
 
 ### mfa
@@ -163,8 +163,8 @@ The `mfa` function allows you to configure Multi-factor Authentication (MFA). Th
 * `codePeriodDiscrepancy` specifies the allowed discrepancy to the TOTP. 1 would mean a single block of each `codePeriodSeconds` either side of the time window. Default: 1.
 * `codeDigits` specifies the number of digits used in the TOTP. Default: 6 digits.
 * `hashingAlgorithm` specifies which choice of Hashing Algorithm to use. Available choices are: `HashingFunction.SHA1`, `HashingFunction.SHA256` or `HashingFunction.SHA512`. Default: `HashingFunction.SHA1`.
-* `issuer` specifies a reference to the Organisation or Entity issuing the MFA. Default: Genesis.
-* `label` specifies a label for the MFA. This is typically an email address of the issuing Entity or Organisation. Default: genesis.global.
+* `issuer` specifies a reference to the organisation or entity issuing the MFA. Default: Genesis.
+* `label` specifies a label for the MFA. This is typically an email address of the issuing entity or organisation. Default: genesis.global.
 * `confirmWaitPeriodSecs` specifies the period of time in seconds before a secret has to be confirmed. Default: 300 seconds.
 * `secretEncryptKey` specifies the key that is used to encrypt Secrets in the database. If this is null or undefined, Secrets will not be encrypted in the database. Default: null.
 * `usernameTableLookUpSalt` specifies the salt with which a username is hashed when stored in the database with the above Secret. If this is null or undefined, the username will not be hashed in the database. Default: null.
@@ -172,21 +172,13 @@ The `mfa` function allows you to configure Multi-factor Authentication (MFA). Th
 ### loginAck
 The `loginAck` function enables you to define additional values to be sent back to the client as part of the `LOGIN_ACK` message. When you call the `loginAck` function, you have to supply a table or view as a parameter. The following functions will be invoked on this table or view:
 
-#### loadRecord
-The `loadRecord` function can be invoked within the `loginAck` function to load a single record from the previously supplied table or view.
+- The `loadRecord` function within the `loginAck` function loads a single record from the previously supplied table or view.
+- The `fields` function within the `loginAck` function specifies which additional fields should be sent back to the client as part of the LOGIN_ACK message.
+- The `customLoginAck` function enables you to modify the list of permissions, profiles and user preferences returned to the client as part of the `LOGIN_ACK` message. For this purpose, the `User` entity is provided as a parameter, as well as three properties:
+    * permissions - a mutable list containing all the right codes associated to the user. Given its mutability, codes can be added or removed.
+    * profiles - a mutable list containing all the profiles associated with the user.  Given its mutability, profiles can be added or removed.
+    * userPreferences - a [GenesisSet](../../../server/inter-process-messages/genesisset/) object containing additional fields provided as part of the [loginAck](#loginack) function. This `GenesisSet` can be modified to provide additional fields or remove existing ones.
 
-#### fields
-The `fields` function can be invoked within the `loginAck` function to specify which additional fields should be sent back to the client as part of the LOGIN_ACK message.
-
-#### customLoginAck
-
-The `customLoginAck` function enables you to modify the list of permissions, profiles and user preferences returned to the client as part of the `LOGIN_ACK` message. For this purpose, the `User` entity is provided as a parameter, as well as three properties:
-
-* permissions - a mutable list containing all the right codes associated to the user. Given its mutability, codes can be added or removed.
-* profiles - a mutable list containing all the profiles associated with the user.  Given its mutability, profiles can be added or removed.
-* userPreferences - a [GenesisSet](../../../server/inter-process-messages/genesisset/) object containing additional fields provided as part of the [loginAck](#loginack) function. This `GenesisSet` can be modified to provide additional fields or remove existing ones.
-
-### Example
 Here is an example configuration:
 
 ```kotlin

--- a/versioned_docs/version-2023.1/03_server/05_access-control/05_sso-saml.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/05_sso-saml.md
@@ -197,9 +197,9 @@ The Genesis username should be the user’s email address.
 
 This section provides a more detailed description of the workflow between a Genesis application SP and an external IDP. The flow assumes the following settings:
 
-- `ssoToggle` is set to true in the Genesis application’s `config.ts`, this ensures that the ‘Enable SSO?’ checkbox is displayed on the application's login page.
-- 'Enable SSO’ is checked, either manually in the UI, or `ssoEnable` is set to true by default in the config.
-- In the front end, the following has been added to `src/routes/config.ts`:
+- `ssoToggle` is set to true in the Genesis application’s `config.ts`, this ensures that the **Enable SSO?’ checkbox is displayed on the application's login page.
+- either **Enable SSO** is checked manually in the UI, or `ssoEnable` is set to true by default in the config.
+- in the front end, the following has been added to `src/routes/config.ts`:
 
 ```javascript
 this.routes.map(
@@ -224,7 +224,7 @@ this.routes.map(
 
 ```
 
-1. The front end hits **ssoListEndpoint** - by default - this is `gwf/sso/listJWT/SSO` (This is configurable).
+1. The front end hits **ssoListEndpoint** - by default, this is `gwf/sso/listJWT/SSO` (this is configurable).
 2. **ssoListEndpoint** returns a list of identity providers:
    ```
    [
@@ -233,14 +233,14 @@ this.routes.map(
    ]
    ```
 3. Identity providers are parsed and the dropdown is populated on the login page.
-4. The user selects an identity provider using the dropdown (or keeps the preselected default). Then the user clicks the '**SSO Login**' button.
+4. The user selects an identity provider using the dropdown (or keeps the preselected default). Then the user clicks the **SSO Login** button.
 5. The browser redirects to the **ssoLoginUrl**, which might be, for example: `https://dev-position2/gwf/saml/login?idp=provider1`.
 6. The server sends the user to the identity provider’s login page.
 7. The user logs in using their SSO credentials.
 
 8. The server redirects the client back to the client-app with a new url param: `SSO_TOKEN`.
 
-9. The front end checks for the presence of an `SSO_TOKEN` url param. If found, it stores it in session storage and uses it to perform an ‘SSO Login’.
+9. The front end checks for the presence of an `SSO_TOKEN` url param. If found, it stores it in session storage and uses it to perform an SSO Login.
 10. The server responds with an ACK and the user is now logged in. If there is an error, a NACK is returned and the login fails.
 
 ## Testing SAML

--- a/versioned_docs/version-2023.1/03_server/05_access-control/06_sso-oidc.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/06_sso-oidc.md
@@ -114,11 +114,11 @@ Each `identityProvider` configuration has the following properties:
 | client | The client id and secret | Yes | No default value | Object |
 | config | Holds the endpoint and verification configuration for the OIDC provider | Yes if `remoteConfig` is not present | No default value | Object |
 | remoteConfig | If the OIDC provider has the configuration endpoint `remoteConfig`, this can be used to point to that endpoint for automatic `endpoint` and `verification` configuration | Yes if `config` is not present | No default value | Object |
-| scopes | Requested scopes on authorization | No | `openid profile email` | Set |
+| scopes | Requested scopes on authorisation | No | `openid profile email` | Set |
 | onNewUser | Predefined action when a new user logs in. | No | `ALLOW_ACCESS` - add the user to the database  | Enum (ALLOW_ACCESS, DO_NOTHING) |
 | usernameClaim | The claim to be used as username in the Genesis database. | No | `email`  | String |
 | tokenLifeInSeconds | The life time of the issued SSO_TOKEN. | Yes | No default value | Int |
-| redirectUri | The URI to handle the code authorization. | Yes | No default value | String |
+| redirectUri | The URI to handle the code authorisation. | Yes | No default value | String |
 
 
 Each `config` configuration has the following properties:
@@ -126,7 +126,7 @@ Each `config` configuration has the following properties:
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
 | endpoints | Holds the token and authorization endpoints | Yes | No default value | Object |
-| verification | Holds configuration for the public key of the JWT issuer, the allowed clock skew and whether validation is enabled | No | No JWT verification | Object |
+| verification | Holds configuration for the public key of the JWT issuer, the allowed clock skew, and whether validation is enabled | No | No JWT verification | Object |
 
 Each `remoteConfig` configuration has the following properties:
 
@@ -140,8 +140,8 @@ Each `client` configuration has the following properties:
 
 | Property name | Description | Mandatory | Default value | Type |
 | --- | ------ | --- | --- | --- |
-| id | The client id provided by the OIDC Provider when application was registered | Yes | No default value | String |
-| secret | The client secret provided by the OIDC Provider when application was registered | Yes | No default value | String |
+| id | The client id provided by the OIDC provider when application was registered | Yes | No default value | String |
+| secret | The client secret provided by the OIDC provider when application was registered | Yes | No default value | String |
 
 Each `endpoints` configuration has the following properties:
 
@@ -169,7 +169,7 @@ If `verification` is defined, either `publicKey` or `publicKeyUrl` must also be 
 Sometimes, applications require functionality where the user logs out of the OIDC provider. By default, this is disabled.
 
 :::note
-If a user logs out of the OIDC Provider, she or he will also be logged out of all other applications that work with that provider.
+If a user logs out of the OIDC provider, she or he will also be logged out of all other applications that work with that provider.
 :::
 
 There are several steps required to enable OIDC logout. 

--- a/versioned_docs/version-2023.1/03_server/05_access-control/07_authorisation-overview.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/07_authorisation-overview.md
@@ -161,7 +161,7 @@ customPermissions { message ->
 }
 ```
 
-The `customPermissions` function acts as an additional permissions check which works in a similar way to  `permissionCodes`. If this function returns true, the user will be able to access the resource, otherwise the request will be rejected. The example above perfoms a database lookup on the "USER_ATTRIBUTES" table, and will only return "true" if the user has `AccessType.ALL`.
+The `customPermissions` function acts as an additional permissions check which works in a similar way to  `permissionCodes`. If this function returns true, the user will be able to access the resource, otherwise the request will be rejected. The example above performs a database look-up on the "USER_ATTRIBUTES" table, and will only return "true" if the user has `AccessType.ALL`.
 
 The main advantage of declaring a `customPermissions` function is that you can write any sort of custom code within it. This can make integration with existing entitlement systems a much easier task, as it means you can avoid replicating the correct rights and profiles hierarchy within the Genesis database.
 
@@ -177,7 +177,7 @@ All `customPermissions` functions give you access to a property called `entityDb
 Generic permissions is a term used to name the optional permissions configuration that is available for a Genesis application; this is included as part of the Genesis Auth Module.
 
 To fully activate Generic permissions, you need to add the following values to your [system definition file](../../../server/configuring-runtime/system-definitions/) before you run `genesisInstall`.
-These values specify which table column will be used to associate users to entities for fine-grained row permissions.
+These values specify which table column will be used to associate users with entities for fine-grained row permissions.
 
 
 ```kotlin
@@ -200,10 +200,10 @@ Note these **important** details:
 - When new users are created in the Genesis GUI Admin screens, a required field, COUNTERPARTY, is presented to the operating user. This limits users to belonging to a single counterparty.
 
 
-A user can define additional **permissions.xml** files. For example, you could define something like **order-management-permissions.xml**, with an order management system auth implementation, and it will be read by `AUTH_PERMS` process on startup.
+A user can define additional **permissions.xml** files. For example, you could define something like **order-management-permissions.xml**, with an order management system auth implementation, and it will be read by `AUTH_PERMS` process on start-up.
 
 There are two kinds of permission entity defined by Generic Permissions in the **auth-permission.templt.xml** file:
 
 - **USER_VISIBILITY** - an AuthCache that determines which user is visible to which user; this is driven by which users are associated for the entity. Using our example, if two users are both in the same counterparty, then they should be viewable to each other.
 
-- **ENTITY_VISIBILITY** - an AuthCache that determines if a user has access to particular entity; in our example, if the user is permissioned for a particular counterparty, then it will be able to see the associated row data for that counterparty.
+- **ENTITY_VISIBILITY** - an AuthCache that determines if a user has access to a particular entity; in our example, if the user is permissioned for a particular counterparty, then it will be able to see the associated row data for that counterparty.

--- a/versioned_docs/version-2023.1/03_server/05_access-control/08_authorisation.md
+++ b/versioned_docs/version-2023.1/03_server/05_access-control/08_authorisation.md
@@ -11,7 +11,7 @@ tags:
 
 
 ## Types of control
-Authorisation is achieved by permissioning dynamically. This means you can control access to information in increasingly precise ways, for example:
+Authorisation controls which features and information users have access to. This is achieved by permissioning dynamically. This means you can control access to information in increasingly precise ways, for example:
 
 * An entire grid from the UI
 * An entire data server
@@ -25,7 +25,7 @@ You could hide an entire grid from the UI. So one group of users could view refe
 
 ### Entity-level
 
-This is row or column level access to information. Different users can all view the same grid, but each one sees different data. This is best explained with these simple scenarios:
+This is row- or column-level access to information. Different users can all view the same grid, but each one sees different data. This is best explained with these simple scenarios:
 
 * You can have user A, user B and user C all having the RIGHT_CODE to view a specific grid, but each one sees different trades in that grid. This enables you to separate different trading desks.
 * Each user might only have access to trades for specific clients.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-755

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
YES

Have you checked all new or changed links?
NOT YET

Is there anything else you would like us to know?
NO

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

