### PR TITLE
PTL-758 - remove double conclusion session on Quick Start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ tmp
 .vscode
 
 /src/client-modules/
-src/client-modules/iife.d.ts
+/src/client-modules/iife.d.ts
+src/client-modules/docs.iife.min.js

--- a/docs/01_getting-started/02_quick-start/08_run-the-application-docker.md
+++ b/docs/01_getting-started/02_quick-start/08_run-the-application-docker.md
@@ -349,9 +349,4 @@ Below, we have added two trades. We have sold MMM at 404 and bought back at 401.
 
 ![](/img/final-result.png)
 
-
-## Conclusion
-That’s it. You have quickly built a very simple application using some fundamental Genesis components.
-
-
 There's obviously a lot more to building enterprise-ready applications. However, you now have enough knowledge and experience of the Genesis low-code platform to look at our reference documentation and learn more there.

--- a/versioned_docs/version-2023.1/01_getting-started/02_quick-start/08_run-the-application-docker.md
+++ b/versioned_docs/version-2023.1/01_getting-started/02_quick-start/08_run-the-application-docker.md
@@ -349,9 +349,4 @@ Below, we have added two trades. We have sold MMM at 404 and bought back at 401.
 
 ![](/img/final-result.png)
 
-
-## Conclusion
-That’s it. You have quickly built a very simple application using some fundamental Genesis components.
-
-
 There's obviously a lot more to building enterprise-ready applications. However, you now have enough knowledge and experience of the Genesis low-code platform to look at our reference documentation and learn more there.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-758

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs and 2023.1

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
```
It's a new dawn
It's a new day
It's a new life
For me
And I'm feeling good
```
For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

