### PR TITLE
PTL-716: Fix repeat example

### DIFF
--- a/docs/04_web/10_dynamic-layout/10_foundation-layout.md
+++ b/docs/04_web/10_dynamic-layout/10_foundation-layout.md
@@ -466,7 +466,7 @@ class Commodities extends FASTElement {
 const template = html<Commodities>`
 <foundation-layout>
 	<foundation-layout-region type="horizontal">
-		${when(x => x.positions, html<Position>`
+		${repeat(x => x.positions, html<Position>`
 			<foundation-layout-item title="${x => x.symbol}">
 				<chart symbol="${x => x.symbol}"></chart>
 			</foundation-layout-item>`)}

--- a/versioned_docs/version-2023.1/04_web/10_dynamic-layout/10_foundation-layout.md
+++ b/versioned_docs/version-2023.1/04_web/10_dynamic-layout/10_foundation-layout.md
@@ -468,30 +468,13 @@ class Commodities extends FASTElement {
 const template = html<Commodities>`
 <foundation-layout>
 	<foundation-layout-region type="horizontal">
-		${when(x => x.positions, html<Position>`
+		${repeat(x => x.positions, html<Position>`
 			<foundation-layout-item title="${x => x.symbol}">
 				<chart symbol="${x => x.symbol}"></chart>
 			</foundation-layout-item>`)}
 	</foundation-layout-region>
 </foundation-layout>`;
 ```
-
-For an example where the `Commodities` object has three positions, you will see the following output:
-```
-+-----------------------------------------------------+
-|              Component 1 Contents                   |
-+-----------------------------------------------------+
-|              Component 2 Contents                   |
-+-----------------------------------------------------+
-|              Component 3 Contents                   |
-+-----------------------------------------------------+
-```
-
-
-:::note
-`<chart>` is just an example component; it doesn't exist within `foundation-ui`.
-:::
-
 ### `when` directive
 
 Using the `when` directive:


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-716

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
docs and 2023.1

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

