### PR TITLE
PTL-764: links removed from release notes

### DIFF
--- a/docs/05_operations/11_release-notes/01_Version-2023.1.md
+++ b/docs/05_operations/11_release-notes/01_Version-2023.1.md
@@ -23,11 +23,11 @@ The basis of this version is:
 Release date: February 28, 2023. 
 
 ## Feature highlights
-* **Revamped pending approval workflow** - The pending approval workflow has been revamped to support GPAL configuration and other improvements. More information [here](../../../server/event-handler/advanced/#pending-approvals).
-* **Self-service password reset functionality** - The platform now supports self-service password reset capabilities. Please see this [page](../../../server/access-control/password-authentication/#selfservicereset) for more information.
-* **JSON Schema validation** - Event Handlers now validate each incoming message based on the implicit JSON schema definition. See more information in [schema validation](../../../server/event-handler/advanced/#disabling-schema-validation) and [inter-process messages](../../../server/inter-process-messages/metadata-annotations/).
+* **Revamped pending approval workflow** - The pending approval workflow has been revamped to support GPAL configuration and other improvements. 
+* **Self-service password reset functionality** - The platform now supports self-service password reset capabilities.
+* **JSON Schema validation** - Event Handlers now validate each incoming message based on the implicit JSON schema definition.
 * **Case-insensitive user login** - The user name field is now case-insensitive when attempting login operations.
-* **Custom permissions support** - A new function called `customPermissions` is available within the `permissioning` block to improve integration with third-party entitlement systems. More information in this [page](../../../server/access-control/authorisation-overview/#custom-permissions-function).
+* **Custom permissions support** - A new function called `customPermissions` is available within the `permissioning` block to improve integration with third-party entitlement systems. 
 * **OpenID Connect improvements** - It is now possible to set up a new logout workflow within Genesis that also logs out the user from the underlying SSO identity provider.
 
 ## Genesis Server Framework (GSF)
@@ -41,12 +41,12 @@ GSF and its modules are compiled using Kotlin 1.7.10 and Gradle 7.5.0.
 ## GSF
 
 ### Breaking changes
-- Make username available in scope within a permissioning 'where' clause (see [sample code](../../../server/access-control/authorisation/#where-clauses))
+- Make username available in scope within a permissioning 'where' clause. 
 - MS SQL fields now use the appropriate "max length" parameter when the `maxSize` value goes beyond the MS SQL limit. 
 - The 'USER' table has been updated to include a unique index for the 'REFRESH_TOKEN' field.
 - The minimal safe TLS version is now set to 1.2.
-- The pending approval mechanism has had a [major revamp](../../../server/event-handler/advanced/#pending-approvals)).
-- JSON [schema validation](../../../server/event-handler/advanced/#disabling-schema-validation) and [inter-process messages](../../../server/inter-process-messages/metadata-annotations/) have been enabled for Event Handlers in GSF.
+- The pending approval mechanism has had a major revamp.
+- JSON schema validation and inter-process messages have been enabled for Event Handlers in GSF.
 
 ### Features
 
@@ -58,7 +58,7 @@ GSF and its modules are compiled using Kotlin 1.7.10 and Gradle 7.5.0.
 - We now allow running containers as non-root users.
 - There is now access to self-service password reset without logging in.
 - We have enabled case-insensitive support for username as part of the login workflow in GENESIS_ROUTER.
-- Auth map is now optional in permissioning GPAL (see this [example](../../../server/access-control/authorisation-overview/#auth-sub-block)).
+- Auth map is now optional in permissioning GPAL.
 - Mon process statuses now include a new HEALTHY state when a process has passed its health checks.
 - Auto-increment ids can be shared between more than one table definition to have their own sequence value.
 
@@ -101,7 +101,7 @@ GSF and its modules are compiled using Kotlin 1.7.10 and Gradle 7.5.0.
 
 ### Features
 
-- We have added "customLoginAck" block to auth-preferences, so we can [further customise the login ack message](../../../server/access-control/password-authentication/#customloginack).
+- We have added "customLoginAck" block to auth-preferences, so we can further customise the login ack message.
 - New fields have been added to ALL_APPROVAL_ALERTS and add new query for ALL_APPROVAL_ALERTS_AUDITS as part of the pending approval workflow revamp.
 - We have added allowedClockSkewSeconds property to the OIDC verification configuration.
 - There is now logout functionality for OIDC.
@@ -191,7 +191,7 @@ This release maps to 10.5.0 of `foundation ui` packages.
 
 - The deprecated `getPermissions()` and `getProfiles()` have been removed from the session. Use `auth.currentUser.profiles` and `auth.currentUser.permissions` instead.
 - For the `grid-pro-genesis-datasource`, the attributes have been made kebab-case rather than camelCase for consistency. The functionality from the `withGridInit` flag has been removed and replaced with `deferredGridOptions`.
-- `foundation-login`. Use the exported configure function to customise login with the available [config](https://github.com/genesislcap/foundation-ui/blob/v2023.1/packages/foundation/foundation-mf/foundation-login/docs/api/foundation-login.loginconfig.md) settings. Note you need to be running 6.5.0 of `auth` and `genesis` on the back end.
+- `foundation-login`. Use the exported configure function to customise login with the available config settings. Note you need to be running 6.5.0 of `auth` and `genesis` on the back end.
 ```
  {
     path: 'login',
@@ -354,12 +354,12 @@ These are the complete changes.
 - Showcases/micro-front ends not running locally 
 - Allow to pass column config to file-upload-grid 
 - column config without overriding it by metadata 
-- (foundation-entity-management): lifecycle mixin for entitites.ts and users.ts 
+- (foundation-entity-management): lifecycle mixin for entities.ts and users.ts 
 - (foundation-testing): add insertRule mock 
 - (foundation-ui): adjusting storybook versions 
 - (foundation-login): ensure autoConnect is non-blocking 
 - (foundation-ui): label made optional and fixed grid filtering issue 
-- (foundation-ui): file upload url was missing /gwf prefix. 
+- (foundation-ui): file upload url was missing /gwf prefix 
 - (foundation-login): add hostPath config 
 - (foundation-login): update README, logout to '/' 
 
@@ -367,7 +367,7 @@ These are the complete changes.
 - Improve genx error/help messages  
 - Fixing linting error 
 - Update orderBy param handling with extra logger.warn
-- (grid-pro): included onSortChanged in list of events the save columnState.
+- (grid-pro): included onSortChanged in list of events the save columnState
 - Fixing stylelint error in zero slider
 - Address bootstrap warning on serve lib version (forms pkg) 
 - Update storybook to V7+ (@next for now)
@@ -377,10 +377,10 @@ These are the complete changes.
 - Enable CI to push version commits to protected branches 
 - (foundation-comms): delete router logic from comms 
 - ensuring PR titles are valid conventional commits 
-- (grid-pro): enableCellFlashing option and - autoCellRendererByType improvement. 
+- (grid-pro): enableCellFlashing option and - autoCellRendererByType improvement 
 - Separate Slack channel for Web releases
 - Update CODEOWNERS file 
-- (foundation-header): added part names to logo elements. 
+- (foundation-header): added part names to logo elements
 - Added design-system-export component 
 - Remove username from requests payload 
 - Publishing to public NPM registry 

--- a/docs/05_operations/11_release-notes/02_Version-2022.4.md
+++ b/docs/05_operations/11_release-notes/02_Version-2022.4.md
@@ -87,7 +87,7 @@ This is a high-level overview of the changes.
 ### Features
 * Added a `foundation-layout` package to provide application and route-based layout, similar to [Golden Layout](https://golden-layout.com/). Most APIs are in [@beta](https://api-extractor.com/pages/tsdoc/tag_beta/), but feel free to test these before full public release.
 * Added a `foundation-criteria` package to provide a type-safe criteria builder for generating queries.
-* Added a `foundation-filters` package to provide a collection of client-side filters that can be used in complex logic chains ([docs](../../../web/filters/foundation-filters/)).
+* Added a `foundation-filters` package to provide a collection of client-side filters that can be used in complex logic chains.
 * Added support for OpenID SSO in `foundation-login`.
 * Added bubble and scatter chart types.
 * Added drag-and-drop field ordering functionality to `foundation-reporting`.

--- a/docs/05_operations/11_release-notes/03_Version-2022.3.md
+++ b/docs/05_operations/11_release-notes/03_Version-2022.3.md
@@ -83,7 +83,7 @@ Features
 - we have added options for username and password to allow the use of authenticated MQTT brokers  
 - tls certificate verification can now be disabled for mqtt connection 
 - chore: FDB diagnostic utility scripts added
-- chore: status badge in [README.md](http://readme.md/) updated
+- chore: status badge in README.md updated
 - chore: oracle warning removed
 - chore: updating opencsv to 5.7.1 
 - chore: improvements to tidy up the docker plugin configuration 

--- a/docs/05_operations/11_release-notes/04_Version-2022.2.md
+++ b/docs/05_operations/11_release-notes/04_Version-2022.2.md
@@ -10,6 +10,12 @@ tags:
     - v-2022.2
 ---
 
+:::warning
+
+This documentation version has been archived.
+
+::
+
 ## Release notes
 This is version v2022.2 of the documentation for the Genesis low-code platform.
 
@@ -205,12 +211,12 @@ The basis of this version is:
 - A number of (`foundation-header`, `foundation-reporting`) styling improvements to micro front-ends.
 - The `foundation-header` for micro front-ends is more configurable.
 - Created How-To and API documentation for several of our micro front-ends:
-    - [Header](../../../web/micro-front-ends/foundation-header)
-    - [Entity Management](../../../web/micro-front-ends/foundation-entity-management)
-    - [User Management](../../../web/micro-front-ends/foundation-entity-management#User-management)
-    - [Profile Management](../../../web/micro-front-ends/foundation-entity-management/#profile-management)
-    - [Login](../../../web/micro-front-ends/foundation-login)
-    - [Reporting](../../../web/micro-front-ends/front-end-reporting/foundation-reporting)
+    - Header
+    - Entity Management
+    - User Management
+    - Profile Management
+    - Login
+    - Reporting
 - Added multiple parameter support for Testing Suite in foundation-testing
 - More code examples in our Showcase Client App, including selecting values and labels in our combobox programmatically.
 - Added slotted-styles component to allow overriding component styles.
@@ -258,7 +264,7 @@ ZeroMQ publishers and subscribers (and the ZeroMQ proxy implementation) now have
 
     - this.socket.recvStr();
     - final byte msgTrimmed = this.socket.recv();
-    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker);
+    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker));
     - ZeroMQForwarder.kt. This is used when proxying ZeroMQ updates via the GENESIS_CLUSTER implementation. Publishers will send messages to GENESIS_CLUSTER and GENESIS_CLUSTER will redistribute those to any other process subscribed to it.
 
 - Methods. We have added trace logging for the following methods:

--- a/docs/05_operations/11_release-notes/04_Version-2022.2.md
+++ b/docs/05_operations/11_release-notes/04_Version-2022.2.md
@@ -36,7 +36,7 @@ Release date: July 08, 2022. Note that there is sub-release, [2022.2.1](../../..
 - **DSL**. The first release (version 0.0.1) of our proprietary DSL now enables you to define full-stack applications, unifying front-end and back-end development.
     This is designed to improve the speed and efficiency of development on the Genesis low-code platform. You can now:
 
-    - enable authentication more easily across your applications- more easily authorise access to grids, views or commands
+    - enable authentication more easily across your applications - more easily authorise access to grids, views or commands
     - create custom commands and advanced views (via custom cell renderers).
 
 Main details are:

--- a/docs/05_operations/11_release-notes/05_Version-2022.1.md
+++ b/docs/05_operations/11_release-notes/05_Version-2022.1.md
@@ -10,6 +10,12 @@ tags:
     - v-2022.1
 ---
 
+:::warning
+
+This documentation version has been archived.
+
+:::
+
 This is version v2022.1 of the documentation for the Genesis low-code platform.
 
 The basis of this version is:
@@ -344,7 +350,7 @@ consolidator(TRADE, ORDER) {
 }
 ```
 
-In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. For further details, please see [here](../../03_server/07_consolidator/01_introduction.md).
+In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. 
 
 The main advantages over the previous consolidator syntax are:
 

--- a/versioned_docs/version-2022.3/05_operations/10_release-notes/01_Version-2022.3.md
+++ b/versioned_docs/version-2022.3/05_operations/10_release-notes/01_Version-2022.3.md
@@ -162,7 +162,7 @@ Features
 - we have added options for username and password to allow the use of authenticated MQTT brokers  
 - tls certificate verification can now be disabled for mqtt connection 
 - chore: FDB diagnostic utility scripts added
-- chore: status badge in [README.md](http://readme.md/) updated
+- chore: status badge in README.md updated
 - chore: oracle warning removed
 - chore: updating opencsv to 5.7.1 
 - chore: improvements to tidy up the docker plugin configuration 

--- a/versioned_docs/version-2022.3/05_operations/10_release-notes/02_Version-2022.2.md
+++ b/versioned_docs/version-2022.3/05_operations/10_release-notes/02_Version-2022.2.md
@@ -36,7 +36,7 @@ Release date: July 08, 2022. Note that there is sub-release, [2022.2.1](../../..
 - **DSL**. The first release (version 0.0.1) of our proprietary DSL now enables you to define full-stack applications, unifying front-end and back-end development.
     This is designed to improve the speed and efficiency of development on the Genesis low-code platform. You can now:
 
-    - enable authentication more easily across your applications- more easily authorise access to grids, views or commands
+    - enable authentication more easily across your applications - more easily authorise access to grids, views or commands
     - create custom commands and advanced views (via custom cell renderers).
 
 Main details are:

--- a/versioned_docs/version-2022.3/05_operations/10_release-notes/02_Version-2022.2.md
+++ b/versioned_docs/version-2022.3/05_operations/10_release-notes/02_Version-2022.2.md
@@ -10,6 +10,12 @@ tags:
     - v-2022.2
 ---
 
+:::info NOTE
+
+This documentation version has been archived.
+
+:::
+
 ## Release notes
 This is version v2022.2 of the documentation for the Genesis low-code platform.
 
@@ -196,7 +202,7 @@ The basis of this version is:
 - New flex-layout component added for easy-to-use Flexbox layouts (there’s also an upcoming app-layout component with UI persistence features).
 - **IMPORTANT** select / combobox / multiselect now have their own datasource adapters, allowing quick and easy integration with back-end data (this is the same as in our grids, but for list elements!)
 - New error-boundary component, which enables improved error management for UI elements.
-- [Grid column persistence](../../../getting-started/go-to-the-next-level/data-grid/#saving-user-preferences) to restore a user’s column preferences between app reloads.
+- Grid column persistence to restore a user’s column preferences between app reloads.
 - **IMPORTANT** charts component wrapper for [@ant-design/charts](https://github.com/ant-design/ant-design-charts/) added, allowing the following types: Line, Area, Bar, Column, Pie, Dual Axes, Rose.
 - Added SSO login support for Symphony. WebSocket connection addresses now fully configurable (auto assignment of ws: or wss:, and allowing other extensions - default still /gwf/)
 - New CLI tasks to help end users analyse their component usage and switch design-system prefixes. These generate sample code for users to copy from the terminal to their projects.
@@ -205,15 +211,15 @@ The basis of this version is:
 - A number of (`foundation-header`, `foundation-reporting`) styling improvements to micro front-ends.
 - The `foundation-header` for micro front-ends is more configurable.
 - Created How-To and API documentation for several of our micro front-ends:
-    - [Header](../../../web/micro-front-ends/foundation-header)
-    - [Entity Management](../../../web/micro-front-ends/foundation-entity-management)
-    - [User Management](../../../web/micro-front-ends/foundation-user-management)
-    - [Profile Management](../../../web/micro-front-ends/foundation-profile-management)
-    - [Login](../../../web/micro-front-ends/foundation-login)
-    - [Reporting](../../../web/micro-front-ends/front-end-reporting)
+    - Header
+    - Entity Management
+    - User Management
+    - Profile Management
+    - Login
+    - Reporting
 - Added multiple parameter support for Testing Suite in foundation-testing
 - More code examples in our Showcase Client App, including selecting values and labels in our combobox programmatically.
-- Added [slotted-styles](https://docs.genesis.global/secure/getting-started/go-to-the-next-level/customize-look-and-feel/#styling-grid-pro) component to allow overriding component styles.
+- Added slotted-styles component to allow overriding component styles.
 
 ### Maintenance
 - Various CLI tweaks to support continuing DSL work.
@@ -258,7 +264,7 @@ ZeroMQ publishers and subscribers (and the ZeroMQ proxy implementation) now have
 
     - this.socket.recvStr();
     - final byte msgTrimmed = this.socket.recv();
-    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker);
+    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker));
     - ZeroMQForwarder.kt. This is used when proxying ZeroMQ updates via the GENESIS_CLUSTER implementation. Publishers will send messages to GENESIS_CLUSTER and GENESIS_CLUSTER will redistribute those to any other process subscribed to it.
 
 - Methods. We have added trace logging for the following methods:

--- a/versioned_docs/version-2022.3/05_operations/10_release-notes/03_Version-2022.1.md
+++ b/versioned_docs/version-2022.3/05_operations/10_release-notes/03_Version-2022.1.md
@@ -10,6 +10,12 @@ tags:
     - v-2022.1
 ---
 
+:::info NOTE
+
+This documentation version has been archived.
+
+:::
+
 This is version v2022.1 of the documentation for the Genesis low-code platform.
 
 The basis of this version is:
@@ -344,7 +350,7 @@ consolidator(TRADE, ORDER) {
 }
 ```
 
-In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. For further details, please see [here](https://docs.genesis.global/secure/creating-applications/defining-your-application/business-logic/consolidators/consolidators/).
+In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. 
 
 The main advantages over the previous consolidator syntax are:
 

--- a/versioned_docs/version-2022.4/05_operations/11_release-notes/01_Version-2022.4.md
+++ b/versioned_docs/version-2022.4/05_operations/11_release-notes/01_Version-2022.4.md
@@ -87,7 +87,7 @@ This is a high-level overview of the changes.
 ### Features
 * Added a `foundation-layout` package to provide application and route-based layout, similar to [Golden Layout](https://golden-layout.com/). Most APIs are in [@beta](https://api-extractor.com/pages/tsdoc/tag_beta/), but feel free to test these before full public release.
 * Added a `foundation-criteria` package to provide a type-safe criteria builder for generating queries.
-* Added a `foundation-filters` package to provide a collection of client-side filters that can be used in complex logic chains ([docs](../../../web/filters/foundation-filters/)).
+* Added a `foundation-filters` package to provide a collection of client-side filters that can be used in complex logic chains.
 * Added support for OpenID SSO in `foundation-login`.
 * Added bubble and scatter chart types.
 * Added drag-and-drop field ordering functionality to `foundation-reporting`.

--- a/versioned_docs/version-2022.4/05_operations/11_release-notes/02_Version-2022.3.md
+++ b/versioned_docs/version-2022.4/05_operations/11_release-notes/02_Version-2022.3.md
@@ -83,7 +83,7 @@ Features
 - we have added options for username and password to allow the use of authenticated MQTT brokers  
 - tls certificate verification can now be disabled for mqtt connection 
 - chore: FDB diagnostic utility scripts added
-- chore: status badge in [README.md](http://readme.md/) updated
+- chore: status badge in README.md updated
 - chore: oracle warning removed
 - chore: updating opencsv to 5.7.1 
 - chore: improvements to tidy up the docker plugin configuration 

--- a/versioned_docs/version-2022.4/05_operations/11_release-notes/03_Version-2022.2.md
+++ b/versioned_docs/version-2022.4/05_operations/11_release-notes/03_Version-2022.2.md
@@ -10,6 +10,12 @@ tags:
     - v-2022.2
 ---
 
+:::info NOTE
+
+This documentation version has been archived.
+
+:::
+
 ## Release notes
 This is version v2022.2 of the documentation for the Genesis low-code platform.
 
@@ -196,7 +202,7 @@ The basis of this version is:
 - New flex-layout component added for easy-to-use Flexbox layouts (there’s also an upcoming app-layout component with UI persistence features).
 - **IMPORTANT** select / combobox / multiselect now have their own datasource adapters, allowing quick and easy integration with back-end data (this is the same as in our grids, but for list elements!)
 - New error-boundary component, which enables improved error management for UI elements.
-- [Grid column persistence](../../../getting-started/go-to-the-next-level/data-grid/#saving-user-preferences) to restore a user’s column preferences between app reloads.
+- Grid column persistence to restore a user’s column preferences between app reloads.
 - **IMPORTANT** charts component wrapper for [@ant-design/charts](https://github.com/ant-design/ant-design-charts/) added, allowing the following types: Line, Area, Bar, Column, Pie, Dual Axes, Rose.
 - Added SSO login support for Symphony. WebSocket connection addresses now fully configurable (auto assignment of ws: or wss:, and allowing other extensions - default still /gwf/)
 - New CLI tasks to help end users analyse their component usage and switch design-system prefixes. These generate sample code for users to copy from the terminal to their projects.
@@ -205,15 +211,15 @@ The basis of this version is:
 - A number of (`foundation-header`, `foundation-reporting`) styling improvements to micro front-ends.
 - The `foundation-header` for micro front-ends is more configurable.
 - Created How-To and API documentation for several of our micro front-ends:
-    - [Header](../../../web/micro-front-ends/foundation-header)
-    - [Entity Management](../../../web/micro-front-ends/foundation-entity-management)
-    - [User Management](../../../web/micro-front-ends/foundation-entity-management#User-management)
-    - [Profile Management](../../../web/micro-front-ends/foundation-entity-management/#profile-management)
-    - [Login](../../../web/micro-front-ends/foundation-login)
-    - [Reporting](../../../web/micro-front-ends/front-end-reporting/foundation-reporting)
+    - Header
+    - Entity Management
+    - User Management
+    - Profile Management
+    - Login
+    - Reporting
 - Added multiple parameter support for Testing Suite in foundation-testing
 - More code examples in our Showcase Client App, including selecting values and labels in our combobox programmatically.
-- Added [slotted-styles](https://docs.genesis.global/secure/getting-started/go-to-the-next-level/customize-look-and-feel/#styling-grid-pro) component to allow overriding component styles.
+- Added slotted-styles component to allow overriding component styles.
 
 ### Maintenance
 - Various CLI tweaks to support continuing DSL work.
@@ -258,7 +264,7 @@ ZeroMQ publishers and subscribers (and the ZeroMQ proxy implementation) now have
 
     - this.socket.recvStr();
     - final byte msgTrimmed = this.socket.recv();
-    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker);
+    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker));
     - ZeroMQForwarder.kt. This is used when proxying ZeroMQ updates via the GENESIS_CLUSTER implementation. Publishers will send messages to GENESIS_CLUSTER and GENESIS_CLUSTER will redistribute those to any other process subscribed to it.
 
 - Methods. We have added trace logging for the following methods:

--- a/versioned_docs/version-2022.4/05_operations/11_release-notes/03_Version-2022.2.md
+++ b/versioned_docs/version-2022.4/05_operations/11_release-notes/03_Version-2022.2.md
@@ -36,7 +36,7 @@ Release date: July 08, 2022. Note that there is sub-release, [2022.2.1](../../..
 - **DSL**. The first release (version 0.0.1) of our proprietary DSL now enables you to define full-stack applications, unifying front-end and back-end development.
     This is designed to improve the speed and efficiency of development on the Genesis low-code platform. You can now:
 
-    - enable authentication more easily across your applications- more easily authorise access to grids, views or commands
+    - enable authentication more easily across your applications - more easily authorise access to grids, views or commands
     - create custom commands and advanced views (via custom cell renderers).
 
 Main details are:

--- a/versioned_docs/version-2022.4/05_operations/11_release-notes/04_Version-2022.1.md
+++ b/versioned_docs/version-2022.4/05_operations/11_release-notes/04_Version-2022.1.md
@@ -10,6 +10,12 @@ tags:
     - v-2022.1
 ---
 
+:::info NOTE
+
+This documentation version has been archived.
+
+:::
+
 This is version v2022.1 of the documentation for the Genesis low-code platform.
 
 The basis of this version is:
@@ -344,7 +350,7 @@ consolidator(TRADE, ORDER) {
 }
 ```
 
-In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. For further details, please see [here](https://docs.genesis.global/secure/creating-applications/defining-your-application/business-logic/consolidators/consolidators/).
+In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. 
 
 The main advantages over the previous consolidator syntax are:
 

--- a/versioned_docs/version-2023.1/05_operations/11_release-notes/01_Version-2023.1.md
+++ b/versioned_docs/version-2023.1/05_operations/11_release-notes/01_Version-2023.1.md
@@ -23,11 +23,11 @@ The basis of this version is:
 Release date: February 28, 2023. 
 
 ## Feature highlights
-* **Revamped pending approval workflow** - The pending approval workflow has been revamped to support GPAL configuration and other improvements. More information [here](../../../server/event-handler/advanced/#pending-approvals).
-* **Self-service password reset functionality** - The platform now supports self-service password reset capabilities. Please see this [page](../../../server/access-control/password-authentication/#selfservicereset) for more information.
-* **JSON Schema validation** - Event Handlers now validate each incoming message based on the implicit JSON schema definition. See more information in [schema validation](../../../server/event-handler/advanced/#disabling-schema-validation) and [inter-process messages](../../../server/inter-process-messages/metadata-annotations/).
+* **Revamped pending approval workflow** - The pending approval workflow has been revamped to support GPAL configuration and other improvements. 
+* **Self-service password reset functionality** - The platform now supports self-service password reset capabilities. 
+* **JSON Schema validation** - Event Handlers now validate each incoming message based on the implicit JSON schema definition.
 * **Case-insensitive user login** - The user name field is now case-insensitive when attempting login operations.
-* **Custom permissions support** - A new function called `customPermissions` is available within the `permissioning` block to improve integration with third-party entitlement systems. More information in this [page](../../../server/access-control/authorisation-overview/#custom-permissions-function).
+* **Custom permissions support** - A new function called `customPermissions` is available within the `permissioning` block to improve integration with third-party entitlement systems.
 * **OpenID Connect improvements** - It is now possible to set up a new logout workflow within Genesis that also logs out the user from the underlying SSO identity provider.
 
 ## Genesis Server Framework (GSF)
@@ -41,12 +41,12 @@ GSF and its modules are compiled using Kotlin 1.7.10 and Gradle 7.5.0.
 ## GSF
 
 ### Breaking changes
-- Make username available in scope within a permissioning 'where' clause (see [sample code](../../../server/access-control/authorisation/#where-clauses))
+- Make username available in scope within a permissioning 'where' clause.
 - MS SQL fields now use the appropriate "max length" parameter when the `maxSize` value goes beyond the MS SQL limit. 
 - The 'USER' table has been updated to include a unique index for the 'REFRESH_TOKEN' field.
 - The minimal safe TLS version is now set to 1.2.
-- The pending approval mechanism has had a [major revamp](../../../server/event-handler/advanced/#pending-approvals)).
-- JSON [schema validation](../../../server/event-handler/advanced/#disabling-schema-validation) and [inter-process messages](../../../server/inter-process-messages/metadata-annotations/) have been enabled for Event Handlers in GSF.
+- The pending approval mechanism has had a major revamp.
+- JSON schema validation and inter-process messages have been enabled for Event Handlers in GSF.
 
 ### Features
 
@@ -58,7 +58,7 @@ GSF and its modules are compiled using Kotlin 1.7.10 and Gradle 7.5.0.
 - We now allow running containers as non-root users.
 - There is now access to self-service password reset without logging in.
 - We have enabled case-insensitive support for username as part of the login workflow in GENESIS_ROUTER.
-- Auth map is now optional in permissioning GPAL (see this [example](../../../server/access-control/authorisation-overview/#auth-sub-block)).
+- Auth map is now optional in permissioning GPAL.
 - Mon process statuses now include a new HEALTHY state when a process has passed its health checks.
 - Auto-increment ids can be shared between more than one table definition to have their own sequence value.
 
@@ -101,7 +101,7 @@ GSF and its modules are compiled using Kotlin 1.7.10 and Gradle 7.5.0.
 
 ### Features
 
-- We have added "customLoginAck" block to auth-preferences, so we can [further customise the login ack message](../../../server/access-control/password-authentication/#customloginack).
+- We have added "customLoginAck" block to auth-preferences, so we can further customise the login ack message.
 - New fields have been added to ALL_APPROVAL_ALERTS and add new query for ALL_APPROVAL_ALERTS_AUDITS as part of the pending approval workflow revamp.
 - We have added allowedClockSkewSeconds property to the OIDC verification configuration.
 - There is now logout functionality for OIDC.
@@ -350,16 +350,16 @@ These are the complete changes.
 - Update breaking behavior in genesis-datasource-next 
 - (grid-pro): grid config cache regression 
 - Address missing default export breaking foundation-zero storybook build 
-- Smart forms correct schema payload  address 
+- Smart forms correct schema payload address 
 - Showcases/micro-front ends not running locally 
 - Allow to pass column config to file-upload-grid 
 - column config without overriding it by metadata 
-- (foundation-entity-management): lifecycle mixin for entitites.ts and users.ts 
+- (foundation-entity-management): lifecycle mixin for entities.ts and users.ts 
 - (foundation-testing): add insertRule mock 
 - (foundation-ui): adjusting storybook versions 
 - (foundation-login): ensure autoConnect is non-blocking 
 - (foundation-ui): label made optional and fixed grid filtering issue 
-- (foundation-ui): file upload url was missing /gwf prefix. 
+- (foundation-ui): file upload url was missing /gwf prefix
 - (foundation-login): add hostPath config 
 - (foundation-login): update README, logout to '/' 
 

--- a/versioned_docs/version-2023.1/05_operations/11_release-notes/02_Version-2022.4.md
+++ b/versioned_docs/version-2023.1/05_operations/11_release-notes/02_Version-2022.4.md
@@ -87,7 +87,7 @@ This is a high-level overview of the changes.
 ### Features
 * Added a `foundation-layout` package to provide application and route-based layout, similar to [Golden Layout](https://golden-layout.com/). Most APIs are in [@beta](https://api-extractor.com/pages/tsdoc/tag_beta/), but feel free to test these before full public release.
 * Added a `foundation-criteria` package to provide a type-safe criteria builder for generating queries.
-* Added a `foundation-filters` package to provide a collection of client-side filters that can be used in complex logic chains ([docs](../../../web/filters/foundation-filters/)).
+* Added a `foundation-filters` package to provide a collection of client-side filters that can be used in complex logic chains.
 * Added support for OpenID SSO in `foundation-login`.
 * Added bubble and scatter chart types.
 * Added drag-and-drop field ordering functionality to `foundation-reporting`.

--- a/versioned_docs/version-2023.1/05_operations/11_release-notes/03_Version-2022.3.md
+++ b/versioned_docs/version-2023.1/05_operations/11_release-notes/03_Version-2022.3.md
@@ -83,7 +83,7 @@ Features
 - we have added options for username and password to allow the use of authenticated MQTT brokers  
 - tls certificate verification can now be disabled for mqtt connection 
 - chore: FDB diagnostic utility scripts added
-- chore: status badge in [README.md](http://readme.md/) updated
+- chore: status badge in README.md updated
 - chore: oracle warning removed
 - chore: updating opencsv to 5.7.1 
 - chore: improvements to tidy up the docker plugin configuration 
@@ -120,7 +120,7 @@ The following fixes have been made
 - `remap`: fixed incorrect check for free space in FoundationDB 
 - `remap`: logger and stack trace issues fixed 
 - `remap`: fixed issues with table counter changes when renaming a table and/or removing/reading with the same name 
-- `remap`: fixed underflow errors when using `FDBIndexWriterHelper` on FDB2. 
+- `remap`: fixed underflow errors when using `FDBIndexWriterHelper` on FDB2 
 - `remap`: SQL column resizing added
 - `remap`: need for a separate module for compacted processes has been removed 
 - `remap` tests now use `DictionaryCreatedAliasStore` instead of `SqlAliasStore` 

--- a/versioned_docs/version-2023.1/05_operations/11_release-notes/04_Version-2022.2.md
+++ b/versioned_docs/version-2023.1/05_operations/11_release-notes/04_Version-2022.2.md
@@ -37,7 +37,7 @@ Release date: July 08, 2022. Note that there is sub-release, [2022.2.1](../../..
 - **DSL**. The first release (version 0.0.1) of our proprietary DSL now enables you to define full-stack applications, unifying front-end and back-end development.
     This is designed to improve the speed and efficiency of development on the Genesis low-code platform. You can now:
 
-    - enable authentication more easily across your applications- more easily authorise access to grids, views or commands
+    - enable authentication more easily across your applications - more easily authorise access to grids, views or commands
     - create custom commands and advanced views (via custom cell renderers).
 
 Main details are:

--- a/versioned_docs/version-2023.1/05_operations/11_release-notes/04_Version-2022.2.md
+++ b/versioned_docs/version-2023.1/05_operations/11_release-notes/04_Version-2022.2.md
@@ -10,6 +10,13 @@ tags:
     - v-2022.2
 ---
 
+
+:::info NOTE
+
+This documentation version has been archived.
+
+:::
+
 ## Release notes
 This is version v2022.2 of the documentation for the Genesis low-code platform.
 
@@ -196,7 +203,7 @@ The basis of this version is:
 - New flex-layout component added for easy-to-use Flexbox layouts (there’s also an upcoming app-layout component with UI persistence features).
 - **IMPORTANT** select / combobox / multiselect now have their own datasource adapters, allowing quick and easy integration with back-end data (this is the same as in our grids, but for list elements!)
 - New error-boundary component, which enables improved error management for UI elements.
-- [Grid column persistence](../../../getting-started/web-training/web-training-day4/) to restore a user’s column preferences between app reloads.
+- Grid column persistence to restore a user’s column preferences between app reloads.
 - **IMPORTANT** charts component wrapper for [@ant-design/charts](https://github.com/ant-design/ant-design-charts/) added, allowing the following types: Line, Area, Bar, Column, Pie, Dual Axes, Rose.
 - Added SSO login support for Symphony. WebSocket connection addresses now fully configurable (auto assignment of ws: or wss:, and allowing other extensions - default still /gwf/)
 - New CLI tasks to help end users analyse their component usage and switch design-system prefixes. These generate sample code for users to copy from the terminal to their projects.
@@ -205,15 +212,15 @@ The basis of this version is:
 - A number of (`foundation-header`, `foundation-reporting`) styling improvements to micro front-ends.
 - The `foundation-header` for micro front-ends is more configurable.
 - Created How-To and API documentation for several of our micro front-ends:
-    - [Header](../../../web/micro-front-ends/foundation-header)
-    - [Entity Management](../../../web/micro-front-ends/foundation-entity-management)
-    - [User Management](../../../web/micro-front-ends/foundation-entity-management#User-management)
-    - [Profile Management](../../../web/micro-front-ends/foundation-entity-management/#profile-management)
-    - [Login](../../../web/micro-front-ends/foundation-login)
-    - [Reporting](../../../web/micro-front-ends/front-end-reporting/foundation-reporting)
+    - Header
+    - Entity Management
+    - User Management
+    - Profile Management
+    - Login
+    - Reporting
 - Added multiple parameter support for Testing Suite in foundation-testing
 - More code examples in our Showcase Client App, including selecting values and labels in our combobox programmatically.
-- Added [slotted-styles](../../../getting-started/web-training/web-training-day4/) component to allow overriding component styles.
+- Added slotted-styles component to allow overriding component styles.
 
 ### Maintenance
 - Various CLI tweaks to support continuing DSL work.
@@ -258,7 +265,7 @@ ZeroMQ publishers and subscribers (and the ZeroMQ proxy implementation) now have
 
     - this.socket.recvStr();
     - final byte msgTrimmed = this.socket.recv();
-    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker);
+    - the unpacked message (final V message = handler.getUpdateQueueUnpacker().unpack(tlUnpacker));
     - ZeroMQForwarder.kt. This is used when proxying ZeroMQ updates via the GENESIS_CLUSTER implementation. Publishers will send messages to GENESIS_CLUSTER and GENESIS_CLUSTER will redistribute those to any other process subscribed to it.
 
 - Methods. We have added trace logging for the following methods:

--- a/versioned_docs/version-2023.1/05_operations/11_release-notes/05_Version-2022.1.md
+++ b/versioned_docs/version-2023.1/05_operations/11_release-notes/05_Version-2022.1.md
@@ -10,6 +10,13 @@ tags:
     - v-2022.1
 ---
 
+
+:::info NOTE
+
+This documentation version has been archived.
+
+:::
+
 This is version v2022.1 of the documentation for the Genesis low-code platform.
 
 The basis of this version is:
@@ -344,7 +351,7 @@ consolidator(TRADE, ORDER) {
 }
 ```
 
-In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. For further details, please see [here](../../03_server/07_consolidator/01_introduction.md).
+In the above example, we aggregate data from the TRADE table into the ORDER table. We group by orderId and we count the number of trades and sum the notional. 
 
 The main advantages over the previous consolidator syntax are:
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-764

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
yes

Have you checked all new or changed links?
yes

Is there anything else you would like us to know?
there is not

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

