### PR TITLE
move away from toUpperCase

### DIFF
--- a/versioned_docs/version-2023.1/03_server/03_request-server/03_advanced.md
+++ b/versioned_docs/version-2023.1/03_server/03_request-server/03_advanced.md
@@ -29,10 +29,10 @@ requestReplies {
 
         request {
             ALTERNATE_TYPE withTransformation { type, _ ->
-                type?.toUpperCase() ?: "UNKNOWN"
+                type?.uppercase() ?: "UNKNOWN"
             }
             INSTRUMENT_CODE withTransformation { type, set ->
-                val value = if (set.fields["ALTERNATE_TYPE"].toString().toUpperCase() == "RIC") {
+                val value = if (set.fields["ALTERNATE_TYPE"].toString().uppercase() == "RIC") {
                     type
                 } else {
                     "NOT_RIC"


### PR DESCRIPTION
`toUpperCase()` in the examples is shown as deprecated, and we should use `uppercase()` instead

Thank you for contributing to the documentation.

Your Jira ticket is:
P********

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

