### PR TITLE
feat: document LSOF_AVAILABLE property in Cluster and IntelliJ plugin docs (PLAT-868)

### DIFF
--- a/docs/03_server/11_tooling/02_intellij-plugin.md
+++ b/docs/03_server/11_tooling/02_intellij-plugin.md
@@ -159,6 +159,13 @@ The log file view defaults to show only warnings. You can change the level from 
 Currently, the plugin does not pick up `<loggingLevel>` entries in `processes.xml` files.
 To set the log level for a process, use the [LogLevel script](/operations/commands/server-commands/#loglevel-script).
 
+### Chronicle files
+
+:::tip
+On Windows, set `LSOF_AVAILABLE` to `false` in order
+for the Chronicle queue files to be properly cleaned up.
+:::
+
 ### Debug
 
 It’s possible to debug ‘normal’ code using the **debug** option from the generated run configurations.

--- a/docs/05_operations/03_clustering/02_genesis.md
+++ b/docs/05_operations/03_clustering/02_genesis.md
@@ -42,6 +42,8 @@ systems {
         item(name = "location", value = "LO")
         item(name = "LogFramework", value = "LOG4J2")
         item(name = "LogFrameworkConfig", value = "log4j2-default.xml")
+        // defaults to true, false only for Windows
+        item(name = "LSOF_AVAILABLE", value = "false")
     }
 }
 ```

--- a/versioned_docs/version-2022.3/05_operations/03_clustering/01_clusters.md
+++ b/versioned_docs/version-2022.3/05_operations/03_clustering/01_clusters.md
@@ -41,6 +41,8 @@ systems {
         item(name = "location", value = "LO")
         item(name = "LogFramework", value = "LOG4J2")
         item(name = "LogFrameworkConfig", value = "log4j2-default.xml")
+        // defaults to true, false only for Windows
+        item(name = "LSOF_AVAILABLE", value = "false")
     }
 }
 ```

--- a/versioned_docs/version-2022.4/05_operations/03_clustering/02_genesis.md
+++ b/versioned_docs/version-2022.4/05_operations/03_clustering/02_genesis.md
@@ -41,6 +41,8 @@ systems {
         item(name = "location", value = "LO")
         item(name = "LogFramework", value = "LOG4J2")
         item(name = "LogFrameworkConfig", value = "log4j2-default.xml")
+        // defaults to true, false only for Windows
+        item(name = "LSOF_AVAILABLE", value = "false")
     }
 }
 ```

--- a/versioned_docs/version-2023.1/03_server/11_tooling/02_intellij-plugin.md
+++ b/versioned_docs/version-2023.1/03_server/11_tooling/02_intellij-plugin.md
@@ -159,6 +159,13 @@ The log file view defaults to show only warnings. You can change the level from 
 Currently, the plugin will not pick up `<loggingLevel>` entries in **processes.xml** files.
 To set the log level for a process, use the [LogLevel script](/operations/commands/server-commands/#loglevel-script)
 
+### Chronicle files
+
+:::tip
+On Windows, set `LSOF_AVAILABLE` to `false` in order
+for the Chronicle queue files to be properly cleaned up.
+:::
+
 ### Debug
 
 It’s possible to debug ‘normal’ code using the **debug** option from the generated run configurations.
@@ -218,7 +225,7 @@ The preferred way of running a script is via the IntelliJ terminal window; any s
 
 ![Running a script](/img/plugin-terminal-3.png)
 
-Once a scri[t has been run, the passed arguments will be saved in the run config for the script until new arguments are passed.
+Once a script has been run, the passed arguments will be saved in the run config for the script until new arguments are passed.
 To run a script with the same arguments, just re-run the run config.
 
 Alternatively, open the folder **Scripts**, find the one you want to run, right-click on it and select **Run**.

--- a/versioned_docs/version-2023.1/05_operations/03_clustering/02_genesis.md
+++ b/versioned_docs/version-2023.1/05_operations/03_clustering/02_genesis.md
@@ -41,6 +41,8 @@ systems {
         item(name = "location", value = "LO")
         item(name = "LogFramework", value = "LOG4J2")
         item(name = "LogFrameworkConfig", value = "log4j2-default.xml")
+        // defaults to true, false only for Windows
+        item(name = "LSOF_AVAILABLE", value = "false")
     }
 }
 ```


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
[PLAT-868](https://genesisglobal.atlassian.net/browse/PLAT-868)

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Yes

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

