### PR TITLE
Improve site-specific for overriding scripts

### DIFF
--- a/docs/03_server/01_configuring-runtime/09_site-specific.md
+++ b/docs/03_server/01_configuring-runtime/09_site-specific.md
@@ -54,12 +54,14 @@ systemDefinition {
 }```
 
 ## Overriding scripts
-Any script file that you put in your site-specific folder will override a file of the same name in your application's main (non-site-specific) folders.
+
+If you want to override any scripts in your application such as **{app-name}-dataserver.kts**, **{app-name}-eventhandler.kts**, etc, you need to go to **site-specific/main/src/main/resources/scripts** folder and create the new script file with the same name as the script you want to override.
+
+To see the changes, you need to deploy your application, and if you are using intellij plugin, you shall see these files under your **.genesis-home/site-specific**
 
 This is essential where you use standard modules, such as Auth; you should never change these modules. 
 
 :::danger
 Never change the standard modules, such as Auth. You can copy their script files to **site-specific** and change them there.
 :::
-
 

--- a/versioned_docs/version-2023.1/03_server/01_configuring-runtime/09_site-specific.md
+++ b/versioned_docs/version-2023.1/03_server/01_configuring-runtime/09_site-specific.md
@@ -55,7 +55,10 @@ systemDefinition {
 ```
 
 ## Overriding scripts
-Any script file that you put in your site-specific folder will override a file of the same name in your application's main (non-site-specific) folders.
+
+If you want to override any scripts in your application such as **{app-name}-dataserver.kts**, **{app-name}-eventhandler.kts**, etc, you need to go to **site-specific/main/src/main/resources/scripts** folder and create the new script file with the same name as the script you want to override.
+
+To see the changes, you need to deploy your application, and if you are using intellij plugin, you shall see these files under your **.genesis-home/site-specific**
 
 This is essential where you use standard modules, such as Auth; you should never change these modules. 
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-835

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
2023.1 and docs

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No.

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

