### PR TITLE
PTL-891: add more examples for grid-pro-genesis-datasource

### DIFF
--- a/docs/04_web/02_web-components/02_grids/01_grid-pro/3-grid-pro-genesis-datasource.md
+++ b/docs/04_web/02_web-components/02_grids/01_grid-pro/3-grid-pro-genesis-datasource.md
@@ -10,7 +10,9 @@ tags:
     - datasource
 ---
 
-Used in [Connected Data](../../../../../web/web-components/grids/grid-pro/grid-pro-connected/) scenarios, this will fetch data from a Genesis server (or any other server that implements the Genesis protocol). <br /> <br /> *Available attributes and props may change in the future and are open for feedback but are reflecting the DATA_LOGON message options](/creating-applications/defining-your-application/integrations/rest-endpoints/#data_logon)*
+Used in [Connected Data](../../../../../web/web-components/grids/grid-pro/grid-pro-connected/) scenarios, this will fetch data from a Genesis server (or any other server that implements the Genesis protocol).
+
+*All available attributes and pops are reflecting the [DATA_LOGON messages options](../../../../../server/integration/rest-endpoints/basics/#data_logon)*
 
 ## Attributes and props
 
@@ -20,26 +22,61 @@ Used in [Connected Data](../../../../../web/web-components/grids/grid-pro/grid-p
 
 - **`isSnapshot: boolean`**: Defaults to false. 
 
-- **`maxRows: number`**: Maximum number of rows to be returned as part of the initial message, and as part of any additional MORE_ROWS messages
+- **`max-rows: number`**: Maximum number of rows to be returned as part of the initial message, and as part of any additional MORE_ROWS messages
 
-- **`maxView: number`**: Maximum number of rows to track as part of a client "view"
+- **`max-view: number`**: Maximum number of rows to track as part of a client "view"
 
-- **`orderBy: string`**: This option can be used to select a [Data Server index](../../../../../database/data-types/index-entities/) (defined in xml), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
+- **`moving-view: boolean`**: If true, when the maximum number of rows defined in `max-view` is reached, the Data Server will start discarding the oldest rows (in terms of timestamp) and sending newer rows. If false, the updates in the server will be sent to the front end regardless of order. Note that this will only update the UI, no changes will be performed in the database.
+
+- **`order-by: string`**: This option can be used to select a [Data Server index](../../../../../database/data-types/index-entities/) (defined in xml), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
 
 - **`request: any`**: Similar to `fields` but for [Request Server](../../../../../server/request-server/introduction/) scenarios. This optional parameter allow you to specify request fields which can include wildcards. Example: you could request all RIC Codes for example, or all RIC Codes beginning with "V" for example.
 
-- **`resourceName: string`**: The target [Data Server](../../../../../server/data-server/introduction/) or [Request Server](../../../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
+- **`resource-name: string`**: The target [Data Server](../../../../../server/data-server/introduction/) or [Request Server](../../../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
 
 - **`reverse: boolean`**: This option changes the [Data Server index](../../../../../database/data-types/index-entities/) iteration. For example, if you are using the default index, they query will return rows from newest database records to oldest.
 
-```html title="Streaming data from ALL_PROCESS_STATUS data server"
-<alpha-card>
-  <alpha-grid-pro>
+- **`polling-interval: number`**: This option allows you to set a custom polling frequency (in milliseconds) for a [request server](../../../../server/request-server/introduction/) resource. Note that this option only works with request server, if you resource is a dataserver, your grid is updated in real time.
+
+### examples
+
+Here is an example using `grid-pro-genesis-datasource` with a maximum number of displayed to 5 and setting up `moving_view`:
+
+```typescript title="Example of moving_view"
+<alpha-grid-pro>
     <grid-pro-genesis-datasource 
-      resourceName="ALL_PROCESSES_STATUS" 
-      isSnapshot="true" 
-      fields="PROCESS_NAME LOG_LEVEL" />
+        resource-name="ALL_TRADE"
+        max-view="4"
+        max-view="true" />
     ...
-  </alpha-grid-pro>
-  ...
-</alpha-card>
+</alpha-grid-pro>
+...
+```
+
+Below you find an example of `grid-pro-genesis-datasource` including `max-row`, `max-view`, `moving_view`, `fields`, `isSnapshot` and `resource-name`
+
+```typescript title="Using a grid-pro with grid-pro-genesis-datasource"
+<alpha-grid-pro>
+    <grid-pro-genesis-datasource 
+        resource-name="ALL_PROCESSES_STATUS" 
+        isSnapshot="true" 
+        fields="PROCESS_NAME LOG_LEVEL" 
+        max-view="4"
+        max-row="5"
+        max-view="true" />
+    ...
+</alpha-grid-pro>
+...
+```
+
+Lastly, an example of how to use `grid-pro-genesis-datasource` with `polling-interval`, setting the pulling frequency to 10 seconds. Remember to set a request server in order to use the `polling-interval` option.
+
+```typescript title="Example of polling-interval"
+<alpha-grid-pro>
+    <grid-pro-genesis-datasource 
+        resource-name="REQUEST_SERVER_ALL_TRADE"
+        polling-interval="10000" />
+    ...
+</alpha-grid-pro>
+...
+```

--- a/versioned_docs/version-2023.1/04_web/02_web-components/02_grids/01_grid-pro/3-grid-pro-genesis-datasource.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/02_grids/01_grid-pro/3-grid-pro-genesis-datasource.md
@@ -3,14 +3,16 @@ id: grid-pro-genesis-datasource
 title: Grid Pro - Genesis datasource
 keywords: [web, web components, grid, grid pro, datasource]
 tags:
-    - web
-    - web components
-    - grid
-    - grid pro
-    - datasource
+- web
+- web components
+- grid
+- grid pro
+- datasource
 ---
 
-Used in [Connected Data](../../../../../web/web-components/grids/grid-pro/grid-pro-connected/) scenarios, this will fetch data from a Genesis server (or any other server that implements the Genesis protocol). <br /> <br /> *Available attributes and props may change in the future and are open for feedback but are reflecting the DATA_LOGON message options](/creating-applications/defining-your-application/integrations/rest-endpoints/#data_logon)*
+Used in [Connected Data](../../../../../web/web-components/grids/grid-pro/grid-pro-connected/) scenarios, this will fetch data from a Genesis server (or any other server that implements the Genesis protocol).
+
+*All available attributes and pops are reflecting the [DATA_LOGON messages options](../../../../../server/integration/rest-endpoints/basics/#data_logon)*
 
 ## Attributes and props
 
@@ -18,28 +20,63 @@ Used in [Connected Data](../../../../../web/web-components/grids/grid-pro/grid-p
 
 - **`fields: boolean`**: Similar to `request` but for [Data Server](../../../../../server/data-server/introduction/) scenarios. This optional parameter allows you to select a subset of fields from the query if the client is not interested in receiving all of them. Example: "TRADE_ID QUANTITY PRICE INSTRUMENT_ID". By default all fields are returned if this option is not specified.
 
-- **`isSnapshot: boolean`**: Defaults to false. 
+- **`isSnapshot: boolean`**: Defaults to false.
 
-- **`maxRows: number`**: Maximum number of rows to be returned as part of the initial message, and as part of any additional MORE_ROWS messages
+- **`max-rows: number`**: Maximum number of rows to be returned as part of the initial message, and as part of any additional MORE_ROWS messages
 
-- **`maxView: number`**: Maximum number of rows to track as part of a client "view"
+- **`max-view: number`**: Maximum number of rows to track as part of a client "view"
 
-- **`orderBy: string`**: This option can be used to select a [Data Server index](../../../../../database/data-types/index-entities/) (defined in xml), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
+- **`moving-view: boolean`**: If true, when the maximum number of rows defined in `max-view` is reached, the Data Server will start discarding the oldest rows (in terms of timestamp) and sending newer rows. If false, the updates in the server will be sent to the front end regardless of order. Note that this will only update the UI, no changes will be performed in the database.
+
+- **`order-by: string`**: This option can be used to select a [Data Server index](../../../../../database/data-types/index-entities/) (defined in xml), which is especially useful if you want the data to be sorted in a specific way. By default, data server rows will be returned in order of creation (from oldest database record to newest).
 
 - **`request: any`**: Similar to `fields` but for [Request Server](../../../../../server/request-server/introduction/) scenarios. This optional parameter allow you to specify request fields which can include wildcards. Example: you could request all RIC Codes for example, or all RIC Codes beginning with "V" for example.
 
-- **`resourceName: string`**: The target [Data Server](../../../../../server/data-server/introduction/) or [Request Server](../../../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
+- **`resource-name: string`**: The target [Data Server](../../../../../server/data-server/introduction/) or [Request Server](../../../../../server/request-server/introduction/) name. Example: "ALL_TRADES" or "ALT_COUNTERPARTY_ID"
 
 - **`reverse: boolean`**: This option changes the [Data Server index](../../../../../database/data-types/index-entities/) iteration. For example, if you are using the default index, they query will return rows from newest database records to oldest.
 
-```html title="Streaming data from ALL_PROCESS_STATUS data server"
-<alpha-card>
-  <alpha-grid-pro>
+- **`polling-interval: number`**: This option allows you to set a custom polling frequency (in milliseconds) for a [request server](../../../../server/request-server/introduction/) resource. Note that this option only works with request server, if you resource is a dataserver, your grid is updated in real time.
+
+### examples
+
+Here is an example using `grid-pro-genesis-datasource` with a maximum number of displayed to 5 and setting up `moving_view`:
+
+```typescript title="Example of moving_view"
+<alpha-grid-pro>
     <grid-pro-genesis-datasource 
-      resourceName="ALL_PROCESSES_STATUS" 
-      isSnapshot="true" 
-      fields="PROCESS_NAME LOG_LEVEL" />
+        resource-name="ALL_TRADE"
+        max-view="4"
+        max-view="true" />
     ...
-  </alpha-grid-pro>
-  ...
-</alpha-card>
+</alpha-grid-pro>
+...
+```
+
+Below you find an example of `grid-pro-genesis-datasource` including `max-row`, `max-view`, `moving_view`, `fields`, `isSnapshot` and `resource-name`
+
+```typescript title="Using a grid-pro with grid-pro-genesis-datasource"
+<alpha-grid-pro>
+    <grid-pro-genesis-datasource 
+        resource-name="ALL_PROCESSES_STATUS" 
+        isSnapshot="true" 
+        fields="PROCESS_NAME LOG_LEVEL" 
+        max-view="4"
+        max-row="5"
+        max-view="true" />
+    ...
+</alpha-grid-pro>
+...
+```
+
+Lastly, an example of how to use `grid-pro-genesis-datasource` with `polling-interval`, setting the pulling frequency to 10 seconds. Remember to set a request server in order to use the `polling-interval` option.
+
+```typescript title="Example of polling-interval"
+<alpha-grid-pro>
+    <grid-pro-genesis-datasource 
+        resource-name="REQUEST_SERVER_ALL_TRADE"
+        polling-interval="10000" />
+    ...
+</alpha-grid-pro>
+...
+```


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-891

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs and 2023.1

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
I have only changed 2023.1 and docs because I don't know by the time of 2022.4 release if these options was supported. 

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

