### PR TITLE
PTL-795: Updating quickstart with latest genx commands & fix dev training

### DIFF
--- a/docs/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/docs/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -27,31 +27,7 @@ import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 
-At this point, the seed application is created and the `genx` dependencies are installed.
-
-Then there are more questions, which you can respond to as follows (we have provided some notes below):
-
-```shell title="Terminal"
-? Package scope (without the @) genesislcap
-? Package name alpha
-? Create design system Yes
-? Design system name alpha
-? Base design system package (@latest will be used) @genesislcap/foundation-ui
-? Set API Host (Y/n) Yes
-? API Host (with websocket prefix and suffix if any) (ws://localhost/gwf/)
-? Group Id global.genesis
-? Application Version 1.0.0-SNAPSHOT
-```
-:::note
-Here's a quick note about those questions:
-- package scope is the namespace identifier for your app
-- package name is the identifier for the app itself
-- a design system and a base design system package are necessary for the front end 
-- the API host is the address that the front end will connect to
-- Group ID is another identifier (sorry about all these)
-:::
-
-At this point, the application will be configured. On completion, you will see the following text:
+At this point, the seed application is created and the `genx` dependencies are installed. On completion, you will see the following text:
 
 ```shell title="Terminal"
 ✔ Project successfully created. Next steps:                                                   

--- a/docs/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/docs/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -42,16 +42,16 @@ Make sure you added the TRADE_STATUS field to the TRADE table in the **alpha-tab
 
 ```kotlin {4}
 tables {
-    table (name = "TRADE", id = 2000) {
-        ...
-        TRADE_STATUS
-
-        primaryKey {
-            TRADE_ID
-        }
-
-    }
+  table (name = "TRADE", id = 2000) {
     ...
+    TRADE_STATUS
+
+    primaryKey {
+      TRADE_ID
+    }
+
+  }
+  ...
 }
 ```
 
@@ -132,7 +132,7 @@ sealed class TradeEffect {
 }
 ```
 
-### 3. Add the module as a dependency in the **build.gradle.kts** inside **alpha-script-config** module.
+### 3. Add the module as a dependency in the *build.gradle.kts* inside **alpha-script-config** module.
 
 ```
 ...
@@ -142,9 +142,9 @@ api(project(":alpha-eventhandler"))
 
 ### 4. Edit the event handler to add an integrated state machine
 
-Let's edit the event handler to add an integrated state machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created.
+Let's edit the event handler to add an integrated state machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created. 
 
-```kotlin {1-9,11}
+```kotlin {1-9,12}
 import java.io.File
 import java.time.LocalDate
 import global.genesis.TradeStateMachine
@@ -168,7 +168,7 @@ eventHandler {
 Then, integrate the state machine in the TRADE_INSERT event *onCommit*.
 
 ```kotlin {2,5}
