### PR TITLE
PTL-788 Improve the naming on ranged queries when where clause is used

### DIFF
--- a/docs/02_database/05_database-interface/03_rxdb.md
+++ b/docs/02_database/05_database-interface/03_rxdb.md
@@ -295,7 +295,7 @@ Flowable<DbRecord> tradeByIDIDAndPrice = rxDb.getBulkFromEnd("TRADE", "TRADE_BY_
 Whereas a `get` operation selects a single entry from a unique index, and a `getBulk` operation selects the whole table, `getRange` selects a range within an index. 
 
 By providing different parameters, you can refine what information you are returned:
-* `startRecord` is needed in all cases, and defines where the range should start from.
+* `startRecord` is needed in all cases, and defines where the range should start from, if `endRecord` is provided, else acts as where clause to get similar records. 
 * `endRecord` is an optional end record for where the range should end.
 * `index` is also needed in all cases, it is the String name of the Index upon which the range spans.
 * `numKeyFields` is the number of key fields to take into account for the range.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-788

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes -->

Have you checked all new or changed links?
<!--- Yes  -->

Is there anything else you would like us to know?
<!---  No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

