### PR TITLE
fix the "Queries" in the wrong file

### DIFF
--- a/docs/03_server/04_event-handler/01_introduction.md
+++ b/docs/03_server/04_event-handler/01_introduction.md
@@ -47,4 +47,4 @@ We recommend using **Kotlin** to implement Event Handlers.
 
 :::
 
-All queries created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.
+All events created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.

--- a/versioned_docs/version-2022.3/03_server/04_event-handler/01_introduction.md
+++ b/versioned_docs/version-2022.3/03_server/04_event-handler/01_introduction.md
@@ -48,4 +48,4 @@ We recommend using **Kotlin** to implement Event Handlers.
 
 :::
 
-All queries created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.
+All events created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.

--- a/versioned_docs/version-2022.4/03_server/04_event-handler/01_introduction.md
+++ b/versioned_docs/version-2022.4/03_server/04_event-handler/01_introduction.md
@@ -47,4 +47,4 @@ We recommend using **Kotlin** to implement Event Handlers.
 
 :::
 
-All queries created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.
+All events created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.

--- a/versioned_docs/version-2023.1/03_server/04_event-handler/01_introduction.md
+++ b/versioned_docs/version-2023.1/03_server/04_event-handler/01_introduction.md
@@ -47,4 +47,4 @@ We recommend using **Kotlin** to implement Event Handlers.
 
 :::
 
-All queries created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.
+All events created in the Event Handler are exposed as HTTP/HTTPs [REST endpoints](../../../server/integration/rest-endpoints/introduction/) automatically by the Genesis platform. You can use any http client, such as postman, to access these custom endpoints.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-851

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
All versions

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