-eventHandler<Trade>(name = "TRADE_INSERT") {
+eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
     onCommit { event ->
         val trade = event.details
         trade.enteredBy = event.userName
@@ -245,7 +245,7 @@ Remove the TRADE_DELETE Event Handler if you included it before.
 
 You want to manage the state of the trade, so remove the delete Event Handler. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
 
-To test it, you can try to modify a TRADE and see the states changing accordingly.
+To test it, you can try to modify a TRADE and see the states changing accordingly. 
 
 ### Exercise 4.1: state machines
 :::info ESTIMATED TIME
@@ -260,47 +260,47 @@ Open the **home.ts** file and add the TRADE_STATUS field in the const *COLUMNS*.
 ...
 //grid columns that will be showed
 const COLUMNS = [
-    {
-        ...defaultColumnConfig,
-        field: 'TRADE_ID',
-        headerName: 'Id',
-    },
-    {
-        ...defaultColumnConfig,
-        field: 'QUANTITY',
-        headerName: 'Quantity',
-    },
-    {
-        ...defaultColumnConfig,
-        field: 'PRICE',
-        headerName: 'Price',
-    },
-    {
-        ...defaultColumnConfig,
-        field: 'SYMBOL',
-        headerName: 'Symbol',
-    },
-    {
-        ...defaultColumnConfig,
-        field: 'DIRECTION',
-        headerName: 'Direction',
-    },
-    {
-        ...defaultColumnConfig,
-        field: 'TRADE_STATUS',
-        headerName: 'Status',
-    },
+  {
+    ...defaultColumnConfig,
+    field: 'TRADE_ID',
+    headerName: 'Id',
+  },
+  {
+    ...defaultColumnConfig,
+    field: 'QUANTITY',
+    headerName: 'Quantity',
+  },
+  {
+    ...defaultColumnConfig,
+    field: 'PRICE',
+    headerName: 'Price',
+  },
+  {
+    ...defaultColumnConfig,
+    field: 'SYMBOL',
+    headerName: 'Symbol',
+  },
+  {
+    ...defaultColumnConfig,
+    field: 'DIRECTION',
+    headerName: 'Direction',
+  },
+  {
+    ...defaultColumnConfig,
+    field: 'TRADE_STATUS',
+    headerName: 'Status',
+  },  
 ];
 
 @customElement({
-        name,
-        template,
-        styles,
+  name,
+  template,
+  styles,
 })
 export class Home extends FASTElement {
     ...
     constructor() {
-        super();
+      super();
     }
 }
 
@@ -311,22 +311,22 @@ And add the *deleteEvent* as to the **home.template.ts** file.
 ```html {10}
 ...
 export const HomeTemplate = html<Home>`
-    <div class="split-layout">
-        <div class="top-layout">
-            <entity-management
-                    resourceName="ALL_TRADES"
-                    title = "Trades"
-                    entityLabel="Trades"
-                    createEvent = "EVENT_TRADE_INSERT"
-                    deleteEvent = "EVENT_TRADE_CANCELLED"
-                    :columns=${x => x.columns}
-            :createFormUiSchema=${() => tradeFormCreateSchema}
-            :updateFormUiSchema=${() => tradeFormUpdateSchema}
-            ></entity-management>
-            ...
-        </div>
+<div class="split-layout">
+    <div class="top-layout">
+        <entity-management
+          resourceName="ALL_TRADES"
+          title = "Trades"
+          entityLabel="Trades"
+          createEvent = "EVENT_TRADE_INSERT"
+          deleteEvent = "EVENT_TRADE_CANCELLED"
+          :columns=${x => x.columns}
+          :createFormUiSchema=${() => tradeFormCreateSchema}
+          :updateFormUiSchema=${() => tradeFormUpdateSchema}
+        ></entity-management>
+    ...
     </div>
-    `;
+</div>
+`;
 ```
 :::
 
@@ -343,12 +343,12 @@ We are going to change the code in the Event Handler so that:
 
 ### Add the validation code
 
-Go to the **alpha-eventhandler.kts** file for the Event Handler.
+Go to the **alpha-eventhandler.kts** file for the Event Handler. 
 
 Add the verification by inserting an **verify** inside the **onValidate** block, before the **onCommit** block in TRADE_INSERT. We can see this below, with separate lines checking the Counterparty ID and the Instrument ID exist in the database. The new block ends by sending an **ack()**.
 
 ```kotlin {2-9}
-eventHandler<Trade>(name = "TRADE_INSERT") {
+eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
     onValidate { event ->
         val message = event.details
         verify {
@@ -377,7 +377,7 @@ The `verify` block you see above is part of the validation helper provided by th
 Add the same verification `onValidate` as in TRADE_INSERT to the TRADE_MODIFY event handler.
 
 
-Implement and test the back end with Console or Postman. To do that, see the [Day 2 example](../../../getting-started/developer-training/training-content-day2/#api-testing-with-auto-generated-rest-endpoints). Basically, you should create a POST request using the URL *http://localhost:9064/EVENT_TRADE_MODIFY*, as well as setting the header accordingly (header with SOURCE_REF and SESSION_AUTH_TOKEN).
+Implement and test the back end with Console or Postman. To do that, see the [Day 2 example](../../../getting-started/developer-training/training-content-day2/#api-testing-with-auto-generated-rest-endpoints). Basically, you should create a POST request using the URL *http://localhost:9064/EVENT_TRADE_MODIFY*, as well as setting the header accordingly (header with SOURCE_REF and SESSION_AUTH_TOKEN). 
 
 ## Auditing​
 
@@ -394,7 +394,7 @@ The first step to add basic auditing is to change the relevant table dictionary.
 ```kotlin {1}
 table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
     sequence(TRADE_ID, "TR")
-    COUNTERPARTY_ID
+    COUNTERPARTY_ID 
     INSTRUMENT_ID not null
     QUANTITY
     PRICE not null
@@ -420,30 +420,30 @@ Next you need to extend the insert, and modify methods in the **TradeStateMachin
 
 ```kotlin {2,5,10,12,20,23}
     suspend fun insert(
-    transaction: AsyncMultiEntityReadWriteGenericSupport,
-    trade: Trade,
-): Transition<Trade, TradeStatus, TradeEffect> =
-    internalState.withTransaction(transaction) {
-        create(trade)
-    }
-
-suspend fun modify(
-    transaction: AsyncMultiEntityReadWriteGenericSupport,
-    tradeId: String, modify: suspend (Trade) -> Unit
-): Transition<Trade, TradeStatus, TradeEffect>? =
-    internalState.withTransaction(transaction) {
-        update(Trade.ById(tradeId)) {
-                trade, _ -> modify(trade)
+        transaction: AsyncMultiEntityReadWriteGenericSupport,
+        trade: Trade,
+    ): Transition<Trade, TradeStatus, TradeEffect> =
+        internalState.withTransaction(transaction) {
+            create(trade)
         }
-    }
 
-suspend fun modify(
-    transaction: AsyncMultiEntityReadWriteGenericSupport,
-    trade: Trade
-): Transition<Trade, TradeStatus, TradeEffect>? =
-    internalState.withTransaction(transaction) {
-        update(trade)
-    }
+    suspend fun modify(
+        transaction: AsyncMultiEntityReadWriteGenericSupport,
+        tradeId: String, modify: suspend (Trade) -> Unit
+    ): Transition<Trade, TradeStatus, TradeEffect>? =
+        internalState.withTransaction(transaction) {
+            update(Trade.ById(tradeId)) {
+                    trade, _ -> modify(trade)
+            }
+        }
+
+    suspend fun modify(
+        transaction: AsyncMultiEntityReadWriteGenericSupport,
+        trade: Trade
+    ): Transition<Trade, TradeStatus, TradeEffect>? =
+        internalState.withTransaction(transaction) {
+            update(trade)
+        }
 ```
 
 #### Update the Event Handlers to use auditing
@@ -451,46 +451,46 @@ suspend fun modify(
 Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the state machine, as the **syncMultiEntityReadWriteGenericSupport** parameter. This should resemble the example below:
 
 ```kotlin {12,19,26,35}
-    eventHandler<Trade>(name = "TRADE_INSERT") {
-    onValidate { event ->
-        val message = event.details
-        verify {
-            entityDb hasEntry Counterparty.ById(message.counterpartyId)
-            entityDb hasEntry Instrument.ById(message.instrumentId)
+    eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
+        onValidate { event ->
+            val message = event.details
+            verify {
+                entityDb hasEntry Counterparty.ById(message.counterpartyId)
+                entityDb hasEntry Instrument.ById(message.instrumentId)
+            }
+            ack()
         }
-        ack()
-    }
-    onCommit { event ->
-        val trade = event.details
-        stateMachine.insert(entityDb, trade)
-        ack()
-    }
-}
-eventHandler<Trade>(name = "TRADE_MODIFY") {
-    onCommit { event ->
-        val trade = event.details
-        stateMachine.modify(entityDb, trade)
-        ack()
-    }
-}
-eventHandler<TradeCancelled>(name = "TRADE_CANCELLED") {
-    onCommit { event ->
-        val message = event.details
-        stateMachine.modify(entityDb, message.tradeId) { trade ->
-            trade.tradeStatus = TradeStatus.CANCELLED
+        onCommit { event ->
+            val trade = event.details
+            stateMachine.insert(entityDb, trade)
+            ack()
         }
-        ack()
     }
-}
-eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED") {
-    onCommit { event ->
-        val message = event.details
-        stateMachine.modify(entityDb, message.tradeId) { trade ->
-            trade.tradeStatus = TradeStatus.ALLOCATED
+    eventHandler<Trade>(name = "TRADE_MODIFY", transactional = true) {
+        onCommit { event ->
+            val trade = event.details
+            stateMachine.modify(entityDb, trade)
+            ack()
         }
-        ack()
     }
-}
+    eventHandler<TradeCancelled>(name = "TRADE_CANCELLED", transactional = true) {
+        onCommit { event ->
+            val message = event.details
+            stateMachine.modify(entityDb, message.tradeId) { trade ->
+                trade.tradeStatus = TradeStatus.CANCELLED
+            }
+            ack()
+        }
+    }
+    eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED", transactional = true) {
+        onCommit { event ->
+            val message = event.details
+            stateMachine.modify(entityDb, message.tradeId) { trade ->
+                trade.tradeStatus = TradeStatus.ALLOCATED
+            }
+            ack()
+        }
+    }
 ```
 
 Run the [generatedao](../../../getting-started/developer-training/training-content-day1/#generatedao), [build and deploy](../../../getting-started/developer-training/training-content-day1/#5-the-build-and-deploy-process).

--- a/docs/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/docs/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -38,7 +38,7 @@ Once we have added add a new field to the data model, we will edit the Event Han
 
 ### 1. Data model
 
-Make sure you added the TRADE_STATUS field to the TRADE table in the **alpha-tables-dictionary.kts** file.
+Make sure you have added the TRADE_STATUS field to the TRADE table in the **alpha-tables-dictionary.kts** file.
 
 ```kotlin {4}
 tables {
@@ -59,7 +59,7 @@ If the TRADE_STATUS is missing, run [generatefields](../../../getting-started/de
 
 ### 2. Create a new class for the State Machine
 
-Add a main folder in the Event Handler module **alpha-eventhandler** and create a state machine class called *TradeStateMachine* inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
+Add a main folder in the Event Handler module **alpha-eventhandler** and create a state machine class called `TradeStateMachine` inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
 
 Add a state machine definition and assign a field in the `onCommit` block,
 
@@ -141,7 +141,7 @@ api(project(":alpha-eventhandler"))
 ...
 ```
 
-### 4. Edit the Event Handler to add an integrated State Machine
+### 4. Add an integrated State Machine to the Event Handler
 
 Let's edit the Event Handler to add an integrated State Machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created. 
 
@@ -179,7 +179,7 @@ eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
 }
 ```
 
-Create two data classes that will be used in the cancel and allocated eventhandler codeblocks. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**.
+Create two data classes that will be used in the cancel and allocated eventHandler codeblocks. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**.
 
 * TradeAllocated
 * TradeCancelled
@@ -242,7 +242,7 @@ eventHandler<Trade>(name = "TRADE_MODIFY", transactional = true) {
 }
 ```
 
-Remove the TRADE_DELETE eventHandler code block if you included it before. You only want to manage the state of the trade. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
+Remove the TRADE_DELETE eventHandler codeblock if you included it before. You only want to manage the state of the trade. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
 
 To test it, you can try to modify a TRADE and see the states changing accordingly. 
 
@@ -373,7 +373,7 @@ The `verify` block you see above is part of the validation helper provided by th
 :::info ESTIMATED TIME
 20 mins
 :::
-Add the same verification `onValidate` as in TRADE_INSERT to the TRADE_MODIFY event handler.
+Add the same verification `onValidate` as in TRADE_INSERT to the TRADE_MODIFY eventHandler codeblock.
 
 
 Implement and test the back end with Console or Postman. To do that, see the [Day 2 example](../../../getting-started/developer-training/training-content-day2/#api-testing-with-auto-generated-rest-endpoints). Basically, you should create a POST request using the URL *http://localhost:9064/EVENT_TRADE_MODIFY*, as well as setting the header accordingly (header with SOURCE_REF and SESSION_AUTH_TOKEN). 
@@ -411,11 +411,11 @@ table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
 
 The id parameter indicates the id of the newly created audit table, and must be different from any other table id.
 
-As we are using the GPAL Event Handlers, this is sufficient to enable auditing on this table. A new table is created with the name of the original table, and the **_AUDIT** suffix added. In this instance, that would be the **TRADE_AUDIT** table.
+As we are using GPAL Event Handlers, this is sufficient to enable auditing on this table. A new table is created with the name of the original table, and the **_AUDIT** suffix added. In this instance, that would be the **TRADE_AUDIT** table.
 
 #### Updating the State Machine to use auditing
 
-Next you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must have a second option so that the method signature uses the **AsyncMultiEntityReadWriteGenericSupport** parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
+Next you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must have a second option so that the method signature uses the `AsyncMultiEntityReadWriteGenericSupport` parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
 
 ```kotlin {2,5,10,12,20,23}
     suspend fun insert(
@@ -447,7 +447,7 @@ Next you need to extend the insert, and modify methods in the **TradeStateMachin
 
 #### Update the Event Handlers to use auditing
 
-Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the State Machine, as the **syncMultiEntityReadWriteGenericSupport** parameter. This should resemble the example below:
+Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the State Machine, as the `syncMultiEntityReadWriteGenericSupport` parameter. This should resemble the example below:
 
 ```kotlin {12,19,26,35}
     eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
@@ -501,6 +501,6 @@ Run the [generatedao](../../../getting-started/developer-training/training-conte
 Try to insert or modify a TRADE and see the auditing happening accordingly. You can use DbMon or Genesis Console to check the data in table TRADE_AUDIT.
 
 :::info END OF DAY 4
-This is the end of the day 4 of our training. To help your training journey, check out how your application should look at the end of day 4 [here](https://github.com/genesiscommunitysuccess/devtraining-seed/tree/Exercise_4.3).
+This is the end of day 4 of our training. To help your training journey, check out how your application should look at the end of day 4 [here](https://github.com/genesiscommunitysuccess/devtraining-seed/tree/Exercise_4.3).
 :::
 

--- a/docs/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/docs/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -34,7 +34,7 @@ State Machines enable you to control workflow by defining the transitions from s
 
 ![](/img/diagram-of-states.png)
 
-Once we have added add a new field to the data model, we will edit the event handler file to add controlled transitions from one state to another.
+Once we have added add a new field to the data model, we will edit the Event Handler file to add controlled transitions from one state to another.
 
 ### 1. Data model
 
@@ -57,11 +57,11 @@ tables {
 
 If the TRADE_STATUS is missing, run [generatefields](../../../getting-started/developer-training/training-content-day1/#generatefields) to generate the fields, AND​ [generatedao](../../../getting-started/developer-training/training-content-day1/#generatedao) to create the DAOs.
 
-### 2. Create a new class for the state machine
+### 2. Create a new class for the State Machine
 
-Add a main folder in the event handler module *alpha-eventhandler* and create a state machine class called *TradeStateMachine* inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
+Add a main folder in the Event Handler module **alpha-eventhandler** and create a state machine class called *TradeStateMachine* inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
 
-Add a state machine definition and assign a field in the **onCommit** block,
+Add a state machine definition and assign a field in the `onCommit` block,
 
 ```kotlin
 package global.genesis
@@ -132,7 +132,8 @@ sealed class TradeEffect {
 }
 ```
 
-### 3. Add the module as a dependency in the **build.gradle.kts** inside **alpha-script-config** module.
+### 3. Add the module as a dependency in **build.gradle.kts**
+Add the module as a dependency in the **build.gradle.kts** inside **alpha-script-config** module.
 
 ```
 ...
@@ -140,9 +141,9 @@ api(project(":alpha-eventhandler"))
 ...
 ```
 
-### 4. Edit the event handler to add an integrated state machine
+### 4. Edit the Event Handler to add an integrated State Machine
 
-Let's edit the event handler to add an integrated state machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created. 
+Let's edit the Event Handler to add an integrated State Machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created. 
 
 ```kotlin {1-9,12}
 import java.io.File
@@ -165,7 +166,7 @@ eventHandler {
 }
 ```
 
-Then, integrate the state machine in the TRADE_INSERT event *onCommit*.
+Then, integrate the State Machine in the TRADE_INSERT event `onCommit`.
 
 ```kotlin {2,5}
 eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
@@ -178,7 +179,7 @@ eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
 }
 ```
 
-Create two data classes that will be used in the cancel and allocated Event Handlers. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**
+Create two data classes that will be used in the cancel and allocated eventhandler codeblocks. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**.
 
 * TradeAllocated
 * TradeCancelled
@@ -201,7 +202,7 @@ package global.genesis.alpha.message.event
 data class TradeCancelled(val tradeId: String)
 ```
 
-Create a new event handler called TRADE_CANCELLED to handle cancellations. Then integrate the state machine in it.
+Create a new eventHandler codeblock called TRADE_CANCELLED to handle cancellations. Then integrate the State Machine in it.
 
 ```kotlin
 eventHandler<TradeCancelled>(name = "TRADE_CANCELLED", transactional = true) {
@@ -215,7 +216,7 @@ eventHandler<TradeCancelled>(name = "TRADE_CANCELLED", transactional = true) {
 }
 ```
 
-Create a new event handler called TRADE_ALLOCATED to handle completion. Integrate the state machine in it.
+Create a new eventHandler codeblock called TRADE_ALLOCATED to handle completion. Integrate the State Machine in it.
 
 ```kotlin
 eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED", transactional = true) {
@@ -229,7 +230,7 @@ eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED", transactional = true) {
 }
 ```
 
-Modify or add the TRADE_MODIFY Event Handler to use the state machine.
+Modify or add the TRADE_MODIFY eventHandler codeblock to use the State Machine.
 
 ```kotlin {4}
 eventHandler<Trade>(name = "TRADE_MODIFY", transactional = true) {
@@ -241,17 +242,15 @@ eventHandler<Trade>(name = "TRADE_MODIFY", transactional = true) {
 }
 ```
 
-Remove the TRADE_DELETE Event Handler if you included it before.
-
-You want to manage the state of the trade, so remove the delete Event Handler. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
+Remove the TRADE_DELETE eventHandler code block if you included it before. You only want to manage the state of the trade. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
 
 To test it, you can try to modify a TRADE and see the states changing accordingly. 
 
-### Exercise 4.1: state machines
+### Exercise 4.1: State Machines
 :::info ESTIMATED TIME
 40 mins
 :::
-Modify the class TradeStateMachine to keep the `trade.price`. Removing the current rule when TradeStatus.NEW, and set the field trade.enteredBy to empty when TradeStatus.CANCELLED.
+Modify the class TradeStateMachine to keep the `trade.price`. Remove the current rule when TradeStatus.NEW, and set the field trade.enteredBy to empty when TradeStatus.CANCELLED.
 
 :::info UI CHANGES
 Open the **home.ts** file and add the TRADE_STATUS field in the const *COLUMNS*.
@@ -306,7 +305,7 @@ export class Home extends FASTElement {
 
 ```
 
-And add the *deleteEvent* as to the **home.template.ts** file.
+And add the `deleteEvent` to the **home.template.ts** file.
 
 ```html {10}
 ...
@@ -345,7 +344,7 @@ We are going to change the code in the Event Handler so that:
 
 Go to the **alpha-eventhandler.kts** file for the Event Handler. 
 
-Add the verification by inserting an **verify** inside the **onValidate** block, before the **onCommit** block in TRADE_INSERT. We can see this below, with separate lines checking the Counterparty ID and the Instrument ID exist in the database. The new block ends by sending an **ack()**.
+Add the verification by inserting a `verify` inside the `onValidate` block, before the `onCommit` block in TRADE_INSERT. We can see this below, with separate lines checking that the Counterparty ID and the Instrument ID exist in the database. The new block ends by sending an **ack()**.
 
 ```kotlin {2-9}
 eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
@@ -367,10 +366,10 @@ eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
 ```
 
 :::info verify function
-The `verify` block you see above is part of the validation helper provided by the Platform to make it easier to verify conditions against the database. Outside of the `verify` block, you can write any Kotlin code to validate whatever you want to.
+The `verify` block you see above is part of the validation helper provided by the Platform to make it easier to verify conditions against the database. Outside the `verify` block, you can write any Kotlin code to validate whatever you want to.
 :::
 
-### Exercise 4.2: adding onValidate to event handlers
+### Exercise 4.2: adding onValidate to Event Handlers
 :::info ESTIMATED TIME
 20 mins
 :::
@@ -383,13 +382,13 @@ Implement and test the back end with Console or Postman. To do that, see the [Da
 
 We want to be able to track the changes made to the various trades on the TRADE table, such that we could see the times and modifications made in the history of the trade. So, we are going to add basic auditing to the TRADE table in order to keep a record of the changing states of the trades.
 
-This can be useful for historical purposes, if you need to at a later date be able to produce an accurate course of events.
+This can be useful for historical purposes, if you need to be able to produce an accurate course of events at a later date.
 
 ### Adding basic auditing
 
-#### Adding audit to table dictionary
+#### Adding audit to the table dictionary
 
-The first step to add basic auditing is to change the relevant table dictionary. In this instance, we will be making changes to the **alpha-tables-dictionary.kts**, in order to add the parameter `audit = details()` to the table definition. It should resemble the following:
+For basic auditing, the first step is to change the relevant table dictionary. In this instance, we will make changes to the **alpha-tables-dictionary.kts**, in order to add the parameter `audit = details()` to the table definition. It should resemble the following:
 
 ```kotlin {1}
 table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
@@ -410,13 +409,13 @@ table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
 }
 ```
 
-The id parameter indicates the id of the newly created audit table, and will need to be different from any other table id.
+The id parameter indicates the id of the newly created audit table, and must be different from any other table id.
 
-As we are using the GPAL event handlers, this is sufficient to enable auditing on this table. A new table is created by the name of the original table, with the **_AUDIT** suffix added to the end. In this instance that would be the **TRADE_AUDIT** table.
+As we are using the GPAL Event Handlers, this is sufficient to enable auditing on this table. A new table is created with the name of the original table, and the **_AUDIT** suffix added. In this instance, that would be the **TRADE_AUDIT** table.
 
-#### Updating the state machine to use auditing
+#### Updating the State Machine to use auditing
 
-Next you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must be have a second option so that the method signature uses the **AsyncMultiEntityReadWriteGenericSupport** parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
+Next you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must have a second option so that the method signature uses the **AsyncMultiEntityReadWriteGenericSupport** parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
 
 ```kotlin {2,5,10,12,20,23}
     suspend fun insert(
@@ -448,7 +447,7 @@ Next you need to extend the insert, and modify methods in the **TradeStateMachin
 
 #### Update the Event Handlers to use auditing
 
-Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the state machine, as the **syncMultiEntityReadWriteGenericSupport** parameter. This should resemble the example below:
+Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the State Machine, as the **syncMultiEntityReadWriteGenericSupport** parameter. This should resemble the example below:
 
 ```kotlin {12,19,26,35}
     eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {

--- a/docs/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/docs/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -132,7 +132,7 @@ sealed class TradeEffect {
 }
 ```
 
-### 3. Add the module as a dependency in the *build.gradle.kts* inside **alpha-script-config** module.
+### 3. Add the module as a dependency in the **build.gradle.kts** inside **alpha-script-config** module.
 
 ```
 ...

--- a/docs/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/docs/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -24,9 +24,9 @@ This day covers:
 - [Adding logic to the event handler](#adding-logic-to-the-event-handler)
 - [Auditing​](#auditing)
 
-## State management​
+## State Management​
 
-State machines enable you to control workflow by defining the transitions from state to state. This example enables you to build a very simple state machine so that you can add new trades. You will create a new field called TRADE_STATUS, which can have three possible states: NEW, ALLOCATED, CANCELLED.
+State Machines enable you to control workflow by defining the transitions from state to state. This example enables you to build a very simple state machine so that you can add new trades. You will create a new field called TRADE_STATUS, which can have three possible states: NEW, ALLOCATED, CANCELLED.
 
 * NEW can go to ALLOCATED or CANCELLED.
 * ALLOCATED and CANCELLED can’t go anywhere else.

--- a/versioned_docs/version-2022.3/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2022.3/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -9,81 +9,43 @@ tags:
     - new project
 ---
 
-The GenX CLI tool enables you to seed projects. In this case we want to generate a blank full-stack application project.
+:::info
+Before you start, make sure you have checked out the [hardware and software requirements](../../../getting-started/quick-start/hardware-and-software/). 
+
+Download and install all the relevant requirements.
+:::
 
 ## Starting
 
-Launch it from the terminal:
+We start our quick journey using the CLI provided by Genesis. From the terminal, run:
 
 ```shell title="Terminal"
-npx @genesislcap/genx@latest
+npx -y @genesislcap/genx@latest init alpha -x
+```
+<!-- NO EDIT (NEXT 4 LINES) -->
+import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
+
+<InsecureFlag />
+
+At this point, the seed application is created and the `genx` dependencies are installed. On completion, you will see the following text:
+
+```shell title="Terminal"
+✔ Project successfully created. Next steps:                                                   
+ › Install dependencies with npm run bootstrap
+ › Start development server with npm run dev
+```
+## Opening IntelliJ
+Now open your application in Intellij. Start by opening [IntelliJ IDEA](https://www.jetbrains.com/idea/). In the alpha project, you will see the **readme** file for the project. After importing and indexing, your gradle tab (normally on the right of your window) should contain 3 folders: **alpha**, **client**, **genesisproduct-alpha**.
+
+## Gradle.properties (server/jvm)
+There is a **gradle.properties** file in the **server/jvm** folder. Check that it has the following highlighted properties, and update it if necessary:
+
+```kotlin {2,3} title="server/jvm/gradle.properties"
+                ...
+genesisArtifactoryPath=https://genesisglobal.jfrog.io/genesisglobal/libs-release-client
+enableGenesisIntellijHelperTasks=true
 ```
 
-In the `genx` script, there is a series of questions.
-
-First, you are asked to provide your username and password - these are the credentials you use to access Genesis Artifactory.
-
-```shell title="Windows Terminal"
-? Genesis Username example.username
-? Genesis Password **************
-√ Logged into Genesis
-```
-Then you are asked to select from a short list of seed applications. Select `create application`:
-
-```shell title="Windows Terminal"
-? Please select an option: (Use arrow keys)
-  create workspace - Generates a local workspace to use for your Genesis based apps.
-  configure workspace - Configure a local workspace.
-> create application - Generates a local application.
-  configure application - Configure a local app.
-```
-Now you can proceed using the following responses:
-
-```shell title="Windows Terminal"
-? Create a app in current directory Yes
-? App name alpha
-```
-
-Then you are asked to select the App Seed. Select `Quick Start Application` from the list. Do **not** select the Positions Application.
-You will be asked if you want to overwrite existing files. Select **Y**.
-
-  ```shell title="Windows Terminal"
-App seed (Use arrow keys)
-> **Quick Start Application**
-  Positions Application
-  Hello World Application
-  Foundation-Store Based Application
-  Foundation App Seed
-  Local Application Seed
-  Overwrite existing files (y/N)
-  ```
-
-At this point, the seed application is created and the genx dependencies are installed.
-
-Then there are more questions, which you can respond to as follows (we have provided some notes below):
-
-```shell title="Windows Terminal"
-? Package scope (without the @) genesislcap
-? Package name alpha
-? Create design system Yes
-? Design system name alpha
-? Base design system package (@latest will be used) @genesislcap/foundation-ui
-? Set API Host (Y/n) Yes
-? API Host (with websocket prefix and suffix if any) (ws://localhost/gwf/)
-? Group Id global.genesis
-? Application Version 1.0.0-SNAPSHOT
-```
 :::note
-Here's a quick note about those questions:
-- package scope is the namespace identifier for your app
-- package name is the identifier for the app itself
-- a design system and a base design system package are necessary for the front end 
-- the API host is the address that the front end will connect to
-- Group ID is another identifier (sorry about all these)
+If you had to modify this file, make sure you `reload all gradle projects`.
 :::
-
-At this point, the application will be configured. Assuming it is successful, you will see the following text:
-
-```shell title="Windows Terminal"
-i Application created successfully! 🎉 Please open the application and follow the README to complete setup.
-```

--- a/versioned_docs/version-2022.3/_includes/_cli-insecure-flag.md
+++ b/versioned_docs/version-2022.3/_includes/_cli-insecure-flag.md
@@ -1,0 +1,8 @@
+:::caution Local issuer certificate errors
+
+These may be caused by running GenX CLI in a proxy network that uses self-signed or missing certificates.
+`--insecure` flag can be used to skip SSL certificate verification:
+
+`npx @genesislcap/genx@latest --insecure`
+
+:::

--- a/versioned_docs/version-2022.4/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2022.4/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -10,93 +10,42 @@ tags:
 ---
 
 :::info
-Before you start, make sure you have checked out the [hardware and software requirements](/getting-started/quick-start/hardware-and-software/). 
+Before you start, make sure you have checked out the [hardware and software requirements](../../../getting-started/quick-start/hardware-and-software/). 
 
 Download and install all the relevant requirements.
 :::
 
-## The genx script
-`genx` is a CLI tool that enables you to seed projects. In this case, we shall generate a full-stack application project; the key files will be empty so that you can define the details of the application.
-
-We also have step-by-step instructions on [how to install and use genx](../../../getting-started/prerequisites/genx/).
-
 ## Starting
 
-Once configured and installed, from the Windows terminal, run:
+We start our quick journey using the CLI provided by Genesis. From the terminal, run:
 
-```shell title="Windows Terminal"
-genx
+```shell title="Terminal"
+npx -y @genesislcap/genx@latest init alpha -x
 ```
-
-:::tip
-
-If this does not work, use the command `npx genx`.
-
-:::
-
 <!-- NO EDIT (NEXT 4 LINES) -->
 import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 
-In the `genx` script, there is a series of questions.
+At this point, the seed application is created and the `genx` dependencies are installed. On completion, you will see the following text:
 
-First, you are asked to select from a short list of seed applications. Select `create application`:
-
-```shell title="Windows Terminal"
-? Please select an option: (Use arrow keys)
-  create workspace - Generates a local workspace to use for your Genesis based apps.
-  configure workspace - Configure a local workspace.
-> create application - Generates a local application.
-  configure application - Configure a local app.
+```shell title="Terminal"
+✔ Project successfully created. Next steps:                                                   
+ › Install dependencies with npm run bootstrap
+ › Start development server with npm run dev
 ```
-Now you can proceed using the following responses:
+## Opening IntelliJ
+Now open your application in Intellij. Start by opening [IntelliJ IDEA](https://www.jetbrains.com/idea/). In the alpha project, you will see the **readme** file for the project. After importing and indexing, your gradle tab (normally on the right of your window) should contain 3 folders: **alpha**, **client**, **genesisproduct-alpha**.
 
-```shell title="Windows Terminal"
-? Create a app in current directory Yes
-? App name alpha
+## Gradle.properties (server/jvm)
+There is a **gradle.properties** file in the **server/jvm** folder. Check that it has the following highlighted properties, and update it if necessary:
+
+```kotlin {2,3} title="server/jvm/gradle.properties"
+                ...
+genesisArtifactoryPath=https://genesisglobal.jfrog.io/genesisglobal/libs-release-client
+enableGenesisIntellijHelperTasks=true
 ```
 
-Then you are asked to select the App Seed. Select `Quick Start Application` from the list. Do **not** select the Positions Application.
-You will be asked if you want to overwrite existing files. Select **Y**.
-
-  ```shell title="Windows Terminal"
-App seed (Use arrow keys)
-> **Quick Start Application**
-  Positions Application
-  Hello World Application
-  Foundation-Store Based Application
-  Foundation App Seed
-  Local Application Seed
-  Overwrite existing files (y/N)
-  ```
-
-At this point, the seed application is created and the `genx` dependencies are installed.
-
-Then there are more questions, which you can respond to as follows (we have provided some notes below):
-
-```shell title="Windows Terminal"
-? Package scope (without the @) genesislcap
-? Package name alpha
-? Create design system Yes
-? Design system name alpha
-? Base design system package (@latest will be used) @genesislcap/foundation-ui
-? Set API Host (Y/n) Yes
-? API Host (with websocket prefix and suffix if any) (ws://localhost/gwf/)
-? Group Id global.genesis
-? Application Version 1.0.0-SNAPSHOT
-```
 :::note
-Here's a quick note about those questions:
-- package scope is the namespace identifier for your app
-- package name is the identifier for the app itself
-- a design system and a base design system package are necessary for the front end 
-- the API host is the address that the front end will connect to
-- Group ID is another identifier (sorry about all these)
+If you had to modify this file, make sure you `reload all gradle projects`.
 :::
-
-At this point, the application will be configured. On completion, you will see the following text:
-
-```shell title="Windows Terminal"
-i Application created successfully! 🎉 Please open the application and follow the README to complete setup.
-```

--- a/versioned_docs/version-2023.1/01_getting-started/02_quick-start/02_create-a-new-project.md
+++ b/versioned_docs/version-2023.1/01_getting-started/02_quick-start/02_create-a-new-project.md
@@ -27,31 +27,7 @@ import InsecureFlag from '../../_includes/_cli-insecure-flag.md'
 
 <InsecureFlag />
 
-At this point, the seed application is created and the `genx` dependencies are installed.
-
-Then there are more questions, which you can respond to as follows (we have provided some notes below):
-
-```shell title="Terminal"
-? Package scope (without the @) genesislcap
-? Package name alpha
-? Create design system Yes
-? Design system name alpha
-? Base design system package (@latest will be used) @genesislcap/foundation-ui
-? Set API Host (Y/n) Yes
-? API Host (with websocket prefix and suffix if any) (ws://localhost/gwf/)
-? Group Id global.genesis
-? Application Version 1.0.0-SNAPSHOT
-```
-:::note
-Here's a quick note about those questions:
-- package scope is the namespace identifier for your app
-- package name is the identifier for the app itself
-- a design system and a base design system package are necessary for the front end 
-- the API host is the address that the front end will connect to
-- Group ID is another identifier (sorry about all these)
-:::
-
-At this point, the application will be configured. On completion, you will see the following text:
+At this point, the seed application is created and the `genx` dependencies are installed. On completion, you will see the following text:
 
 ```shell title="Terminal"
 ✔ Project successfully created. Next steps:                                                   

--- a/versioned_docs/version-2023.1/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/versioned_docs/version-2023.1/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -26,7 +26,7 @@ This day covers:
 
 ## State management​
 
-State machines enable you to control workflow by defining the transitions from state to state. This example enables you to build a very simple state machine so that you can add new trades. You will create a new field called TRADE_STATUS, which can have three possible states: NEW, ALLOCATED, CANCELLED.
+State Machines enable you to control workflow by defining the transitions from state to state. This example enables you to build a very simple State Machine so that you can add new trades. You will create a new field called TRADE_STATUS, which can have three possible states: NEW, ALLOCATED, CANCELLED.
 
 * NEW can go to ALLOCATED or CANCELLED.
 * ALLOCATED and CANCELLED can’t go anywhere else.
@@ -34,7 +34,7 @@ State machines enable you to control workflow by defining the transitions from s
 
 ![](/img/diagram-of-states.png)
 
-Once we have added add a new field to the data model, we will edit the event handler file to add controlled transitions from one state to another.
+Once we have added add a new field to the data model, we will edit the Event Handler file to add controlled transitions from one state to another.
 
 ### 1. Data model
 
@@ -57,11 +57,11 @@ tables {
 
 If the TRADE_STATUS is missing, run [generatefields](../../../getting-started/developer-training/training-content-day1/#generatefields) to generate the fields, AND​ [generatedao](../../../getting-started/developer-training/training-content-day1/#generatedao) to create the DAOs.
 
-### 2. Create a new class for the state machine
+### 2. Create a new class for the State Machine
 
-Add a main folder in the event handler module *alpha-eventhandler* and create a state machine class called *TradeStateMachine* inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
+Add a main folder in the Event Handler module *alpha-eventhandler* and create a State Machine class called *TradeStateMachine* inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
 
-Add a state machine definition and assign a field in the **onCommit** block,
+Add a State Machine definition and assign a field in the **onCommit** block:
 
 ```kotlin
 package global.genesis
@@ -132,17 +132,17 @@ sealed class TradeEffect {
 }
 ```
 
-### 3. Add the module as a dependency in the *build.gradle.kts* inside **alpha-script-config** module.
-
+### 3. Add the module as a dependency
+Add the module as a dependency in the **build.gradle.kts** file in the **alpha-script-config** module.
 ```
 ...
 api(project(":alpha-eventhandler"))
 ...
 ```
 
-### 4. Edit the event handler to add an integrated state machine
+### 4. Add an integrated State Machine to the Event Handler
 
-Let's edit the event handler to add an integrated state machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created. 
+Let's edit the Event Handler to add an integrated State Machine. First, in the **alpha-eventhandler.kts** file, add the imports below and declare a variable to be visible to all events by injecting the class `TradeStateMachine`, which we have just created. 
 
 ```kotlin {1-9,12}
 import java.io.File
@@ -165,7 +165,7 @@ eventHandler {
 }
 ```
 
-Then, integrate the state machine in the TRADE_INSERT event *onCommit*.
+Then, integrate the State Machine in the TRADE_INSERT event *onCommit*.
 
 ```kotlin {2,5}
 eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
@@ -178,7 +178,7 @@ eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
 }
 ```
 
-Create two data classes that will be used in the cancel and allocated Event Handlers. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**
+Create two data classes that will be used in the cancel and allocated `eventHandler` blocks. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**.
 
 * TradeAllocated
 * TradeCancelled
@@ -215,7 +215,7 @@ eventHandler<TradeCancelled>(name = "TRADE_CANCELLED", transactional = true) {
 }
 ```
 
-Create a new event handler called TRADE_ALLOCATED to handle completion. Integrate the state machine in it.
+Create a new `eventHandler` block called TRADE_ALLOCATED to handle completion. Integrate the State Machine in it.
 
 ```kotlin
 eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED", transactional = true) {
@@ -229,7 +229,7 @@ eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED", transactional = true) {
 }
 ```
 
-Modify or add the TRADE_MODIFY Event Handler to use the state machine.
+Modify or add the TRADE_MODIFY `eventHandler` block to use the State Machine.
 
 ```kotlin {4}
 eventHandler<Trade>(name = "TRADE_MODIFY", transactional = true) {
@@ -241,17 +241,15 @@ eventHandler<Trade>(name = "TRADE_MODIFY", transactional = true) {
 }
 ```
 
-Remove the TRADE_DELETE Event Handler if you included it before.
-
-You want to manage the state of the trade, so remove the delete Event Handler. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
+Remove the TRADE_DELETE `eventHandler` block if you included it before. You only want to manage the state of the trade. If a trade is incorrect and needs to be deleted, similar functionality can be achieved by cancelling the trade.
 
 To test it, you can try to modify a TRADE and see the states changing accordingly. 
 
-### Exercise 4.1: state machines
+### Exercise 4.1: State Machines
 :::info ESTIMATED TIME
 40 mins
 :::
-Modify the class TradeStateMachine to keep the `trade.price`. Removing the current rule when TradeStatus.NEW, and set the field trade.enteredBy to empty when TradeStatus.CANCELLED.
+Modify the class TradeStateMachine to keep the `trade.price`. Remove the current rule when TradeStatus.NEW, and set the field trade.enteredBy to empty when TradeStatus.CANCELLED.
 
 :::info UI CHANGES
 Open the **home.ts** file and add the TRADE_STATUS field in the const *COLUMNS*.
@@ -306,7 +304,7 @@ export class Home extends FASTElement {
 
 ```
 
-And add the *deleteEvent* as to the **home.template.ts** file.
+And add the *deleteEvent* to the **home.template.ts** file.
 
 ```html {10}
 ...
@@ -345,7 +343,7 @@ We are going to change the code in the Event Handler so that:
 
 Go to the **alpha-eventhandler.kts** file for the Event Handler. 
 
-Add the verification by inserting an **verify** inside the **onValidate** block, before the **onCommit** block in TRADE_INSERT. We can see this below, with separate lines checking the Counterparty ID and the Instrument ID exist in the database. The new block ends by sending an **ack()**.
+Add the verification by inserting a **verify** inside the **onValidate** block, before the **onCommit** block in TRADE_INSERT. We can see this below, with separate lines checking that the Counterparty ID and the Instrument ID exist in the database. The new block ends by sending an **ack()**.
 
 ```kotlin {2-9}
 eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
@@ -367,14 +365,14 @@ eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
 ```
 
 :::info verify function
-The `verify` block you see above is part of the validation helper provided by the Platform to make it easier to verify conditions against the database. Outside of the `verify` block, you can write any Kotlin code to validate whatever you want to.
+The `verify` block you see above is part of the validation helper provided by the Platform to make it easier to verify conditions against the database. Outside the `verify` block, you can write any Kotlin code to validate whatever you want to.
 :::
 
-### Exercise 4.2: adding onValidate to event handlers
+### Exercise 4.2: adding onValidate to eventHandler blocks
 :::info ESTIMATED TIME
 20 mins
 :::
-Add the same verification `onValidate` as in TRADE_INSERT to the TRADE_MODIFY event handler.
+Add the same verification `onValidate` as in TRADE_INSERT to the TRADE_MODIFY eventHandler block.
 
 
 Implement and test the back end with Console or Postman. To do that, see the [Day 2 example](../../../getting-started/developer-training/training-content-day2/#api-testing-with-auto-generated-rest-endpoints). Basically, you should create a POST request using the URL *http://localhost:9064/EVENT_TRADE_MODIFY*, as well as setting the header accordingly (header with SOURCE_REF and SESSION_AUTH_TOKEN). 
@@ -383,13 +381,13 @@ Implement and test the back end with Console or Postman. To do that, see the [Da
 
 We want to be able to track the changes made to the various trades on the TRADE table, such that we could see the times and modifications made in the history of the trade. So, we are going to add basic auditing to the TRADE table in order to keep a record of the changing states of the trades.
 
-This can be useful for historical purposes, if you need to at a later date be able to produce an accurate course of events.
+This can be useful for historical purposes, if you need to be able to produce an accurate course of events at a later date.
 
 ### Adding basic auditing
 
-#### Adding audit to table dictionary
+#### Adding audit to the table dictionary
 
-The first step to add basic auditing is to change the relevant table dictionary. In this instance, we will be making changes to the **alpha-tables-dictionary.kts**, in order to add the parameter `audit = details()` to the table definition. It should resemble the following:
+For basic auditing, the first step is to change the relevant table dictionary. In this instance, we shall make changes to the **alpha-tables-dictionary.kts**, in order to add the parameter `audit = details()` to the table definition. It should resemble the following:
 
 ```kotlin {1}
 table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
@@ -410,13 +408,13 @@ table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
 }
 ```
 
-The id parameter indicates the id of the newly created audit table, and will need to be different from any other table id.
+The id parameter indicates the id of the newly created audit table, and must be different from any other table id.
 
-As we are using the GPAL event handlers, this is sufficient to enable auditing on this table. A new table is created by the name of the original table, with the **_AUDIT** suffix added to the end. In this instance that would be the **TRADE_AUDIT** table.
+As we are using the GPAL Event Handlers, this is sufficient to enable auditing on this table. A new table is created by the name of the original table, with the **_AUDIT** suffix added to the end. In this instance that would be the **TRADE_AUDIT** table.
 
-#### Updating the state machine to use auditing
+#### Updating the State Machine to use auditing
 
-Next you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must be have a second option so that the method signature uses the **AsyncMultiEntityReadWriteGenericSupport** parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
+Next, you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must have a second option so that the method signature uses the **AsyncMultiEntityReadWriteGenericSupport** parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
 
 ```kotlin {2,5,10,12,20,23}
     suspend fun insert(

--- a/versioned_docs/version-2023.1/01_getting-started/06_developer-training/04_training-content-day4.md
+++ b/versioned_docs/version-2023.1/01_getting-started/06_developer-training/04_training-content-day4.md
@@ -38,7 +38,7 @@ Once we have added add a new field to the data model, we will edit the Event Han
 
 ### 1. Data model
 
-Make sure you added the TRADE_STATUS field to the TRADE table in the **alpha-tables-dictionary.kts** file.
+Make sure you have added the TRADE_STATUS field to the TRADE table in the **alpha-tables-dictionary.kts** file.
 
 ```kotlin {4}
 tables {
@@ -59,9 +59,9 @@ If the TRADE_STATUS is missing, run [generatefields](../../../getting-started/de
 
 ### 2. Create a new class for the State Machine
 
-Add a main folder in the Event Handler module *alpha-eventhandler* and create a State Machine class called *TradeStateMachine* inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
+Add a main folder in the Event Handler module **alpha-eventhandler** and create a State Machine class called `TradeStateMachine` inside **alpha-eventhandler/src/main/kotlin/global/genesis**.
 
-Add a State Machine definition and assign a field in the **onCommit** block:
+Add a State Machine definition and assign a field in the `onCommit` block:
 
 ```kotlin
 package global.genesis
@@ -178,7 +178,7 @@ eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
 }
 ```
 
-Create two data classes that will be used in the cancel and allocated `eventHandler` blocks. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**.
+Create two data classes that will be used in the cancel and allocated `eventHandler` codeblocks. These classes should be in **alpha-messages/src/main/kotlin/global/genesis/alpha/message/event**.
 
 * TradeAllocated
 * TradeCancelled
@@ -215,7 +215,7 @@ eventHandler<TradeCancelled>(name = "TRADE_CANCELLED", transactional = true) {
 }
 ```
 
-Create a new `eventHandler` block called TRADE_ALLOCATED to handle completion. Integrate the State Machine in it.
+Create a new `eventHandler` codeblock called TRADE_ALLOCATED to handle completion. Integrate the State Machine in it.
 
 ```kotlin
 eventHandler<TradeAllocated>(name = "TRADE_ALLOCATED", transactional = true) {
@@ -304,7 +304,8 @@ export class Home extends FASTElement {
 
 ```
 
-And add the *deleteEvent* to the **home.template.ts** file.
+```html {10}
+And add the `deleteEvent` to the **home.template.ts** file.
 
 ```html {10}
 ...
@@ -410,11 +411,11 @@ table (name = "TRADE", id = 2000, audit = details(id = 2100, sequence = "TR")) {
 
 The id parameter indicates the id of the newly created audit table, and must be different from any other table id.
 
-As we are using the GPAL Event Handlers, this is sufficient to enable auditing on this table. A new table is created by the name of the original table, with the **_AUDIT** suffix added to the end. In this instance that would be the **TRADE_AUDIT** table.
+As we are using GPAL Event Handlers, this is sufficient to enable auditing on this table. A new table is created by the name of the original table, with the **_AUDIT** suffix added to the end. In this instance that would be the **TRADE_AUDIT** table.
 
 #### Updating the State Machine to use auditing
 
-Next, you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must have a second option so that the method signature uses the **AsyncMultiEntityReadWriteGenericSupport** parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
+Next, you need to extend the insert, and modify methods in the **TradeStateMachine.kt** file. Specifically, each method must have a second option so that the method signature uses the `AsyncMultiEntityReadWriteGenericSupport` parameter and the `internalState.withTransaction(transaction) { }` code block.  For example:
 
 ```kotlin {2,5,10,12,20,23}
     suspend fun insert(
@@ -446,7 +447,7 @@ Next, you need to extend the insert, and modify methods in the **TradeStateMachi
 
 #### Update the Event Handlers to use auditing
 
-Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the state machine, as the **syncMultiEntityReadWriteGenericSupport** parameter. This should resemble the example below:
+Now you must update the **alpha-eventhandler.kts** in order to pass the `entityDb` object into the updated methods of the State Machine, as the `syncMultiEntityReadWriteGenericSupport` parameter. This should resemble the example below:
 
 ```kotlin {12,19,26,35}
     eventHandler<Trade>(name = "TRADE_INSERT", transactional = true) {
@@ -500,6 +501,6 @@ Run the [generatedao](../../../getting-started/developer-training/training-conte
 Try to insert or modify a TRADE and see the auditing happening accordingly. You can use DbMon or Genesis Console to check the data in table TRADE_AUDIT.
 
 :::info END OF DAY 4
-This is the end of the day 4 of our training. To help your training journey, check out how your application should look at the end of day 4 [here](https://github.com/genesiscommunitysuccess/devtraining-seed/tree/Exercise_4.3).
+This is the end of day 4 of our training. To help your training journey, check out how your application should look at the end of day 4 [here](https://github.com/genesiscommunitysuccess/devtraining-seed/tree/Exercise_4.3).
 :::
 

--- a/versioned_docs/version-2023.1/_includes/_cli-insecure-flag.md
+++ b/versioned_docs/version-2023.1/_includes/_cli-insecure-flag.md
@@ -3,6 +3,6 @@
 These may be caused by running GenX CLI in a proxy network that uses self-signed or missing certificates.
 `--insecure` flag can be used to skip SSL certificate verification:
 
-`npx @genesislcap/genx@latest --insecure`
+`npx -y @genesislcap/genx@latest init alpha -x --insecure`
 
 :::


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-795

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs and 2023.4

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

