### PR TITLE
fix: resolving static assets + links to dsc PTL-787

### DIFF
--- a/docs/04_web/03_design-systems/03_preview.mdx
+++ b/docs/04_web/03_design-systems/03_preview.mdx
@@ -17,13 +17,28 @@ On the left-hand side, is the [Editor](../../../web/design-systems/preview/#edit
 
 Try changing the configurations and observe the reflected changes on the right.
 
-![](/img/DSC-checkbox.PNG)
+<div class="demo-view">
+  <img
+    id="shadowed-img"
+    src={require("@site/static/img/DSC-checkbox.PNG").default}
+    alt="Image capture of DSC app"
+  />
+  <div>
+    <a class="overlay-link" href="/dsc/" target="_blank">
+      Launch DSC &#x2197;
+    </a>
+  </div>
+</div>
 
 ## Editor
 
 The **Preserve selected options...** checkbox in the editor is ticked by default.
 
-<img id="shadowed-img" src="/img/preserve-checkbox.PNG" alt="Image capture of checkbox"/>
+<img
+  id="shadowed-img"
+  src={require("@site/static/img/preserve-checkbox.PNG").default}
+  alt="Image capture of checkbox"
+/>
 
 This means that when you switch between design systems, all of your selections are retained.
 For instance, if you change the **Accent Color** while on the **Zero** design system, and then switch to **Foundation-UI**, you will see the changes you made there as well.
@@ -32,11 +47,11 @@ Alternatively, if it's unticked, switching between design systems will not retai
 Instead, they will be reset to design system defaults.
 
 :::note
-Note that in the documentation, the DSC (Design System Configurator), is in *preview* mode rather than *application* mode. There are minor but significant differences between them.
+Note that in the documentation, the DSC (Design System Configurator), is in _preview_ mode rather than _application_ mode. There are minor but significant differences between them.
 :::
 
 :::important
-The **Design System** is an important configuration. Depending on which one you choose, you will get a different look. While in *preview* mode, you will see **Zero** and **Foundation UI** in the dropdown list of **Design System**. But in *application* mode, you will see one more design system.
+The **Design System** is an important configuration. Depending on which one you choose, you will get a different look. While in _preview_ mode, you will see **Zero** and **Foundation UI** in the dropdown list of **Design System**. But in _application_ mode, you will see one more design system.
 :::
 
 For example, if you have launched DSC from an application called **client-app**, you will also see **Client App** in the dropdown list.
@@ -92,4 +107,4 @@ The **Colors** tab, as you may suspect, shows the design tokens available for se
 
 ### Form
 
-The **Form** tab displays a `Smart Form`. This is another component available for us to use. It utilizes a collection of other components like `text-field`, `combobox` and `checkbox`. Design tokens like **Density** and **Design Unit** will trigger more visible changes in the *preview*. Go to the **Form** tab and configure the design tokens in the editor to see the results.
+The **Form** tab displays a `Smart Form`. This is another component available for us to use. It utilizes a collection of other components like `text-field`, `combobox` and `checkbox`. Design tokens like **Density** and **Design Unit** will trigger more visible changes in the _preview_. Go to the **Form** tab and configure the design tokens in the editor to see the results.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "build": "npm run copy:dsc && docusaurus build",
-    "build:next": "SHOW_NEXT=true docusaurus build",
-    "build:base_url": "BASE_URL=/docs/ docusaurus build",
-    "build:production": "BASE_URL=/docs/ BRANCH=master docusaurus build",
+    "build:next": "SHOW_NEXT=true npm run copy:dsc && docusaurus build",
+    "build:base_url": "BASE_URL=/docs/npm run copy:dsc && docusaurus build",
+    "build:production": "BASE_URL=/docs/ BRANCH=master npm run copy:dsc && docusaurus build",
     "clear": "docusaurus clear",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",

--- a/versioned_docs/version-2022.3/04_web/03_design-systems/03_preview.mdx
+++ b/versioned_docs/version-2022.3/04_web/03_design-systems/03_preview.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Design systems - preview'
-sidebar_label: 'Preview'
+title: "Design Systems - Preview"
+sidebar_label: "Preview"
 id: preview
 keywords: [web, design system, preview]
 tags:
@@ -17,4 +17,15 @@ On the left-hand side, is the [Editor](../../../web/design-systems/preview/#edit
 
 Try changing the configurations and observe the reflected changes on the right.
 
-![](/img/DSC-checkbox.PNG)
+<div class="demo-view">
+  <img
+    id="shadowed-img"
+    src={require("@site/static/img/DSC-checkbox.PNG").default}
+    alt="Image capture of DSC app"
+  />
+  <div>
+    <a class="overlay-link" href="/dsc/" target="_blank">
+      Launch DSC &#x2197;
+    </a>
+  </div>
+</div>

--- a/versioned_docs/version-2022.4/04_web/03_design-systems/03_preview.mdx
+++ b/versioned_docs/version-2022.4/04_web/03_design-systems/03_preview.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Design systems - preview'
-sidebar_label: 'Preview'
+title: "Design systems - preview"
+sidebar_label: "Preview"
 id: preview
 keywords: [web, design system, preview]
 tags:
@@ -18,10 +18,14 @@ On the left-hand side, is the [Editor](../../../web/design-systems/preview/#edit
 Try changing the configurations and observe the reflected changes on the right.
 
 <div class="demo-view">
-  <img id="shadowed-img" src="/img/DSC-checkbox.PNG" alt="Image capture of DSC app"/>
+  <img
+    id="shadowed-img"
+    src={require("@site/static/img/DSC-checkbox.PNG").default}
+    alt="Image capture of DSC app"
+  />
   <div>
-    <a class="overlay-link" href="/dsc/" target="_blank">Launch DSC &#x2197;</a>
+    <a class="overlay-link" href="/dsc/" target="_blank">
+      Launch DSC &#x2197;
+    </a>
   </div>
 </div>
-
-<!-- ![](/img/DSC-checkbox.PNG) -->

--- a/versioned_docs/version-2023.1/04_web/03_design-systems/03_preview.mdx
+++ b/versioned_docs/version-2023.1/04_web/03_design-systems/03_preview.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Design Systems - Preview'
-sidebar_label: 'Preview'
+title: "Design systems - preview"
+sidebar_label: "Preview"
 id: preview
 keywords: [web, design system, preview]
 tags:
@@ -17,4 +17,15 @@ On the left-hand side, is the [Editor](../../../web/design-systems/preview/#edit
 
 Try changing the configurations and observe the reflected changes on the right.
 
-![](/img/DSC-checkbox.PNG)
+<div class="demo-view">
+  <img
+    id="shadowed-img"
+    src={require("@site/static/img/DSC-checkbox.PNG").default}
+    alt="Image capture of DSC app"
+  />
+  <div>
+    <a class="overlay-link" href="/dsc/" target="_blank">
+      Launch DSC &#x2197;
+    </a>
+  </div>
+</div>


### PR DESCRIPTION
PTL-787

- Used `require` to resolve static image paths properly (when using `img` tags directly instead of `![]()`).
- Added preview image + link to dsc for all versions of the design system preview.
- Changed the relevant pages to `.mdx` since we're using JSX and not just markdown.
- Added copy:dsc to the rest of the build scripts (won't affect prod, just for local testing).

The reset of the changes are just due to auto-formatting.