### PR TITLE
PTL-906: units for two settings in system definitions

### DIFF
--- a/docs/03_server/01_configuring-runtime/02_system-definitions.md
+++ b/docs/03_server/01_configuring-runtime/02_system-definitions.md
@@ -114,9 +114,9 @@ item(name = "GenesisKey", value = System.getenv("GENESIS_KEY"))
 
 - For [PostgresSQL](../../../database/database-technology/sql/#postgresql): This can be one of two values: POSTGRESQL if you want PostgreSQL to work with namespaces/schemas and LEGACY, which is the default mode; it always stores the dictionary in a table called `dictionary` and a schema called `metadata`.
 
-**ResourcePollerTimeout**: This setting controls how often the genesis daemon process keeps the processes and their metadata up to date.
+**ResourcePollerTimeout**: This setting controls how often (in seconds) the genesis daemon process keeps the processes and their metadata up to date.
 
-**ReqRepTimeout**: This setting contains the default timeout for the request server resources in the system.
+**ReqRepTimeout**: This setting contains the default timeout (in seconds) for the request server resources in the system.
 
 **MetadataChronicleMapAverageKeySizeBytes**, **MetadataChronicleMapAverageValueSizeBytes**, **MetadataChronicleMapEntriesCount**: These are the settings for chronicle map and are related to the way processes store their own metadata resources inside /runtime/proc_metadata
 

--- a/versioned_docs/version-2022.3/03_server/01_configuring-runtime/02_system-definitions.md
+++ b/versioned_docs/version-2022.3/03_server/01_configuring-runtime/02_system-definitions.md
@@ -103,9 +103,9 @@ item(name = "GenesisKey", value = System.getenv("GENESIS_KEY"))
 
 - For [PostgresSQL](../../../database/database-technology/sql/#postgresql): This can be one of two values: POSTGRESQL if you want PostgreSQL to work with namespaces/schemas and LEGACY which is default mode it always stores the dictionary in table called `dictionary` and schema called `metadata`.
 
-**ResourcePollerTimeout**: This setting controls how often the genesis daemon process keeps the processes and their metadata up to date.
+**ResourcePollerTimeout**: This setting controls how often (in seconds) the genesis daemon process keeps the processes and their metadata up to date.
 
-**ReqRepTimeout**: This setting contains the default timeout for the request server resources in the system.
+**ReqRepTimeout**: This setting contains the default timeout (in seconds) for the request server resources in the system.
 
 **MetadataChronicleMapAverageKeySizeBytes**, **MetadataChronicleMapAverageValueSizeBytes**, **MetadataChronicleMapEntriesCount**: These are the settings for chronicle map and are related to the way processes store their own metadata resources inside /runtime/proc_metadata
 

--- a/versioned_docs/version-2022.4/03_server/01_configuring-runtime/02_system-definitions.md
+++ b/versioned_docs/version-2022.4/03_server/01_configuring-runtime/02_system-definitions.md
@@ -105,9 +105,9 @@ item(name = "GenesisKey", value = System.getenv("GENESIS_KEY"))
 
 - For [PostgresSQL](../../../database/database-technology/sql/#postgresql): This can be one of two values: POSTGRESQL if you want PostgreSQL to work with namespaces/schemas and LEGACY, which is the default mode; it always stores the dictionary in a table called `dictionary` and a schema called `metadata`.
 
-**ResourcePollerTimeout**: This setting controls how often the genesis daemon process keeps the processes and their metadata up to date.
+**ResourcePollerTimeout**: This setting controls how often (in seconds) the genesis daemon process keeps the processes and their metadata up to date.
 
-**ReqRepTimeout**: This setting contains the default timeout for the request server resources in the system.
+**ReqRepTimeout**: This setting contains the default timeout (in seconds) for the request server resources in the system.
 
 **MetadataChronicleMapAverageKeySizeBytes**, **MetadataChronicleMapAverageValueSizeBytes**, **MetadataChronicleMapEntriesCount**: These are the settings for chronicle map and are related to the way processes store their own metadata resources inside **/runtime/proc_metadata**.
 

--- a/versioned_docs/version-2023.1/03_server/01_configuring-runtime/02_system-definitions.md
+++ b/versioned_docs/version-2023.1/03_server/01_configuring-runtime/02_system-definitions.md
@@ -113,9 +113,9 @@ item(name = "GenesisKey", value = System.getenv("GENESIS_KEY"))
 
 - For [PostgresSQL](../../../database/database-technology/sql/#postgresql): This can be one of two values: POSTGRESQL if you want PostgreSQL to work with namespaces/schemas and LEGACY, which is the default mode; it always stores the dictionary in a table called `dictionary` and a schema called `metadata`.
 
-**ResourcePollerTimeout**: This setting controls how often the genesis daemon process keeps the processes and their metadata up to date.
+**ResourcePollerTimeout**: This setting controls how often (in seconds) the genesis daemon process keeps the processes and their metadata up to date.
 
-**ReqRepTimeout**: This setting contains the default timeout for the request server resources in the system.
+**ReqRepTimeout**: This setting contains the default timeout (in seconds) for the request server resources in the system.
 
 **MetadataChronicleMapAverageKeySizeBytes**, **MetadataChronicleMapAverageValueSizeBytes**, **MetadataChronicleMapEntriesCount**: These are the settings for chronicle map and are related to the way processes store their own metadata resources inside /runtime/proc_metadata
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-906

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
YES

Have you checked all new or changed links?
YES

Is there anything else you would like us to know?
NO

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

