### PR TITLE
docs: add metrics logging level property to docs (PLAT-830)

### DIFF
--- a/docs/05_operations/08_metrics/01_metrics.md
+++ b/docs/05_operations/08_metrics/01_metrics.md
@@ -35,7 +35,7 @@ item(name = "MetricsReportType", value = "GRAPHITE,SLF4J")
 item(name = "MetricsGraphiteURL", value = "localhost")
 item(name = "MetricsGraphitePort", value = "2003")
 item(name = "MetricsReportIntervalSecs", value = "60") // Optional, defaults to 10 seconds if not specified
-item(name = "Slf4jReporterLoggingLevel", value = "DEBUG") // Optional, defaults to DEBUG, options include {DEBUG, INFO, WARN, ERROR}
+item(name = "Slf4jReporterLoggingLevel", value = "DEBUG") // Optional, defaults to DEBUG, options include {DEBUG, INFO, TRACE, WARN, ERROR}
 ```
 
 ## Metrics API

--- a/docs/05_operations/08_metrics/01_metrics.md
+++ b/docs/05_operations/08_metrics/01_metrics.md
@@ -35,6 +35,7 @@ item(name = "MetricsReportType", value = "GRAPHITE,SLF4J")
 item(name = "MetricsGraphiteURL", value = "localhost")
 item(name = "MetricsGraphitePort", value = "2003")
 item(name = "MetricsReportIntervalSecs", value = "60") // Optional, defaults to 10 seconds if not specified
+item(name = "Slf4jReporterLoggingLevel", value = "DEBUG") // Optional, defaults to DEBUG, options include {DEBUG, INFO, WARN, ERROR}
 ```
 
 ## Metrics API

--- a/versioned_docs/version-2023.1/05_operations/08_metrics/01_metrics.md
+++ b/versioned_docs/version-2023.1/05_operations/08_metrics/01_metrics.md
@@ -35,7 +35,7 @@ item(name = "MetricsReportType", value = "GRAPHITE,SLF4J")
 item(name = "MetricsGraphiteURL", value = "localhost")
 item(name = "MetricsGraphitePort", value = "2003")
 item(name = "MetricsReportIntervalSecs", value = "60") // Optional, defaults to 10 seconds if not specified
-item(name = "Slf4jReporterLoggingLevel", value = "DEBUG") // Optional, defaults to DEBUG, options include {DEBUG, INFO, WARN, ERROR}
+item(name = "Slf4jReporterLoggingLevel", value = "DEBUG") // Optional, defaults to DEBUG, options include {DEBUG, INFO, TRACE, WARN, ERROR}
 ```
 
 ## Metrics API

--- a/versioned_docs/version-2023.1/05_operations/08_metrics/01_metrics.md
+++ b/versioned_docs/version-2023.1/05_operations/08_metrics/01_metrics.md
@@ -35,6 +35,7 @@ item(name = "MetricsReportType", value = "GRAPHITE,SLF4J")
 item(name = "MetricsGraphiteURL", value = "localhost")
 item(name = "MetricsGraphitePort", value = "2003")
 item(name = "MetricsReportIntervalSecs", value = "60") // Optional, defaults to 10 seconds if not specified
+item(name = "Slf4jReporterLoggingLevel", value = "DEBUG") // Optional, defaults to DEBUG, options include {DEBUG, INFO, WARN, ERROR}
 ```
 
 ## Metrics API


### PR DESCRIPTION
Thank you for contributing to the documentation.

This PR adds docs to show how the logging level of SLF4J metrics can be configured using sys def

Your Jira ticket is:
PLAT-830

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc? Yes
<!--- Yes / No -->   

Have you checked all new or changed links?
<!--- Yes / No --> 

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

