### PR TITLE
PTL-769: two broken links

### DIFF
--- a/versioned_docs/version-2022.3/04_web/02_web-components/00_index.md
+++ b/versioned_docs/version-2022.3/04_web/02_web-components/00_index.md
@@ -1,0 +1,45 @@
+---
+title: 'Web components - overview'
+sidebar_label: 'Overview'
+id: overview
+tags:
+  - web
+  - frontend
+  - ui
+  - browsers
+  - support
+---
+
+[Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) are at the very heart of our strategy - which is based on native browsers and a standards-based component model.
+
+This eliminates a number of problems, such as deciding between Angular, React & Vue, dealing with version clashes & upgrades, or needing to onboard web-framework specialists.
+
+Our Web Components are built on top of [Microsoft FAST](https://www.fast.design/docs/introduction/), which is a lightweight abstraction that enables you to build performant, memory-efficient, standards-compliant Web Components.
+
+Our Genesis packages are scoped to `@genesislcap`. These consist of:
+
+- `@genesislcap/foundation-ui`: Base components
+- `@genesislcap/foundation-zero`: The zero design-system variant
+- `@genesislcap/foundation-utils`: Utilities
+- `@genesislcap/foundation-comms`: Comms system
+- ...etc
+
+## Browser support
+Below is a list of browsers that provide native support for Web Components.
+
+### Desktop
+- Firefox (63+)
+- Chrome (67+)
+- Opera (64+)
+- Edge (79+)
+- IE11 (not out of the box, but partial support with polyfills is possible)
+- Safari (10.1+ supports a number of web component features, but fewer than the above browsers)
+
+### Mobile
+- Android Browser (94+)
+- Opera Mobile (64+)
+- Chrome for Android (94+)
+- Firefox for Android (92+)
+- Samsung Internet (6.2+)
+
+See [caniuse.com](https://caniuse.com/?search=web%20components) for more information.

--- a/versioned_docs/version-2022.4/04_web/02_web-components/00_index.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/00_index.md
@@ -1,0 +1,45 @@
+---
+title: 'Web components - overview'
+sidebar_label: 'Overview'
+id: overview
+tags:
+  - web
+  - frontend
+  - ui
+  - browsers
+  - support
+---
+
+[Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) are at the very heart of our strategy - which is based on native browsers and a standards-based component model.
+
+This eliminates a number of problems, such as deciding between Angular, React & Vue, dealing with version clashes & upgrades, or needing to onboard web-framework specialists.
+
+Our Web Components are built on top of [Microsoft FAST](https://www.fast.design/docs/introduction/), which is a lightweight abstraction that enables you to build performant, memory-efficient, standards-compliant Web Components.
+
+Our Genesis packages are scoped to `@genesislcap`. These consist of:
+
+- `@genesislcap/foundation-ui`: Base components
+- `@genesislcap/foundation-zero`: The zero design-system variant
+- `@genesislcap/foundation-utils`: Utilities
+- `@genesislcap/foundation-comms`: Comms system
+- ...etc
+
+## Browser support
+Below is a list of browsers that provide native support for Web Components.
+
+### Desktop
+- Firefox (63+)
+- Chrome (67+)
+- Opera (64+)
+- Edge (79+)
+- IE11 (not out of the box, but partial support with polyfills is possible)
+- Safari (10.1+ supports a number of web component features, but fewer than the above browsers)
+
+### Mobile
+- Android Browser (94+)
+- Opera Mobile (64+)
+- Chrome for Android (94+)
+- Firefox for Android (92+)
+- Samsung Internet (6.2+)
+
+See [caniuse.com](https://caniuse.com/?search=web%20components) for more information.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-769

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
22.4 and 22.3 are relevant

Have you checked all new or changed links?
yes

Is there anything else you would like us to know?
Nein

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

