### PR TITLE
Mends broken links in new pages . These are only in the Next version

### DIFF
--- a/docs/03_server/10_integration/06_notify/03_symphony.md
+++ b/docs/03_server/10_integration/06_notify/03_symphony.md
@@ -157,7 +157,7 @@ notify {
 
 ## Genesis Notify operations for Symphony
 
-The Notify service currently provides additional Symphony operations; these are exposed as [Event Handlers](../../../server/event-handler/introduction).
+The Notify service currently provides additional Symphony operations; these are exposed as [Event Handlers](../../../../server/event-handler/introduction/).
 
 * `GATEWAY_CREATE_CHANNEL` creates a channel (to allow external users to be added to a channel; a channel should be created with `external` set to `true` and `public` to `false`)
 * `GATEWAY_ADD_MEMBER_TO_CHANNEL` adds a user to a channel (if the user is not a member of the host POD, then a connection request will be sent to that user)
@@ -180,7 +180,7 @@ data class AddUserToChannel(val channelName: String, val userId: String)
 data class RemoveUserFromChannel(val channelName: String, val userId: String)
 data class ActionOnChannel(val roomId: String, val activate: Boolean)
 ```
-The Notify service also offers the [Request Server](../../../server/request-server/introduction) resource `LIST_MEMBERS_OF_CHANNEL`, which, unsurprisingly, lists members of a channel.
+The Notify service also offers the [Request Server](../../../../server/request-server/introduction/) resource `LIST_MEMBERS_OF_CHANNEL`, which, unsurprisingly, lists members of a channel.
 
 * Inputs (Request)
 

--- a/docs/04_web/02_web-components/01_form/16_criteria-segmented-control.md
+++ b/docs/04_web/02_web-components/01_form/16_criteria-segmented-control.md
@@ -12,7 +12,7 @@ tags:
 
 This version allows you to use a segmented control that generates criteria based on the selected item.
 
-1. Add `@genesislcap/foundation-criteria` as a dependency in your **package.json** file. Whenever you change the dependencies of your project, ensure you run the `$ npm run bootstrap` command again. For more information, see the [package.json basics](../../../web/basics/package-json-basics/) page.
+1. Add `@genesislcap/foundation-criteria` as a dependency in your **package.json** file. Whenever you change the dependencies of your project, ensure you run the `$ npm run bootstrap` command again. For more information, see the [package.json basics](../../../../web/basics/package-json-basics/) page.
 
 ```javascript
 {


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PLAT-659

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
only Next is relevant

Have you checked all new or changed links?
Yes: 3 of them

Is there anything else you would like us to know?
Wir wunschen unseren Lesern in schoenes Wochenende

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

