### PR TITLE
PTL-882 remove link that causes build fail

### DIFF
--- a/docs/03_server/09_inter-process-messages/03_type-safe-messages.md
+++ b/docs/03_server/09_inter-process-messages/03_type-safe-messages.md
@@ -203,7 +203,7 @@ interface GenesisError {
 So by default, all error/warning messages have the following properties, along with any extra properties that are needed to represent the error:
 
 - CODE is the error code, which can be of two types:
-  - [ErrorCode](../error-codes) is the ENUM class that contains a list of different error codes coming from the server
+  - ErrorCode is the ENUM class that contains a list of different error codes coming from the server
   - String is used to pass any code that is not part of ErrorCode enum
 
 - TEXT is of type String and contains more detailed information about the error code that is being sent.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-882

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Next is the only relevant one

Have you checked all new or changed links?
build now works 

Is there anything else you would like us to know?
WOULD LIKE TO SEE THIS APPROVED AND MERGED AS SOON AS POSSIBLE

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

