### PR TITLE
docs: updated SendIt script arguement list with -force (IP-15)

### DIFF
--- a/versioned_docs/version-2023.1/05_operations/02_commands/01_server-commands.md
+++ b/versioned_docs/version-2023.1/05_operations/02_commands/01_server-commands.md
@@ -723,6 +723,7 @@ The `SendIt` command can take the following arguments:
 | -a       | --all                  | No        | import all the tables from all the csv files to the database | No                |
 | -d       | --delete               | No        | perform delete operations on all records                     | No                |
 | -f       | --file `<arg>`         | No        | name of the csv file where table is imported                 | No                |
+| -force   | --force                | No        | does the action without a prompt                             | No
 | -h       | --help                 | No        | show usage   information                                       | No                |
 | -m       | --modify `<arg>`       | No        | key name used to find original record                        | No                |
 | -mf      | --modifyFields `<arg>` | No        | specifies fields to modify                                     | No                |


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
https://genesisglobal.atlassian.net/browse/IP-15

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
No

Have you checked all new or changed links?
NA

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

