### PR TITLE
feat: Add view support to DbMon and reordered DbMon command list. (GSF-5842)

### DIFF
--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -107,13 +107,18 @@ BROKER
 
 To look at the data held in a specific table, use the [`table`](#dbmon-commands) command followed by the table name: for example `table BROKER`. Once you have selected a table, the `DbMon` prompt changes to show the table name.
 
-### View
-
-To look at the data held in a specific view, use the [`view`](#dbmon-commands) command followed by the view name: for example `view BROKER`. Once you have selected a view, the `DbMon` prompt changes to show the view name.
-
 ```javascript
 DbMon>table BROKER
 DbMon:BROKER>
+```
+
+### View
+
+To look at the data held in a specific view, use the [`view`](#dbmon-commands) command followed by the view name: for example `view BROKER_VIEW`. Once you have selected a view, the `DbMon` prompt changes to show the view name.
+
+```javascript
+DbMon>view BROKER_VIEW
+DbMon:BROKER_VIEW>
 ```
 
 ### Show
@@ -181,7 +186,9 @@ The table BROKER contains 114 records
 ```
 
 ### Set and Unset
-Use the `set` and `unset` commands to set the value of a specific field in the selected database entity. If you have previously selected a record, it will overwrite its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. In the example below, we set a new value for the `QUANTITY` field:
+Use the `set` and `unset` commands to set the value of a specific field in the selected database entity. If you have previously selected a record, it will overwrite its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. 
+
+In the example below, we are viewing the **TRADE** table. The command sets a new value for the `QUANTITY` field:
 
 ``` javascript
 DbMon:TRADE>set QUANTITY = 10
@@ -351,7 +358,7 @@ TRADE_STATUS                             NEW                                    
 ```
 ### Next
 
-You can alo use the `next` command to select the next record in the sequence. Here is an example:
+You can also use the `next` command to select the next record in the sequence. Here is an example:
 
 ```javascript
 DbMon:TRADE>next TRADE_BY_ID

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -18,38 +18,39 @@ DbMon is the Genesis database client. It provides an interface to the underlying
 
 The commands available with DbMon are listed below. 
 
-| Command                             | Argument                                    | Description                                       |
-|-------------------------------------|---------------------------------------------|---------------------------------------------------|
-| writeMode                           |                                             | enables write mode                                |
-| help                                |                                             | lists all commands                                |
-| [showTables](#show-tables)          |                                             | display all tables in the schema                  |
-| [table](#table)                     | `<table_name>`                              | select an specified table                         |
-| [show](#show)                       |                                             | display the current record                        |
-| [displayFields](#display-fields)    | `<field_names>`                             | display only selected columns                     |
-| [count](#count-rows)                |                                             | counts the rows in the table                      |
-| [set](#set--unset)                  | `<field_name> <field_value>`                | sets a field                                      |
-| [unset](#set--unset)                | `<field>`                                   | sets a field to `null`                            |
-| [insert](#insert)                   |                                             | inserts the current                               |
-| [delete](#delete)                   |                                             | deletes the current row                           |
-| [deleteWhere](#deletewhere)         | `<condition>`                               | deletes all matching rows in the selected table   |
-| [update](#update)                   | `<key_name>` `<fields>`                     | updates the current row by key                    |
-| [updateWhere](#updatewhere)         | `<condition> <assignments>`                 | updates all records that matches a given condition|
-| [find](#find)                       | `<key_name>`                                | find an specific record in a index                |
-| [showKeys](#show-keys-indexes)      |                                             | display all indexes                               |
-| [first](#first-and-last)            | `<key_name>`                                | gets the first record by key                      |
-| [last](#first-and-last)             | `<key_name>`                                | gets the last record by key                       |
-| [next](#next)                       | `<key_name>`                                | gets the next record by key                       |
-| [clear](#displaying-a-record---set) |                                             | clears the current context                        |
-| [search](#search)                   | `<condition> [-l <limit>]`                  | return the records that matches with the criteria |
-| [distinct](#distinct)               | `<condition> [-where <limiting_condition>]` | show only distinct records                        |
-| sequenceNumber                      | `<sequence_name>`                           |                                                   |
-| autoIncrementNumber                 | `<field_name>`                              |                                                   |
-| forceAutoIncrementNumber            | `<field_name> <sequence_number>`            |                                                   |
-| forceSequenceNumber                 | `<sequence_name> <sequence_number>`         |                                                   |
-| listAll                             | `<key_name> <num_key_fields> <max_records>` |                                                   |
-| qsearch                             | `<condition> [-l <limit>]`                  |                                                   |
-| qshow                               |                                             |                                                   |
-
+| Command                              | Argument                                    | Description                                        |
+|--------------------------------------|---------------------------------------------|----------------------------------------------------|
+| autoIncrementNumber                  | `<field_name>`                              |                                                    |
+| [clear](#displaying-a-record---set)  |                                             | clears the current context                         |
+| [count](#count-rows)                 |                                             | counts the rows in the table/view                  |
+| [delete](#delete)                    |                                             | deletes the current row                            |
+| [deleteWhere](#deletewhere)          | `<condition>`                               | deletes all matching rows in the selected table    |
+| [distinct](#distinct)                | `<condition> [-where <limiting_condition>]` | show only distinct records                         |
+| [displayFields](#display-fields)     | `<field_names>`                             | display only selected columns                      |
+| [find](#find)                        | `<key_name>`                                | find an specific record in a index                 |
+| forceAutoIncrementNumber             | `<field_name> <sequence_number>`            |                                                    |
+| forceSequenceNumber                  | `<sequence_name> <sequence_number>`         |                                                    |
+| [first](#first-and-last)             | `<key_name>`                                | gets the first record by key                       |
+| help                                 |                                             | lists all commands                                 |
+| [insert](#insert)                    |                                             | inserts the current                                |
+| [last](#first-and-last)              | `<key_name>`                                | gets the last record by key                        |
+| listAll                              | `<key_name> <num_key_fields> <max_records>` |                                                    |
+| [next](#next)                        | `<key_name>`                                | gets the next record by key                        |
+| qsearch                              | `<condition> [-l <limit>]`                  |                                                    |
+| qshow                                |                                             |                                                    |
+| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that matches with the criteria  |
+| [set](#set-and-unset)                | `<field_name> <field_value>`                | sets a field                                       |
+| sequenceNumber                       | `<sequence_name>`                           |                                                    |
+| [show](#show)                        |                                             | display the current record                         |
+| [showKeys](#show-keys-indexes)       |                                             | display all indexes                                |
+| [showTables](#show-tables-and-views) |                                             | display all tables in the schema                   |
+| [showViews](#show-tables-and-views)  |                                             | display all views in the schema                    |
+| [table](#table)                      | `<table_name>`                              | select an specified table                          |
+| [unset](#set-and-unset)              | `<field>`                                   | sets a field to `null`                             |
+| [update](#update)                    | `<key_name>` `<fields>`                     | updates the current row by key                     |
+| [updateWhere](#updatewhere)          | `<condition> <assignments>`                 | updates all records that matches a given condition |
+| [view](#view)                        | `<view_name>`                               | select an specified view                           |
+| writeMode                            |                                             | enables write mode                                 |
 
 ## Starting DbMon
 
@@ -73,13 +74,13 @@ As you can see, once you are in a DbMon session, the `DbMon>` prompt is displaye
 
 To end a DbMon session, just type [`quit`](#dbmon-commands) at the DbMon prompt.
 
-## Working with tables
+## Working with tables and views
 
-Most of the time, you'll be using DbMon to examine tables in one way or another. 
+Most of the time, you'll be using DbMon to examine tables or views in one way or another. Write operations are not allowed on views. 
 
-### Show tables
+### Show tables and views
 
-To see a list of available tables, use the [`showtables`](#dbmon-commands) command. This displays an alphabetical list of available tables, for example:
+To see a list of available tables/views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) commands. This displays an alphabetical list of available tables or views, for example:
 
 ```javascript
 ==================================
@@ -106,6 +107,10 @@ BROKER
 
 To look at the data held in a specific table, use the [`table`](#dbmon-commands) command followed by the table name: for example `table BROKER`. Once you have selected a table, the `DbMon` prompt changes to show the table name.
 
+### View
+
+To look at the data held in a specific view, use the [`view`](#dbmon-commands) command followed by the view name: for example `view POSITION_VIEW`. Once you have selected a view, the `DbMon` prompt changes to show the view name.
+
 ```javascript
 DbMon>table BROKER
 DbMon:BROKER>
@@ -113,7 +118,7 @@ DbMon:BROKER>
 
 ### Show
 
-To see the columns available in the selected table use the [`show`](#dbmon-commands) command. This displays the current record in the selected table. If no record has been selected, it displays an empty record (notice the value column below is not populated):
+To see the columns available in the selected table/view use the [`show`](#dbmon-commands) command. This displays the current record in the selected table/view. If no record has been selected, it displays an empty record (notice the value column below is not populated):
 
 ```javascript
 ==================================
@@ -145,7 +150,7 @@ VIEW_CODE                                                           STRING
 
 If you are only interested in seeing selected columns, use the [`displayFields`](#dbmon-commands) command and list the names of the columns you are interested in (separated by spaces). 
 
-Any subsequent [`show`](#dbmon-commands) commands will only display those columns, rather than all the columns in the table.
+Any subsequent [`show`](#dbmon-commands) commands will only display those columns, rather than all the columns in the table/view.
 
 
 ```javascript
@@ -168,7 +173,7 @@ To view all columns again, use the [`displayFields`](#dbmon-commands) command fo
 
 ### Count rows
 
-To discover how many rows of data there are in a table, use the [`count`](#dbmon-commands) command. For large tables, this could take some time to return:
+To discover how many rows of data there are in a table/view, use the [`count`](#dbmon-commands) command. For large database entities, this could take some time to return:
 
 ```javascript
 DbMon:BROKER>count
@@ -176,7 +181,7 @@ The table BROKER contains 114 records
 ```
 
 ### Set and Unset
-The `set` and `unset` commands are used to set the value of a specific field in the selected table. If you have previously selected a record, it will override its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. In the example below, we set a new value for the `QUANTITY` field:
+The `set` and `unset` commands are used to set the value of a specific field in the selected database entity. If you have previously selected a record, it will override its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. In the example below, we set a new value for the `QUANTITY` field:
 
 ``` javascript
 DbMon:TRADE>set QUANTITY = 10
@@ -296,15 +301,15 @@ Updated record: DbRecord [tableName=TRADE] [PRICE = 90.0, SYMBOL = EUR, QUANTITY
 To be able to use this command, you need to be in `writeMode`.
 :::
 
-## Finding data in a table
+## Finding data in a table or view
 
 ### Find
 
-In DbMon, you can only see one record at a time. To display the record you want, you must first locate it using the [`find`](#dbmon-commands) command, which searches the table’s indexes for a given key value.  
+In DbMon, you can only see one record at a time. To display the record you want, you must first locate it using the [`find`](#dbmon-commands) command, which searches the table’s or view’s indexes for a given key value.  
 
 ### Show keys (indexes)
 
-To see the indexes (or keys) on the selected table, use the [`showKeys`](#dbmon-commands) command. This displays a list of the index names and the fields you will need to supply to use the index:
+To see the indexes (or keys) on the selected table/view, use the [`showKeys`](#dbmon-commands) command. This displays a list of the index names and the fields you will need to supply to use the index:
 
 ```javascript
 ==================================
@@ -322,7 +327,7 @@ BROKER_BY_VIEW_CODE                VIEW_CODE                                Seco
 	------------------------------------------------------------------------------------------ 
 ```
 ### First and Last
-If you are interested in selecting the `first` or the `last` record, you can use the `first` or `last` along with the index name. After selecting a record, to be able to see it in the dbmon, you need to run the `show` command. In the following example, we are going to select the first record in the **TRADE** table using the index **TRADE_BY_ID**.
+If you are interested in selecting the `first` or the `last` record, you can use the `first` or `last` along with the index name. After selecting a record, to be able to see it in the dbmon, you need to run the `show` command. In the following example, we are going to select the first record in the **TRADE** table using the index **TRADE_BY_ID**, although we could perform the same operation using a view index.
 
 ```javascript
 DbMon:TRADE>first TRADE_BY_ID
@@ -370,7 +375,7 @@ TRADE_STATUS                             NEW                                    
 ```
 ### Displaying a record - Set
 
-To display a particular record from a table, use the [`set`](#dbmon-commands) command to populate an index field with the value you are searching for. Then use the [`find`](#dbmon-commands) command along with the appropriate index name.
+To display a particular record from a table or view, use the [`set`](#dbmon-commands) command to populate an index field with the value you are searching for. Then use the [`find`](#dbmon-commands) command along with the appropriate index name.
 
 The example below looks for a broker that has a `VIEW_CODE` value of “WALSH”. We have searched for the Key named `BROKER_BY_VIEW_CODE` and to use that key we whave set the `VIEW_CODE` to the value `WALSH`.
 
@@ -405,7 +410,7 @@ VIEW_CODE                 WALSH                                     STRING
 
 If you then want to [`find`](#dbmon-commands) a record with a different `VIEW_CODE`, you need to go back to having an empty record so that you can [`set`](#dbmon-commands) the `VIEW_CODE` again and perform another [`find`](#dbmon-commands). 
 
-To do this, use the [`clear`](#dbmon-commands) command.This resets your view onto the table so that you can start again. 
+To do this, use the [`clear`](#dbmon-commands) command.This resets your prompt onto the table or view so that you can start again. 
 
 :::note
 The [`clear`](#dbmon-commands) command does not have any effect on the data itself, just on your “window” into the database.
@@ -413,10 +418,10 @@ The [`clear`](#dbmon-commands) command does not have any effect on the data itse
 
 ### Search
 
-If you wish to look for a record (or a number of records) but your criterion does not match an index on the table, you can use the [`search`](#dbmon-commands) command.
+If you wish to look for a record (or a number of records) but your criterion does not match an index on the database entity, you can use the [`search`](#dbmon-commands) command.
 
 :::warning
-For larger tables, this can be slow and risks causing latency to your application's users.
+For larger entities, this can be slow and risks causing latency to your application's users.
 :::
 
 For example, if you wanted to find all the records in the `BROKER` table where the `COUNTRY_CODE` was IRL, and there is no index that can be used (and there might be multiple results), the [`search`](#dbmon-commands) command would look like this:
@@ -616,6 +621,16 @@ Total Results:  8
 Total Distinct Values Count:  6
 ```
 
+```jsx
+DbMon:BROKER>distinct COUNTRY_CODE -where REGION=='UK'&&COUNTRY_CODE!='GBR'
+Distinct Value                           Count
+===========================================================================================
+[null]                                   8    
+-------------------------------------------------------------------------------------------
+Total Results:  8
+Total Distinct Values Count:  1
+```
+
 ## Help
 
 Once inside `DbMon`, you can run the command [`help`](#dbmon-commands) to show all the available `DbMon` commands.
@@ -650,10 +665,12 @@ set <field_name> <field_value>
 show
 showKeys
 showTables
+showViews
 table <table_name>
 unset
 update <key_name>
 updateWhere <condition> <assignments>
+view    
 writeMode
 ```
 

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -14,54 +14,17 @@ tags:
 
 DbMon is the Genesis database client. It provides a set of commands that enable you to view and change the database as necessary. DbMon hides the details of the specific database technology, so this does not affect your usage. 
 
-Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon. This page gives details of all the DbMon commands and provides practical examples of how you can use them.
+Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon. 
 
-## DbMon commands
+This page gives details of all the DbMon commands and provides practical examples of how you can use them.
 
-The commands available with DbMon are listed below. 
-
-| Command                              | Argument                                    | Description                                       |
-|--------------------------------------|---------------------------------------------|---------------------------------------------------|
-| autoIncrementNumber                  | `<field_name>`                              |                                                   |
-| [clear](#displaying-a-record---set)  |                                             | clear the current context                         |
-| [count](#count-rows)                 |                                             | count the rows in the table/view                  |
-| [delete](#delete)                    |                                             | delete the current row                            |
-| [deleteWhere](#deletewhere)          | `<condition>`                               | delete all matching rows in the selected table    |
-| [distinct](#distinct)                | `<condition> [-where <limiting_condition>]` | show only distinct records                        |
-| [displayFields](#display-fields)     | `<field_names>`                             | display only selected columns                     |
-| [find](#find)                        | `<key_name>`                                | find a specific record in a index                 |
-| forceAutoIncrementNumber             | `<field_name> <sequence_number>`            |                                                   |
-| forceSequenceNumber                  | `<sequence_name> <sequence_number>`         |                                                   |
-| [first](#first-and-last)             | `<key_name>`                                | get the first record by key                       |
-| help                                 |                                             | list all commands                                 |
-| [insert](#insert)                    |                                             | insert the current                                |
-| [last](#first-and-last)              | `<key_name>`                                | get the last record by key                        |
-| listAll                              | `<key_name> <num_key_fields> <max_records>` |                                                   |
-| [next](#next)                        | `<key_name>`                                | get the next record by key                        |
-| qsearch                              | `<condition> [-l <limit>]`                  |                                                   |
-| qshow                                |                                             |                                                   |
-| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that match the criteria        |
-| [set](#set-and-unset)                | `<field_name> <field_value>`                | set a field                                       |
-| sequenceNumber                       | `<sequence_name>`                           |                                                   |
-| [show](#show)                        |                                             | display the current record                        |
-| [showKeys](#show-keys-indexes)       |                                             | display all indexes                               |
-| [showTables](#show-tables-and-views) |                                             | display all tables in the schema                  |
-| [showViews](#show-tables-and-views)  |                                             | display all views in the schema                   |
-| [table](#table)                      | `<table_name>`                              | select an specified table                         |
-| [unset](#set-and-unset)              | `<field>`                                   | set a field to `null`                             |
-| [update](#update)                    | `<key_name>` `<fields>`                     | update the current row by key                     |
-| [updateWhere](#updatewhere)          | `<condition> <assignments>`                 | update all records that matches a given condition |
-| [view](#view)                        | `<view_name>`                               | select an specified view                          |
-| writeMode                            |                                             | enable write mode                                 |
 
 ## Starting DbMon
 
 To start a DbMon session, first switch to the user that owns the Genesis installation. Then type `DbMon` at the command prompt:
 
 ```javascript
-[titan] /home/titan >DbMon
-28 Jul 2021 17:01:53.998 1087 [main] WARN  global.genesis.commons.config.ConfigFileFinder - Product extralibs does not have a config directory
-
+[titian] /home/titian >DbMon
 
 ==================================
 Genesis database Monitor
@@ -76,24 +39,18 @@ As you can see, once you are in a DbMon session, the `DbMon>` prompt is displaye
 
 To end a DbMon session, just type [`quit`](#dbmon-commands) at the DbMon prompt.
 
-## Making changes safely
+## Finding and viewing information
 
-When you run DbMon, it creates a local image of your database. This enables you to look at values and safely change them locally without writing to the database.
-
-If you then want to make changes to the database, you must first enable `writeMode`. 
-
-## Working with tables and views
-
-Most of the time, you'll be using DbMon to work on a specific table or view. DbMon enables you to: 
+A Genesis database organises information in tables and views. DbMon enables you to: 
 
 - find all the tables in your database (`showTables`)
-- select a table to work on (`table`)
+- select a table to examine (`table`)
 - find all the views in your database (`showViews`)
-- select a view to work on (`view`)
-- 
+- select a view to examine (`view`)
+
 ### Show tables and views
 
-To see a list of available tables or views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) commands. This displays an alphabetical list of available tables or views. For example, here we have used the command `showTables`:
+To see a list of available tables or views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) command. This displays an alphabetical list of available tables or views. For example, here we have used the command `showTables`:
 
 ```javascript
 ==================================
@@ -113,7 +70,7 @@ AUDIT
 AUDIT_SSI_UPDATE
 AUDIT_TRAIL
 BROKER
-<<List Snipped For Primer>>
+<<List continues...>>
 ```
 
 ### Table
@@ -134,9 +91,9 @@ DbMon>view BROKER_VIEW
 DbMon:BROKER_VIEW>
 ```
 
-### Show
+### Viewing the columns in a table or view
 
-To see the columns available in the currently selected table or view, use the [`show`](#dbmon-commands) command. This displays the columns (fields) for the current record. If no record has been selected, it displays an empty record (as you can see in the example below, where the value column is not populated):
+To see the columns in the currently selected table or view, use the [`show`](#dbmon-commands) command. This displays the columns (fields) for the current record. If you haven't already retrieved a specific record, the Value column will be empty (as you can see in the example below):
 
 ```javascript
 ==================================
@@ -164,7 +121,7 @@ REGION                                                              STRING
 VIEW_CODE                                                           STRING
 ```
 
-### Display fields
+### Viewing selected columns
 
 If you are only interested in seeing selected columns, use the [`displayFields`](#dbmon-commands) command and list the names of the columns you are interested in (separated by spaces). 
 
@@ -189,8 +146,331 @@ DbMon:BROKER>displayFields
 Display fields reset!
 ```
 
+### Finding and viewing a specific record
 
-### Count rows
+In DbMon you can only see one record at a time.
+
+To display the record you want, use the `find` command, which searches the table’s indices for a given key value.  
+
+So you need to know what the indices (keys) are for the currently selected table; use the `showKeys` command. This lists each key (index), along with the field name you need to supply to use the index.  In the example below, the BROKER table has a primary index (BROKER_BY_ID, where the relevant field is BROKER_ID) and three secondary indices.
+
+```javascript
+==================================
+BROKER
+==================================
+Key Name                           Field Name                               Index Type
+=======================================================
+BROKER_BY_BROKER_EXTERNAL_ID       EXTERNAL_ID                              Secondary
+------------------------------------------------------------------------------------------
+BROKER_BY_ID                       BROKER_ID                                Primary
+------------------------------------------------------------------------------------------
+BROKER_BY_TIMESTAMP                TIMESTAMP                                Secondary
+------------------------------------------------------------------------------------------
+BROKER_BY_VIEW_CODE                VIEW_CODE                                Secondary
+	------------------------------------------------------------------------------------------ 
+```
+
+Now that you know the indices and the fields they require, you can find a record in the table or view.
+
+The example below looks for a broker that has a `VIEW_CODE` value of “WALSH”. 
+
+1. The `set` command sets the value of the `VIEW_CODE` to the value `WALSH`. _This is a local setting; it does not change the database._
+2. The `find` command looks for the index (key) `BROKER_BY_VIEW_CODE`.
+3. The `show` command displays the result.
+
+```javascript
+DbMon:BROKER>set VIEW_CODE WALSH
+DbMon:BROKER>find BROKER_BY_VIEW_CODE
+DbMon:BROKER>show
+==================================
+BROKER
+==================================
+Field Name                Value                                     Type
+===========================================================================================
+TIMESTAMP                 2022-07-08 14:14:26.818(n:0,s:2630)       NANO_TIMESTAMP
+BROKER_ID                 725                                       INT
+BROKER_PARENT_ID          724                                       INT
+CODE                      114216                                    STRING
+CODE_TYPE                 Registered                                STRING
+COUNTRY_CODE              GBR                                       STRING
+CREATED_DATE              2022-12-11 11:43:53.210 +0000             DATETIME
+CREATED_USER              ismail.augustine                          STRING
+EXTERNAL_ID               725N                                      STRING
+FID_BROKER_ID             WALSH                                     STRING
+IS_ACTIVE                 true                                      BOOLEAN
+LEI_NUMBER                MP6I5ZYZBEU3UXPYFY54                      STRING
+MODIFIED_DATE             2022-03-14 09:44:25.703 +0000             DATETIME
+MODIFIED_USER             ismail.augustine                              STRING
+NAME                      WALSH Bank Plc                            STRING 
+NETTING_GROUP_ID                                                    INT
+REGION                    UK                                        STRING
+VIEW_CODE                 WALSH                                     STRING
+```
+
+If you then want to [`find`](#dbmon-commands) a record with a different `VIEW_CODE`, you need to go back to having an empty record so that you can [`set`](#dbmon-commands) the `VIEW_CODE` again and perform another [`find`](#dbmon-commands). 
+
+To do this, use the [`clear`](#dbmon-commands) command. This resets your prompt onto the table or view so that you can start again. _This is a local setting; it does not change the database._
+
+## Searching for one or more records
+To look for a record (or a number of records) without using an index (key), use the `search` command. This lists all the records that match the criteria that you supply.
+
+:::warning
+For larger tables, this can be slow and could cause latency to users of your application.
+:::
+
+For example, to find all the records in the BROKER table where the COUNTRY_CODE is IRL:
+
+```javascript
+DbMon:BROKER>search COUNTRY_CODE=='IRL'
+==================================
+BROKER
+==================================
+Field Name                Value                                     Type
+===========================================================================================
+TIMESTAMP                 2022-02-12 11:07:58.116339964             NANO_TIMESTAMP
+BROKER_ID                 4001                                      INT
+BROKER_PARENT_ID                                                    INT
+CODE                      223987                                    STRING
+CODE_TYPE                 Registered                                STRING
+COUNTRY_CODE              IRL                                       STRING
+CREATED_DATE              2022-10-08 14:20:17.400 +0000             DATETIME
+CREATED_USER              john.clement                              STRING
+EXTERNAL_ID               4001N                                     STRING
+FID_BROKER_ID             SISS                                      STRING
+IS_ACTIVE                 true                                      BOOLEAN
+LEI_NUMBER                636400IBV22ZOU1NFS87                      STRING
+MODIFIED_DATE             2022-10-08 14:20:17.400 +0000             DATETIME
+MODIFIED_USER             john.clement                              STRING
+NAME                      Phillip N Orion ltd                       STRING
+NETTING_GROUP_ID          601                                       INT
+REGION                    UK                                        STRING
+VIEW_CODE                 SISS                                      STRING
+-------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
+Total Results:  1
+```
+
+The example above found only one record, so it displayed it. If there are multiple records that match the search criteria, these are listed one after the other on the screen. 
+
+```javascript
+DbMon:BROKER>search COUNTRY_CODE=='USA'
+==================================
+BROKER
+==================================
+Field Name                Value                                     Type
+===========================================================================================
+<Results Snipped>
+-------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
+Total Results:  6
+```
+To limit the number of results, you can supply the limit (-l) parameter to the [`search`](#dbmon-commands) command. In the example below, we repeat the previous search, but limit the number of results to the first three. 
+
+```javascript
+DbMon:BROKER>search COUNTRY_CODE=='USA' -l 3
+==================================
+BROKER
+==================================
+Field Name                Value                                     Type
+===========================================================================================
+<Results Snipped>
+-------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
+Total Results:  3
+```
+
+To string criteria together, use || for logical OR and && for logical AND. For example, if you want to [`search`](#dbmon-commands) for any `BROKER` where the `COUNTRY_CODE` is USA or IRL:
+
+```javascript
+DbMon:BROKER>search COUNTRY_CODE=='IRL'||COUNTRY_CODE=='USA'
+==================================
+BROKER
+==================================
+Field Name                Value                                     Type
+===========================================================================================
+<Results Snipped>
+-------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
+Total Results
+```
+The logical operators available are:
+
+| Symbol | Name                        |
+|--------|-----------------------------|
+| ==     | Equality (Equal To)         |
+| !=     | Non-Equality (Not Equal To) |
+| >      | Greater Than                |
+| <      | Less Than                   |
+| &&     | Logical And                 |
+| ![](/img/logical-or.png)    | Logical Or                  |
+
+### Searching with wildcards
+
+You can search using the * wildcard. Note that this might be quite slow if running against a large dataset.
+
+```jsx
+DbMon:USER_ATTRIBUTES>search USER_NAME.matches('Dealer1.*')
+==================================
+USER_ATTRIBUTES
+==================================
+Field Name                               Value                                    Type
+===========================================================================================
+<Results snipped>
+-------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------
+Total Results:  3
+```
+
+### Searching for a Datetime or Date
+
+When setting a DATE or DATETIME, the format must be specified as follows:
+
+- DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS Z"
+- DATE_FORMAT = "yyyy-MM-dd"
+
+Accepted Datetime formats:
+
+- DateTime with milliseconds precision: yyyyMMdd-HH:mm:ss.SSS
+- DateTime with seconds precision: yyyyMMdd-HH:mm:ss
+- DateTime with minutes precision: yyyyMMdd-HH:mm
+
+Accepted Date formats:
+- yyyyMMdd
+
+Here are some examples of searches for datetimes and dates:
+
+```jsx
+// if MODIFIED_DATE is 2022-10-08 14:20:17.400 in database 
+DbMon:BROKER>search MODIFIED_DATE=="20221008-14:20:17.400"
+
+// if MODIFIED_DATE is 2022-10-08 14:20:17 in database 
+DbMon:BROKER>search MODIFIED_DATE=="20221008-14:20:17"
+
+// if MODIFIED_DATE is 2022-10-08 14:20 in database 
+DbMon:BROKER>search MODIFIED_DATE>"20221008-14:20" && COUNTRY_CODE=='IRL'
+
+// if MODIFIED_DATE is 2022-10-08 in database 
+DbMon:BROKER>search MODIFIED_DATE=="20221008" || COUNTRY_CODE=='IRL'
+```
+
+Here are some examples of searches that use the distinct command to find records with a specific field value that were modified at a specific date or datetime:
+
+```jsx
+// if MODIFIED_DATE is 2022-10-08 14:20:17.400 in database 
+DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE=="20221008-14:20:17.400"
+
+// if MODIFIED_DATE is 2022-10-08 14:20:17 in database 
+DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE>"20221008-14:20:17" && IS_ACTIVE=='true'
+
+// if MODIFIED_DATE is 2022-10-08 14:20 in database 
+DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE<"20221008-14:20" || IS_ACTIVE=='true'
+
+// if MODIFIED_DATE is 2022-10-08 in database 
+DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE=="20221008"
+```
+
+
+## Counting records
+
+### Distinct
+
+In the example below, the [`distinct`](#dbmon-commands) command is used to find out how many `BROKER` records there are for each unique `COUNTRY_CODE`.
+
+```jsx
+DbMon:BROKER>distinct COUNTRY_CODE
+Distinct Value                           Count
+===========================================================================================
+AUS                                      1
+BEL                                      1
+DEU                                      1
+FRA                                      2
+GBR                                      114
+IRL                                      1
+NLD                                      2
+USA                                      6
+-------------------------------------------------------------------------------------------
+Total Results:  128
+Total Distinct Values Count:  8
+```
+
+The [`distinct`](#dbmon-commands) command also accepts a `-where` parameter, which enables you to filter the rows that are counted. 
+
+This example retrieves the count of unique `COUNTRY_CODE` for `BROKER` records that have a `REGION` of UK, but which do not have the value of `GBP` for `COUNTRY_CODE`:
+
+```jsx
+count
+countcountDbMon:BROKER>distinct COUNTRY_CODE -where REGION=='UK'&&COUNTRY_CODE!='GBR'
+Distinct Value                           Count
+===========================================================================================
+AUS                                      1
+BEL                                      1
+DEU                                      1
+FRA                                      2
+IRL                                      1
+NLD                                      2
+-------------------------------------------------------------------------------------------
+Total Results:  8
+Total Distinct Values Count:  6
+```
+
+```jsx
+DbMon:BROKER>distinct COUNTRY_CODE -where REGION=='UK'&&COUNTRY_CODE!='GBR'
+Distinct Value                           Count
+===========================================================================================
+[null]                                   8    
+-------------------------------------------------------------------------------------------
+Total Results:  8
+Total Distinct Values Count:  1
+```
+### Finding the first and last record
+If you are interested in selecting the `first` or the `last` record, you can use the `first` or `last` along with the index name. After selecting a record, to be able to see it in the dbmon, you need to run the `show` command. In the following example, we are going to select the first record in the **TRADE** table using the index **TRADE_BY_ID**, although we could perform the same operation using a view index.
+
+```javascript
+DbMon:TRADE>first TRADE_BY_ID
+DbMon:TRADE>show
+==================================
+TRADE
+==================================
+Field Name                               Value                                    Type                
+===========================================================================================
+TIMESTAMP                                2023-08-15 12:09:47.802(n:0,s:112)       NANO_TIMESTAMP      
+COUNTERPARTY_ID                          3                                        STRING              
+DIRECTION                                BUY                                      ENUM[BUY SELL]      
+ENTERED_BY                               JaneDee                                  STRING              
+INSTRUMENT_ID                            1                                        STRING              
+PRICE                                    76.0                                     DOUBLE              
+QUANTITY                                 99                                       INT                 
+SYMBOL                                   EUR                                      STRING              
+TRADE_DATE                                                                        DATE                
+TRADE_ID                                 0350e01b-7064-4c60-8bcc-6084b6bee342T... STRING              
+TRADE_STATUS                             NEW                                      ENUM[NEW ALLOCATED CANCELLED]
+```
+### Next
+
+You can also use the `next` command to select the next record in the sequence. Here is an example:
+
+```javascript
+DbMon:TRADE>next TRADE_BY_ID
+DbMon:TRADE>show
+==================================
+TRADE
+==================================
+Field Name                               Value                                    Type                
+===========================================================================================
+TIMESTAMP                                2023-08-15 12:09:10.992(n:0,s:103)       NANO_TIMESTAMP      
+COUNTERPARTY_ID                          3                                        STRING              
+DIRECTION                                BUY                                      ENUM[BUY SELL]      
+ENTERED_BY                               JaneDee                                  STRING              
+INSTRUMENT_ID                            1                                        STRING              
+PRICE                                    76.0                                     DOUBLE              
+QUANTITY                                 99                                       INT                 
+SYMBOL                                   EUR                                      STRING              
+TRADE_DATE                                                                        DATE                
+TRADE_ID                                 a4ce9a4c-21e1-416c-ae48-401eeef3f3b9T... STRING              
+TRADE_STATUS                             NEW                                      ENUM[NEW ALLOCATED CANCELLED]
+```
+
+### Counting rows (records)
 
 To discover how many rows of data there are in the currently selected table or view, use the [`count`](#dbmon-commands) command. For large database entities, this could take some time to return:
 
@@ -199,7 +479,8 @@ DbMon:BROKER>count
 The table BROKER contains 114 records
 ```
 
-### Set and Unset
+
+### Setting field values
 Use the `set` and `unset` commands to set the value of a specific field in the selected table or view. If you have previously selected a record, it will overwrite its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. 
 
 In the example below, we are viewing the **TRADE** table. The command sets a new value for the `QUANTITY` field:
@@ -221,6 +502,8 @@ DbMon:TRADE>unset QUANTITY
 :::
 The `set` and `unset` commands will not be reflected in the database unless you use `insert` with `writeMode`.
 :::
+
+## Changing the database
 
 ### Insert
 
@@ -326,335 +609,13 @@ Updated record: DbRecord [tableName=TRADE] [PRICE = 90.0, SYMBOL = EUR, QUANTITY
 To be able to use this command, you need to be in `writeMode`.
 :::
 
-## Finding data in a table or view
-
-### Find
-
-In DbMon, you can only see one record at a time. To display the record you want, you must first locate it using the [`find`](#dbmon-commands) command, which searches the table’s or view’s indexes for a given key value.  
-
-### Show keys (indexes)
-
-To see the indexes (or keys) on the selected table/view, use the [`showKeys`](#dbmon-commands) command. This displays a list of the index names and the fields you will need to supply to use the index:
-
-```javascript
-==================================
-BROKER
-==================================
-Key Name                           Field Name                               Index Type
-=======================================================
-BROKER_BY_BROKER_EXTERNAL_ID       EXTERNAL_ID                              Secondary
-------------------------------------------------------------------------------------------
-BROKER_BY_ID                       BROKER_ID                                Primary
-------------------------------------------------------------------------------------------
-BROKER_BY_TIMESTAMP                TIMESTAMP                                Secondary
-------------------------------------------------------------------------------------------
-BROKER_BY_VIEW_CODE                VIEW_CODE                                Secondary
-	------------------------------------------------------------------------------------------ 
-```
-### First and Last
-If you are interested in selecting the `first` or the `last` record, you can use the `first` or `last` along with the index name. After selecting a record, to be able to see it in the dbmon, you need to run the `show` command. In the following example, we are going to select the first record in the **TRADE** table using the index **TRADE_BY_ID**, although we could perform the same operation using a view index.
-
-```javascript
-DbMon:TRADE>first TRADE_BY_ID
-DbMon:TRADE>show
-==================================
-TRADE
-==================================
-Field Name                               Value                                    Type                
-===========================================================================================
-TIMESTAMP                                2023-08-15 12:09:47.802(n:0,s:112)       NANO_TIMESTAMP      
-COUNTERPARTY_ID                          3                                        STRING              
-DIRECTION                                BUY                                      ENUM[BUY SELL]      
-ENTERED_BY                               JaneDee                                  STRING              
-INSTRUMENT_ID                            1                                        STRING              
-PRICE                                    76.0                                     DOUBLE              
-QUANTITY                                 99                                       INT                 
-SYMBOL                                   EUR                                      STRING              
-TRADE_DATE                                                                        DATE                
-TRADE_ID                                 0350e01b-7064-4c60-8bcc-6084b6bee342T... STRING              
-TRADE_STATUS                             NEW                                      ENUM[NEW ALLOCATED CANCELLED]
-```
-### Next
-
-You can also use the `next` command to select the next record in the sequence. Here is an example:
-
-```javascript
-DbMon:TRADE>next TRADE_BY_ID
-DbMon:TRADE>show
-==================================
-TRADE
-==================================
-Field Name                               Value                                    Type                
-===========================================================================================
-TIMESTAMP                                2023-08-15 12:09:10.992(n:0,s:103)       NANO_TIMESTAMP      
-COUNTERPARTY_ID                          3                                        STRING              
-DIRECTION                                BUY                                      ENUM[BUY SELL]      
-ENTERED_BY                               JaneDee                                  STRING              
-INSTRUMENT_ID                            1                                        STRING              
-PRICE                                    76.0                                     DOUBLE              
-QUANTITY                                 99                                       INT                 
-SYMBOL                                   EUR                                      STRING              
-TRADE_DATE                                                                        DATE                
-TRADE_ID                                 a4ce9a4c-21e1-416c-ae48-401eeef3f3b9T... STRING              
-TRADE_STATUS                             NEW                                      ENUM[NEW ALLOCATED CANCELLED]
-```
-### Displaying a record - Set
-
-To display a particular record from a table or view, use the [`set`](#dbmon-commands) command to populate an index field with the value you are searching for. Then use the [`find`](#dbmon-commands) command along with the appropriate index name.
-
-The example below looks for a broker that has a `VIEW_CODE` value of “WALSH”. We have searched for the Key named `BROKER_BY_VIEW_CODE` and to use that key we whave set the `VIEW_CODE` to the value `WALSH`.
-
-```javascript
-DbMon:BROKER>set VIEW_CODE WALSH
-DbMon:BROKER>find BROKER_BY_VIEW_CODE
-DbMon:BROKER>show
-==================================
-BROKER
-==================================
-Field Name                Value                                     Type
-===========================================================================================
-TIMESTAMP                 2022-07-08 14:14:26.818(n:0,s:2630)       NANO_TIMESTAMP
-BROKER_ID                 725                                       INT
-BROKER_PARENT_ID          724                                       INT
-CODE                      114216                                    STRING
-CODE_TYPE                 Registered                                STRING
-COUNTRY_CODE              GBR                                       STRING
-CREATED_DATE              2022-12-11 11:43:53.210 +0000             DATETIME
-CREATED_USER              ismail.augustine                          STRING
-EXTERNAL_ID               725N                                      STRING
-FID_BROKER_ID             WALSH                                     STRING
-IS_ACTIVE                 true                                      BOOLEAN
-LEI_NUMBER                MP6I5ZYZBEU3UXPYFY54                      STRING
-MODIFIED_DATE             2022-03-14 09:44:25.703 +0000             DATETIME
-MODIFIED_USER             ismail.augustine                              STRING
-NAME                      WALSH Bank Plc                            STRING 
-NETTING_GROUP_ID                                                    INT
-REGION                    UK                                        STRING
-VIEW_CODE                 WALSH                                     STRING
-```
-
-If you then want to [`find`](#dbmon-commands) a record with a different `VIEW_CODE`, you need to go back to having an empty record so that you can [`set`](#dbmon-commands) the `VIEW_CODE` again and perform another [`find`](#dbmon-commands). 
-
-To do this, use the [`clear`](#dbmon-commands) command.This resets your prompt onto the table or view so that you can start again. 
-
-:::note
-The [`clear`](#dbmon-commands) command does not have any effect on the data itself, just on your “window” into the database.
-:::
-
-### Search
-
-If you wish to look for a record (or a number of records) but your criterion does not match an index on the database entity, you can use the [`search`](#dbmon-commands) command.
-
-:::warning
-For larger entities, this can be slow and risks causing latency to your application's users.
-:::
-
-For example, if you wanted to find all the records in the `BROKER` table where the `COUNTRY_CODE` was IRL, and there is no index that can be used (and there might be multiple results), the [`search`](#dbmon-commands) command would look like this:
 
 ```javascript
 DbMon:BROKER>search COUNTRY_CODE=='IRL'
 ```
 
-```javascript
-==================================
-BROKER
-==================================
-Field Name                Value                                     Type
-===========================================================================================
-TIMESTAMP                 2022-02-12 11:07:58.116339964             NANO_TIMESTAMP
-BROKER_ID                 4001                                      INT
-BROKER_PARENT_ID                                                    INT
-CODE                      223987                                    STRING
-CODE_TYPE                 Registered                                STRING
-COUNTRY_CODE              IRL                                       STRING
-CREATED_DATE              2022-10-08 14:20:17.400 +0000             DATETIME
-CREATED_USER              john.clement                              STRING
-EXTERNAL_ID               4001N                                     STRING
-FID_BROKER_ID             SISS                                      STRING
-IS_ACTIVE                 true                                      BOOLEAN
-LEI_NUMBER                636400IBV22ZOU1NFS87                      STRING
-MODIFIED_DATE             2022-10-08 14:20:17.400 +0000             DATETIME
-MODIFIED_USER             john.clement                              STRING
-NAME                      Phillip N Orion ltd                       STRING
-NETTING_GROUP_ID          601                                       INT
-REGION                    UK                                        STRING
-VIEW_CODE                 SISS                                      STRING
--------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------
-Total Results:  1
-```
-
-If there are multiple records that match the search criteria, these would all be listed one after the other on the screen. To limit the number of results, you can supply the limit (-l) parameter to the [`search`](#dbmon-commands) command. In the example below, the unlimited search returns six results. The next search, which includes the `-l 3` parameter, returns only the first three results:
-
-```javascript
-DbMon:BROKER>search COUNTRY_CODE=='USA'
-==================================
-BROKER
-==================================
-Field Name                Value                                     Type
-===========================================================================================
-<Results Snipped>
--------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------
-Total Results:  6
-
-DbMon:BROKER>search COUNTRY_CODE=='USA' -l 3
-==================================
-BROKER
-==================================
-Field Name                Value                                     Type
-===========================================================================================
-<Results Snipped>
--------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------
-Total Results:  3
-```
-
-To string criteria together, use || for logical OR and && for logical AND. For example, if you want to [`search`](#dbmon-commands) for any `BROKER` where the `COUNTRY_CODE` is USA or IRL:
-
-```javascript
-DbMon:BROKER>search COUNTRY_CODE=='IRL'||COUNTRY_CODE=='USA'
-==================================
-BROKER
-==================================
-Field Name                Value                                     Type
-===========================================================================================
-<Results Snipped>
--------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------
-Total Results
-```
-
-The logical operators available are:
-
-| Symbol | Name                        |
-|--------|-----------------------------|
-| ==     | Equality (Equal To)         |
-| !=     | Non-Equality (Not Equal To) |
-| >      | Greater Than                |
-| <      | Less Than                   |
-| &&     | Logical And                 |
-| ![](/img/logical-or.png)    | Logical Or                  |
-
-#### Searching with wildcards
-
-You can search using the * wildcard. Note that this might be quite slow if running against a large dataset.
-
-```jsx
-DbMon:USER_ATTRIBUTES>search USER_NAME.matches('Dealer1.*')
-==================================
-USER_ATTRIBUTES
-==================================
-Field Name                               Value                                    Type
-===========================================================================================
-<Results snipped>
--------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------
-Total Results:  3
-```
-
-## Datetime or Date
-
-When setting a DATE or DATETIME, the format must be specified as follows:
-
-- DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS Z"
-- DATE_FORMAT = "yyyy-MM-dd"
-
-### Searching a Datetime or Date
-
-Accepted Datetime formats:
-- DateTime with milliseconds precision: yyyyMMdd-HH:mm:ss.SSS
-- DateTime with seconds precision: yyyyMMdd-HH:mm:ss
-- DateTime with minutes precision: yyyyMMdd-HH:mm
-
-Accepted Date formats:
-- yyyyMMdd
-
-#### Using search command
-
-```jsx
-// if MODIFIED_DATE is 2022-10-08 14:20:17.400 in database 
-DbMon:BROKER>search MODIFIED_DATE=="20221008-14:20:17.400"
-
-// if MODIFIED_DATE is 2022-10-08 14:20:17 in database 
-DbMon:BROKER>search MODIFIED_DATE=="20221008-14:20:17"
-
-// if MODIFIED_DATE is 2022-10-08 14:20 in database 
-DbMon:BROKER>search MODIFIED_DATE>"20221008-14:20" && COUNTRY_CODE=='IRL'
-
-// if MODIFIED_DATE is 2022-10-08 in database 
-DbMon:BROKER>search MODIFIED_DATE=="20221008" || COUNTRY_CODE=='IRL'
-```
-
-#### Using the distinct command
-
-```jsx
-// if MODIFIED_DATE is 2022-10-08 14:20:17.400 in database 
-DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE=="20221008-14:20:17.400"
-
-// if MODIFIED_DATE is 2022-10-08 14:20:17 in database 
-DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE>"20221008-14:20:17" && IS_ACTIVE=='true'
-
-// if MODIFIED_DATE is 2022-10-08 14:20 in database 
-DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE<"20221008-14:20" || IS_ACTIVE=='true'
-
-// if MODIFIED_DATE is 2022-10-08 in database 
-DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE=="20221008"
-```
 
 
-## Counting records
-
-### Distinct
-
-In the example below, the [`distinct`](#dbmon-commands) command is used to find out how many `BROKER` records there are for each unique `COUNTRY_CODE`.
-
-```jsx
-DbMon:BROKER>distinct COUNTRY_CODE
-Distinct Value                           Count
-===========================================================================================
-AUS                                      1
-BEL                                      1
-DEU                                      1
-FRA                                      2
-GBR                                      114
-IRL                                      1
-NLD                                      2
-USA                                      6
--------------------------------------------------------------------------------------------
-Total Results:  128
-Total Distinct Values Count:  8
-```
-
-The [`distinct`](#dbmon-commands) command also accepts a `-where` parameter, which enables you to filter the rows that are counted. 
-
-This example retrieves the count of unique `COUNTRY_CODE` for `BROKER` records that have a `REGION` of UK, but which do not have the value of `GBP` for `COUNTRY_CODE`:
-
-```jsx
-count
-countcountDbMon:BROKER>distinct COUNTRY_CODE -where REGION=='UK'&&COUNTRY_CODE!='GBR'
-Distinct Value                           Count
-===========================================================================================
-AUS                                      1
-BEL                                      1
-DEU                                      1
-FRA                                      2
-IRL                                      1
-NLD                                      2
--------------------------------------------------------------------------------------------
-Total Results:  8
-Total Distinct Values Count:  6
-```
-
-```jsx
-DbMon:BROKER>distinct COUNTRY_CODE -where REGION=='UK'&&COUNTRY_CODE!='GBR'
-Distinct Value                           Count
-===========================================================================================
-[null]                                   8    
--------------------------------------------------------------------------------------------
-Total Results:  8
-Total Distinct Values Count:  1
-```
 
 ## Help
 
@@ -701,3 +662,42 @@ writeMode
 
 ## Quiet mode
 `DbMon --quietMode` performs database changes without triggering real-time updates in the update queue layer.
+
+## DbMon commands
+
+Here is a full list of DbMon commands and their arguments.
+
+| Command                              | Argument                                    | Description                                       |
+|--------------------------------------|---------------------------------------------|---------------------------------------------------|
+| autoIncrementNumber                  | `<field_name>`                              |                                                   |
+| [clear](#displaying-a-record---set)  |                                             | clear the current context                         |
+| [count](#count-rows)                 |                                             | count the rows in the table/view                  |
+| [delete](#delete)                    |                                             | delete the current row                            |
+| [deleteWhere](#deletewhere)          | `<condition>`                               | delete all matching rows in the selected table    |
+| [distinct](#distinct)                | `<condition> [-where <limiting_condition>]` | show only distinct records                        |
+| [displayFields](#display-fields)     | `<field_names>`                             | display only selected columns                     |
+| [find](#find)                        | `<key_name>`                                | find a specific record in a index                 |
+| forceAutoIncrementNumber             | `<field_name> <sequence_number>`            |                                                   |
+| forceSequenceNumber                  | `<sequence_name> <sequence_number>`         |                                                   |
+| [first](#first-and-last)             | `<key_name>`                                | get the first record by key                       |
+| help                                 |                                             | list all commands                                 |
+| [insert](#insert)                    |                                             | insert the current                                |
+| [last](#first-and-last)              | `<key_name>`                                | get the last record by key                        |
+| listAll                              | `<key_name> <num_key_fields> <max_records>` |                                                   |
+| [next](#next)                        | `<key_name>`                                | get the next record by key                        |
+| qsearch                              | `<condition> [-l <limit>]`                  |                                                   |
+| qshow                                |                                             |                                                   |
+| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that match the criteria        |
+| [set](#set-and-unset)                | `<field_name> <field_value>`                | set a field                                       |
+| sequenceNumber                       | `<sequence_name>`                           |                                                   |
+| [show](#show)                        |                                             | display the current record                        |
+| [showKeys](#show-keys-indexes)       |                                             | display all indexes                               |
+| [showTables](#show-tables-and-views) |                                             | display all tables in the schema                  |
+| [showViews](#show-tables-and-views)  |                                             | display all views in the schema                   |
+| [table](#table)                      | `<table_name>`                              | select an specified table                         |
+| [unset](#set-and-unset)              | `<field>`                                   | set a field to `null`                             |
+| [update](#update)                    | `<key_name>` `<fields>`                     | update the current row by key                     |
+| [updateWhere](#updatewhere)          | `<condition> <assignments>`                 | update all records that matches a given condition |
+| [view](#view)                        | `<view_name>`                               | select an specified view                          |
+| writeMode                            |                                             | enable write mode                                 |
+

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -12,7 +12,9 @@ tags:
 
 # DbMon
 
-DbMon is the Genesis database client. It provides an interface to the underlying database and hides the details about the specific database technology. Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon. This page gives details of all the DbMon commands and provides practical examples of how you can use them.
+DbMon is the Genesis database client. It provides a set of commands that enable you to view and change the database as necessary. DbMon hides the details of the specific database technology, so this does not affect your usage. 
+
+Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon. This page gives details of all the DbMon commands and provides practical examples of how you can use them.
 
 ## DbMon commands
 
@@ -25,31 +27,31 @@ The commands available with DbMon are listed below.
 | [count](#count-rows)                 |                                             | count the rows in the table/view                  |
 | [delete](#delete)                    |                                             | delete the current row                            |
 | [deleteWhere](#deletewhere)          | `<condition>`                               | delete all matching rows in the selected table    |
-| [distinct](#distinct)                | `<condition> [-where <limiting_condition>]` | show only distinct records                         |
-| [displayFields](#display-fields)     | `<field_names>`                             | display only selected columns                      |
+| [distinct](#distinct)                | `<condition> [-where <limiting_condition>]` | show only distinct records                        |
+| [displayFields](#display-fields)     | `<field_names>`                             | display only selected columns                     |
 | [find](#find)                        | `<key_name>`                                | find a specific record in a index                 |
-| forceAutoIncrementNumber             | `<field_name> <sequence_number>`            |                                                    |
-| forceSequenceNumber                  | `<sequence_name> <sequence_number>`         |                                                    |
+| forceAutoIncrementNumber             | `<field_name> <sequence_number>`            |                                                   |
+| forceSequenceNumber                  | `<sequence_name> <sequence_number>`         |                                                   |
 | [first](#first-and-last)             | `<key_name>`                                | get the first record by key                       |
 | help                                 |                                             | list all commands                                 |
 | [insert](#insert)                    |                                             | insert the current                                |
 | [last](#first-and-last)              | `<key_name>`                                | get the last record by key                        |
-| listAll                              | `<key_name> <num_key_fields> <max_records>` |                                                    |
+| listAll                              | `<key_name> <num_key_fields> <max_records>` |                                                   |
 | [next](#next)                        | `<key_name>`                                | get the next record by key                        |
-| qsearch                              | `<condition> [-l <limit>]`                  |                                                    |
-| qshow                                |                                             |                                                    |
-| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that match the criteria  |
+| qsearch                              | `<condition> [-l <limit>]`                  |                                                   |
+| qshow                                |                                             |                                                   |
+| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that match the criteria        |
 | [set](#set-and-unset)                | `<field_name> <field_value>`                | set a field                                       |
-| sequenceNumber                       | `<sequence_name>`                           |                                                    |
-| [show](#show)                        |                                             | display the current record                         |
-| [showKeys](#show-keys-indexes)       |                                             | display all indexes                                |
-| [showTables](#show-tables-and-views) |                                             | display all tables in the schema                   |
-| [showViews](#show-tables-and-views)  |                                             | display all views in the schema                    |
-| [table](#table)                      | `<table_name>`                              | select an specified table                          |
+| sequenceNumber                       | `<sequence_name>`                           |                                                   |
+| [show](#show)                        |                                             | display the current record                        |
+| [showKeys](#show-keys-indexes)       |                                             | display all indexes                               |
+| [showTables](#show-tables-and-views) |                                             | display all tables in the schema                  |
+| [showViews](#show-tables-and-views)  |                                             | display all views in the schema                   |
+| [table](#table)                      | `<table_name>`                              | select an specified table                         |
 | [unset](#set-and-unset)              | `<field>`                                   | set a field to `null`                             |
 | [update](#update)                    | `<key_name>` `<fields>`                     | update the current row by key                     |
 | [updateWhere](#updatewhere)          | `<condition> <assignments>`                 | update all records that matches a given condition |
-| [view](#view)                        | `<view_name>`                               | select an specified view                           |
+| [view](#view)                        | `<view_name>`                               | select an specified view                          |
 | writeMode                            |                                             | enable write mode                                 |
 
 ## Starting DbMon
@@ -76,11 +78,16 @@ To end a DbMon session, just type [`quit`](#dbmon-commands) at the DbMon prompt.
 
 ## Working with tables and views
 
-Most of the time, you'll be using DbMon to examine tables or views in one way or another. Write operations are not allowed on views. 
+Most of the time, you'll be using DbMon to work on a specific table or view. DbMon enables you to: 
 
+- find all the tables in your database (`showTables`)
+- select a table to work on (`table`)
+- find all the views in your database (`showViews`)
+- select a view to work on (`view`)
+- 
 ### Show tables and views
 
-To see a list of available tables or views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) commands. This displays an alphabetical list of available tables or views, for example:
+To see a list of available tables or views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) commands. This displays an alphabetical list of available tables or views. For example, here we have used the command `showTables`:
 
 ```javascript
 ==================================
@@ -123,7 +130,7 @@ DbMon:BROKER_VIEW>
 
 ### Show
 
-To see the columns available in the selected table or view, use the [`show`](#dbmon-commands) command. This displays the current record in the selected table or view. If no record has been selected, it displays an empty record (notice the value column in the example below is not populated):
+To see the columns available in the currently selected table or view, use the [`show`](#dbmon-commands) command. This displays the columns (fields) for the current record. If no record has been selected, it displays an empty record (as you can see in the example below, where the value column is not populated):
 
 ```javascript
 ==================================
@@ -155,8 +162,9 @@ VIEW_CODE                                                           STRING
 
 If you are only interested in seeing selected columns, use the [`displayFields`](#dbmon-commands) command and list the names of the columns you are interested in (separated by spaces). 
 
-Any subsequent [`show`](#dbmon-commands) commands will only display those columns, rather than all the columns in the table/view.
+While you continue to work on the selected table or view, subsequent [`show`](#dbmon-commands) commands will only display those columns. To view all the columns again, use the [`displayFields`](#dbmon-commands) command followed by no column names.
 
+In the example below, we have used `displayFields` to view four specific columns:
 
 ```javascript
 DbMon:BROKER>displayFields BROKER_ID NAME REGION COUNTRY_CODE
@@ -174,11 +182,11 @@ REGION                                                              STRING
 DbMon:BROKER>displayFields
 Display fields reset!
 ```
-To view all columns again, use the [`displayFields`](#dbmon-commands) command followed by no column names.
+
 
 ### Count rows
 
-To discover how many rows of data there are in a table or view, use the [`count`](#dbmon-commands) command. For large database entities, this could take some time to return:
+To discover how many rows of data there are in the currently selected table or view, use the [`count`](#dbmon-commands) command. For large database entities, this could take some time to return:
 
 ```javascript
 DbMon:BROKER>count
@@ -186,7 +194,7 @@ The table BROKER contains 114 records
 ```
 
 ### Set and Unset
-Use the `set` and `unset` commands to set the value of a specific field in the selected database entity. If you have previously selected a record, it will overwrite its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. 
+Use the `set` and `unset` commands to set the value of a specific field in the selected table or view. If you have previously selected a record, it will overwrite its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. 
 
 In the example below, we are viewing the **TRADE** table. The command sets a new value for the `QUANTITY` field:
 

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -418,7 +418,7 @@ Total Distinct Values Count:  6
 So, what has this found?
 
 - At the bottom, the Total Results is 8. There are 8 records where the region is UK but the country code is not GBR.
-- The Distinct Values is 6. There are 6 Country Codes where the region is UK but the country code is not GBR. These are the six rows displayed.
+- The Distinct Values is 6. There are 6 Country Codes where the region is UK, but whose country code is not GBR. These are the six rows displayed.
  
 Note that there is no validation of the field when you use the `distinct` command. So if we ran the previous example, but we incorrectly typed `COUNTRY_COD` instead of `COUNTRY_CODE`. The command would still work, but the result is potentially confusing.
 
@@ -433,13 +433,16 @@ Total Distinct Values Count:  1
 ```
 
 So, what happened there?
+
 - There are no instances of `Country_COD`, so the only Distinct Value is [null].
 - However, the count is still 8 for this line, because there are 8 records where the region is UK but the country code is not GBR.
 - The Total Results value is the sum of the counts: 8. If your field was invalid, then the Total Results will always equal the count because there is only one value found - null.
 - The Total Distinct Values Count is effectively the number of rows: 1. Only one value was found  - null.
  
 ### Finding the first and last record
-If you are interested in selecting the `first` or the `last` record, you can use the `first` or `last` along with the index name. After selecting a record, to be able to see it in the dbmon, you need to run the `show` command. In the following example, we are going to select the first record in the **TRADE** table using the index **TRADE_BY_ID**, although we could perform the same operation using a view index.
+If you are interested in selecting the `first` or the `last` record, you can use the `first` or `last` along with the index name. You need to run the `show` command to view that record. 
+
+In the following example, we select the first record in the **TRADE** table using the index **TRADE_BY_ID**; we then use `show` to see the record.
 
 ```javascript
 DbMon:TRADE>first TRADE_BY_ID
@@ -463,7 +466,7 @@ TRADE_STATUS                             NEW                                    
 ```
 ### Displaying the next record
 
-You can also use the `next` command to select the next record in the sequence. Here is an example:
+To view the next record in the currently selected table or view, use the `next` command and then the `show` command.
 
 ```javascript
 DbMon:TRADE>next TRADE_BY_ID
@@ -490,19 +493,20 @@ TRADE_STATUS                             NEW                                    
 
 Whenever you make a change to the database, you must use first the command `writeMode`. This is designed to protect the database against casual or unintended changes.
 
-To change a field value:
+To change a field value in a record:
 
 1. Find the table or view that the field belongs to.
 2. Select that table or view.
-3. Set the value of the field.
-4. Run `writeMode`.
-5. Insert the new value.
+3. Find and show the record that you want to change.
+4. Set the value of the field.
+5. Run `writeMode`.
+6. Insert the new value.
 
 
 ### Changing the value of a field
-The `set` command enables you to set the value of a specific field in the selected table or view. You need to do this before you write to the database. The `set` command itself does not change the database.
+The `set` command enables you to set the value of a specific field in the record you are viewing from the currently selected table or view. You need to set the value before you write to the database. The `set` command itself does not change the database. This protects the database from casual changes.
 
-In the example below, we are viewing the **TRADE** table. The command sets a new value for the `QUANTITY` field:
+In the example below, we are viewing a record in the **TRADE** table. The command sets a new value for the `QUANTITY` field:
 
 ``` javascript
 DbMon:TRADE>set QUANTITY 10

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -360,7 +360,7 @@ The table BROKER contains 114 records
 
 ### Finding distinct records
 
-The `distinct` command provides another useful way of searching. Here are some examples of searches that use the distinct command to find records with a specific field value that were modified at a specific date or datetime:
+The `distinct` command provides another useful way of searching. Here are some examples of searches that use the distinct command to find records with a specific field value, which were modified at a specific date or datetime:
 
 ```jsx
 // if MODIFIED_DATE is 2022-10-08 14:20:17.400 in database 

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -12,7 +12,7 @@ tags:
 
 # DbMon
 
-DbMon is the Genesis database client. It provides an interface to the underlying database and hides the details about the specific database technology. Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon.  This page gives details of all the DbMon commands and provides practical examples of how you can use them.
+DbMon is the Genesis database client. It provides an interface to the underlying database and hides the details about the specific database technology. Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon. This page gives details of all the DbMon commands and provides practical examples of how you can use them.
 
 ## DbMon commands
 
@@ -21,36 +21,36 @@ The commands available with DbMon are listed below.
 | Command                              | Argument                                    | Description                                        |
 |--------------------------------------|---------------------------------------------|----------------------------------------------------|
 | autoIncrementNumber                  | `<field_name>`                              |                                                    |
-| [clear](#displaying-a-record---set)  |                                             | clears the current context                         |
-| [count](#count-rows)                 |                                             | counts the rows in the table/view                  |
-| [delete](#delete)                    |                                             | deletes the current row                            |
-| [deleteWhere](#deletewhere)          | `<condition>`                               | deletes all matching rows in the selected table    |
+| [clear](#displaying-a-record---set)  |                                             | clear the current context                         |
+| [count](#count-rows)                 |                                             | count the rows in the table/view                  |
+| [delete](#delete)                    |                                             | delete the current row                            |
+| [deleteWhere](#deletewhere)          | `<condition>`                               | delete all matching rows in the selected table    |
 | [distinct](#distinct)                | `<condition> [-where <limiting_condition>]` | show only distinct records                         |
 | [displayFields](#display-fields)     | `<field_names>`                             | display only selected columns                      |
-| [find](#find)                        | `<key_name>`                                | find an specific record in a index                 |
+| [find](#find)                        | `<key_name>`                                | find a specific record in a index                 |
 | forceAutoIncrementNumber             | `<field_name> <sequence_number>`            |                                                    |
 | forceSequenceNumber                  | `<sequence_name> <sequence_number>`         |                                                    |
-| [first](#first-and-last)             | `<key_name>`                                | gets the first record by key                       |
-| help                                 |                                             | lists all commands                                 |
-| [insert](#insert)                    |                                             | inserts the current                                |
-| [last](#first-and-last)              | `<key_name>`                                | gets the last record by key                        |
+| [first](#first-and-last)             | `<key_name>`                                | get the first record by key                       |
+| help                                 |                                             | list all commands                                 |
+| [insert](#insert)                    |                                             | insert the current                                |
+| [last](#first-and-last)              | `<key_name>`                                | get the last record by key                        |
 | listAll                              | `<key_name> <num_key_fields> <max_records>` |                                                    |
-| [next](#next)                        | `<key_name>`                                | gets the next record by key                        |
+| [next](#next)                        | `<key_name>`                                | get the next record by key                        |
 | qsearch                              | `<condition> [-l <limit>]`                  |                                                    |
 | qshow                                |                                             |                                                    |
-| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that matches with the criteria  |
-| [set](#set-and-unset)                | `<field_name> <field_value>`                | sets a field                                       |
+| [search](#search)                    | `<condition> [-l <limit>]`                  | return the records that match the criteria  |
+| [set](#set-and-unset)                | `<field_name> <field_value>`                | set a field                                       |
 | sequenceNumber                       | `<sequence_name>`                           |                                                    |
 | [show](#show)                        |                                             | display the current record                         |
 | [showKeys](#show-keys-indexes)       |                                             | display all indexes                                |
 | [showTables](#show-tables-and-views) |                                             | display all tables in the schema                   |
 | [showViews](#show-tables-and-views)  |                                             | display all views in the schema                    |
 | [table](#table)                      | `<table_name>`                              | select an specified table                          |
-| [unset](#set-and-unset)              | `<field>`                                   | sets a field to `null`                             |
-| [update](#update)                    | `<key_name>` `<fields>`                     | updates the current row by key                     |
-| [updateWhere](#updatewhere)          | `<condition> <assignments>`                 | updates all records that matches a given condition |
+| [unset](#set-and-unset)              | `<field>`                                   | set a field to `null`                             |
+| [update](#update)                    | `<key_name>` `<fields>`                     | update the current row by key                     |
+| [updateWhere](#updatewhere)          | `<condition> <assignments>`                 | update all records that matches a given condition |
 | [view](#view)                        | `<view_name>`                               | select an specified view                           |
-| writeMode                            |                                             | enables write mode                                 |
+| writeMode                            |                                             | enable write mode                                 |
 
 ## Starting DbMon
 
@@ -80,7 +80,7 @@ Most of the time, you'll be using DbMon to examine tables or views in one way or
 
 ### Show tables and views
 
-To see a list of available tables/views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) commands. This displays an alphabetical list of available tables or views, for example:
+To see a list of available tables or views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) commands. This displays an alphabetical list of available tables or views, for example:
 
 ```javascript
 ==================================
@@ -109,7 +109,7 @@ To look at the data held in a specific table, use the [`table`](#dbmon-commands)
 
 ### View
 
-To look at the data held in a specific view, use the [`view`](#dbmon-commands) command followed by the view name: for example `view POSITION_VIEW`. Once you have selected a view, the `DbMon` prompt changes to show the view name.
+To look at the data held in a specific view, use the [`view`](#dbmon-commands) command followed by the view name: for example `view BROKER`. Once you have selected a view, the `DbMon` prompt changes to show the view name.
 
 ```javascript
 DbMon>table BROKER
@@ -118,7 +118,7 @@ DbMon:BROKER>
 
 ### Show
 
-To see the columns available in the selected table/view use the [`show`](#dbmon-commands) command. This displays the current record in the selected table/view. If no record has been selected, it displays an empty record (notice the value column below is not populated):
+To see the columns available in the selected table or view, use the [`show`](#dbmon-commands) command. This displays the current record in the selected table or view. If no record has been selected, it displays an empty record (notice the value column in the example below is not populated):
 
 ```javascript
 ==================================
@@ -173,7 +173,7 @@ To view all columns again, use the [`displayFields`](#dbmon-commands) command fo
 
 ### Count rows
 
-To discover how many rows of data there are in a table/view, use the [`count`](#dbmon-commands) command. For large database entities, this could take some time to return:
+To discover how many rows of data there are in a table or view, use the [`count`](#dbmon-commands) command. For large database entities, this could take some time to return:
 
 ```javascript
 DbMon:BROKER>count
@@ -181,7 +181,7 @@ The table BROKER contains 114 records
 ```
 
 ### Set and Unset
-The `set` and `unset` commands are used to set the value of a specific field in the selected database entity. If you have previously selected a record, it will override its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. In the example below, we set a new value for the `QUANTITY` field:
+Use the `set` and `unset` commands to set the value of a specific field in the selected database entity. If you have previously selected a record, it will overwrite its value; otherwise, it sets a new record (note that this is only local - to insert a new record to the table, use the insert command). In the case of the `set` command, specify the value you want to set. In the example below, we set a new value for the `QUANTITY` field:
 
 ``` javascript
 DbMon:TRADE>set QUANTITY = 10
@@ -190,7 +190,7 @@ DbMon:TRADE>set QUANTITY = 10
 To set the value to **null**, use the `unset` command, for example:
 
 ``` javascript
-DbMon:TRADE>set QUANTITY = 10
+DbMon:TRADE>unset QUANTITY 
 ```
 
 :::tip
@@ -199,9 +199,9 @@ Changes performed by `set` and `unset` will not be reflected in the database unl
 
 ### Insert
 
-If you are interested in inserting a new record to the database, you can use the `insert`. This command wil insert a new record based on the current record selected. Before y insert this new record, you need to enable the `writeMode`. 
+To insert a new record into the database, use the `insert` command. This inserts a new record based on the current record selected. Before you insert this new record, you must enable `writeMode`. 
 
-In the example below, we make use of the `set` command to create a new record before inserting it into the database.
+In the example below, we use the `set` command to create a new record before inserting it into the database.
 
 ``` javascript
 DbMon:TRADE>set PRICE 80
@@ -232,11 +232,11 @@ Record saved
 
 ### Delete rows
 
-If you would like to delete a row from a table manually using DbMon, then you should use the `delete` or `deleteWhere`. Note that to perform a delete operation, you must run `writeMode` to enable the write mode.
+To delete a row from a table manually using DbMon, use the `delete` or `deleteWhere` command. before you perform a delete operation, you must run `writeMode` to enable write mode.
 
 #### Delete
 
-If you use the `delete` command, it will delete the selected record in the selected table. Here is an example of how to use `delete`, it is deleting the last record in the **TRADE** table:
+Use the `delete` command to delete the selected record in the selected table. The example below deletes the last record in the **TRADE** table:
 
 ```javascript
 DbMon:TRADE>writeMode
@@ -251,9 +251,9 @@ To be able to use this command, you need to be in `writeMode`.
 
 #### deleteWhere
 
-If you use the `deleteWhere` command, it will delete all records in the selected table that matches the specified criteria. After the confirmation, it will prompt all the records that have been deleted.
+The `deleteWhere` command finds all records that match the specified criteria in the currently selected table. Before deleting, it asks you to confirm the deletion.
 
-Here is an example of how to use `deleteWhere`. In this example, we are deleting all records in **TRADE** table with **QUANTITY** values grater than 100.
+In the example below, the currently selected table is **TRADE**. We delete all records that have a **QUANTITY** value greater than 100.
 
 ```javascript
 DbMon:TRADE>writeMode
@@ -270,10 +270,10 @@ To be able to use this command, you need to be in `writeMode`.
 :::
 
 ### Update rows
-If you would like to perform an update in the database manually using DbMon, then you should use the `update` or `updateWhere`. Note that to perform a update operation, you must run `writeMode` to enable the write mode.
+To perform an update in the database manually using DbMon, use the `update` or `updateWhere` command. Note that to perform an update operation, you must first run `writeMode` to enable write mode.
 
 #### Update
-If you use the `update` command, it will update the given fields in the selected row in the selected table. Use the commands `set` and `unset` to manipulate the selected row before you run `update`. To be able to use `update`, you need to provide a `key_name`. Here is an example of how to use the `update` command to update the field PRICE in the **TRADE** table.
+The `update` command updates the given fields in the selected row of the currently selected table. Use the commands `set` and `unset` to manipulate the selected row before you run `update`. To use `update`, you must provide a `key_name`. In the example below, **TRADE** is the currently selected table. We use the `set` command to set the PRICE field to 50, and then `update` command to update the TRADE_BY_UPDATE_PRICE.
 
 ```javascript
 DbMon:TRADE>writeMode
@@ -285,7 +285,7 @@ Record updated
 ```
 
 #### UpdateWhere
-If you use the `updateWhere` command, it will update all records in the selected table hat matches with the specified criteria. After the confirmation, it will prompt all the records that have been updated.
+Use the `updateWhere` command to update all records that match specific criteria. After the confirmation, it will prompt all the records that have been updated.
 
 Here is an example of how to use `updateWhere`. In this example, we are updating the `QUANTITY` value to 10 to all records in **TRADE** with `id = genesis1`.
 
@@ -530,7 +530,7 @@ Total Results:  3
 
 ## Datetime or Date
 
-When setting a DATE or DATETIME, the format must be specified as follow:
+When setting a DATE or DATETIME, the format must be specified as follows:
 
 - DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS Z"
 - DATE_FORMAT = "yyyy-MM-dd"
@@ -561,7 +561,7 @@ DbMon:BROKER>search MODIFIED_DATE>"20221008-14:20" && COUNTRY_CODE=='IRL'
 DbMon:BROKER>search MODIFIED_DATE=="20221008" || COUNTRY_CODE=='IRL'
 ```
 
-#### Using distinct command
+#### Using the distinct command
 
 ```jsx
 // if MODIFIED_DATE is 2022-10-08 14:20:17.400 in database 

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -14,7 +14,7 @@ tags:
 
 DbMon is the Genesis database client. It provides a set of commands that enable you to view and change the database as necessary. DbMon hides the details of the specific database technology, so this does not affect your usage. 
 
-Generic database clients can be used with the Genesis low-code platform, but we recommend that you use DbMon. 
+You can use Generic database clients to work with the Genesis low-code platform, but we recommend that you use DbMon. 
 
 This page gives details of all the DbMon commands and provides practical examples of how you can use them.
 
@@ -37,7 +37,7 @@ As you can see, once you are in a DbMon session, the `DbMon>` prompt is displaye
 
 ## Exiting DbMon
 
-To end a DbMon session, just type [`quit`](#dbmon-commands) at the DbMon prompt.
+To end a DbMon session, just type [`quit`](#dbmon-commands) at the `DbMon>` prompt.
 
 ## Finding and viewing information
 
@@ -48,9 +48,8 @@ A Genesis database organises information in tables and views. DbMon enables you 
 - find all the views in your database (`showViews`)
 - select a view to examine (`view`)
 
-### Show tables and views
 
-To see a list of available tables or views, use the [`showTables`](#dbmon-commands) or the [`showViews`](#dbmon-commands) command. This displays an alphabetical list of available tables or views. For example, here we have used the command `showTables`:
+The [`showTables`](#dbmon-commands) and [`showViews`](#dbmon-commands) commands display an alphabetical list of available tables or views. For example, here we have used the command `showTables`:
 
 ```javascript
 ==================================
@@ -73,7 +72,7 @@ BROKER
 <<List continues...>>
 ```
 
-### Table
+### Selecting a table
 
 To look at the data held in a specific table, use the [`table`](#dbmon-commands) command followed by the table name: for example `table BROKER`. Once you have selected a table, the `DbMon` prompt changes to show the table name.
 
@@ -82,7 +81,7 @@ DbMon>table BROKER
 DbMon:BROKER>
 ```
 
-### View
+### Selecting a view
 
 To look at the data held in a specific view, use the [`view`](#dbmon-commands) command followed by the view name: for example `view BROKER_VIEW`. Once you have selected a view, the `DbMon` prompt changes to show the view name.
 
@@ -152,9 +151,10 @@ In DbMon you can only see one record at a time.
 
 To display the record you want, use the `find` command, which searches the table’s indices for a given key value.  
 
-So you need to know what the indices (keys) are for the currently selected table; use the `showKeys` command. This lists each key (index), along with the field name you need to supply to use the index.  In the example below, the BROKER table has a primary index (BROKER_BY_ID, where the relevant field is BROKER_ID) and three secondary indices.
+So you need to know what the indices (keys) are for the currently selected table or view; for this, use the `showKeys` command. This lists each key (index), along with the field name you need to supply to use the index.  In the example below, the BROKER table has a primary index (BROKER_BY_ID, where the relevant field is BROKER_ID) and three secondary indices.
 
 ```javascript
+DbMon:BROKER>showKeys
 ==================================
 BROKER
 ==================================
@@ -172,7 +172,7 @@ BROKER_BY_VIEW_CODE                VIEW_CODE                                Seco
 
 Now that you know the indices and the fields they require, you can find a record in the table or view.
 
-The example below looks for a broker that has a `VIEW_CODE` value of “WALSH”. 
+The example below looks for a broker that has a `VIEW_CODE` value of `WALSH`. 
 
 1. The `set` command sets the value of the `VIEW_CODE` to the value `WALSH`. _This is a local setting; it does not change the database._
 2. The `find` command looks for the index (key) `BROKER_BY_VIEW_CODE`.
@@ -207,12 +207,12 @@ REGION                    UK                                        STRING
 VIEW_CODE                 WALSH                                     STRING
 ```
 
-If you then want to [`find`](#dbmon-commands) a record with a different `VIEW_CODE`, you need to go back to having an empty record so that you can [`set`](#dbmon-commands) the `VIEW_CODE` again and perform another [`find`](#dbmon-commands). 
+If you then want to find a record with a different `VIEW_CODE`, use the [`clear`](#dbmon-commands) command to clear the record. You can then use [`set`](#dbmon-commands) and [`find`](#dbmon-commands) commands to locate the new record.
 
-To do this, use the [`clear`](#dbmon-commands) command. This resets your prompt onto the table or view so that you can start again. _This is a local setting; it does not change the database._
+_The `clear` command does not change the database._
 
 ## Searching for one or more records
-To look for a record (or a number of records) without using an index (key), use the `search` command. This lists all the records that match the criteria that you supply.
+To look for a record (or a number of records) without using an index (key), use the [`search`](#dbmon-commands) command. This lists all the records that match the criteria that you supply.
 
 :::warning
 For larger tables, this can be slow and could cause latency to users of your application.
@@ -279,7 +279,7 @@ Field Name                Value                                     Type
 Total Results:  3
 ```
 
-To string criteria together, use || for logical OR and && for logical AND. For example, if you want to [`search`](#dbmon-commands) for any `BROKER` where the `COUNTRY_CODE` is USA or IRL:
+To join criteria together, use || for logical OR and && for logical AND. For example, if you want to [`search`](#dbmon-commands) for any `BROKER` where the `COUNTRY_CODE` is USA or IRL:
 
 ```javascript
 DbMon:BROKER>search COUNTRY_CODE=='IRL'||COUNTRY_CODE=='USA'
@@ -306,7 +306,7 @@ The logical operators available are:
 
 ### Searching with wildcards
 
-You can search using the * wildcard. Note that this might be quite slow if running against a large dataset.
+You can search using the * wildcard. Note that this might be quite slow if running against a large dataset. For example:
 
 ```jsx
 DbMon:USER_ATTRIBUTES>search USER_NAME.matches('Dealer1.*')
@@ -321,21 +321,17 @@ Field Name                               Value                                  
 Total Results:  3
 ```
 
-### Searching for a Datetime or Date
+### Searching for a date or datetime
 
-When setting a DATE or DATETIME, the format must be specified as follows:
+When setting a DATE, the format must be specified as follows:
 
-- DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS Z"
-- DATE_FORMAT = "yyyy-MM-dd"
+- DATE_FORMAT = "yyyyMMdd"
 
-Accepted Datetime formats:
+When setting a DATETIME, the format must be specified as follows:
 
-- DateTime with milliseconds precision: yyyyMMdd-HH:mm:ss.SSS
-- DateTime with seconds precision: yyyyMMdd-HH:mm:ss
-- DateTime with minutes precision: yyyyMMdd-HH:mm
-
-Accepted Date formats:
-- yyyyMMdd
+- DateTime with milliseconds precision: DATETIME_FORMAT = "yyyyMMdd-HH:mm:ss.SSS"
+- DateTime with seconds precision: DATETIME_FORMAT = "yyyyMMdd-HH:mm:ss"
+- DateTime with minutes precision: DATETIME_FORMAT = "yyyyMMdd-HH:mm"
 
 Here are some examples of searches for datetimes and dates:
 

--- a/docs/05_operations/02_commands/02_dbmon.md
+++ b/docs/05_operations/02_commands/02_dbmon.md
@@ -20,9 +20,9 @@ Generic database clients can be used with the Genesis low-code platform, but we 
 
 The commands available with DbMon are listed below. 
 
-| Command                              | Argument                                    | Description                                        |
-|--------------------------------------|---------------------------------------------|----------------------------------------------------|
-| autoIncrementNumber                  | `<field_name>`                              |                                                    |
+| Command                              | Argument                                    | Description                                       |
+|--------------------------------------|---------------------------------------------|---------------------------------------------------|
+| autoIncrementNumber                  | `<field_name>`                              |                                                   |
 | [clear](#displaying-a-record---set)  |                                             | clear the current context                         |
 | [count](#count-rows)                 |                                             | count the rows in the table/view                  |
 | [delete](#delete)                    |                                             | delete the current row                            |
@@ -75,6 +75,12 @@ As you can see, once you are in a DbMon session, the `DbMon>` prompt is displaye
 ## Exiting DbMon
 
 To end a DbMon session, just type [`quit`](#dbmon-commands) at the DbMon prompt.
+
+## Making changes safely
+
+When you run DbMon, it creates a local image of your database. This enables you to look at values and safely change them locally without writing to the database.
+
+If you then want to make changes to the database, you must first enable `writeMode`. 
 
 ## Working with tables and views
 
@@ -199,17 +205,21 @@ Use the `set` and `unset` commands to set the value of a specific field in the s
 In the example below, we are viewing the **TRADE** table. The command sets a new value for the `QUANTITY` field:
 
 ``` javascript
-DbMon:TRADE>set QUANTITY = 10
+DbMon:TRADE>set QUANTITY 10
 ```
+In the example below, we are viewing the **TRADE** table. We set new values for the `PRICE` and `QUANTITY` fields:
 
-To set the value to **null**, use the `unset` command, for example:
+``` javascript
+DbMon:TRADE>set PRICE,QUANTITY 523.1,9000
+```
+To set a value to **null**, use the `unset` command, for example:
 
 ``` javascript
 DbMon:TRADE>unset QUANTITY 
 ```
 
-:::tip
-Changes performed by `set` and `unset` will not be reflected in the database unless you use `insert` with `writeMode`.
+:::
+The `set` and `unset` commands will not be reflected in the database unless you use `insert` with `writeMode`.
 :::
 
 ### Insert
@@ -597,7 +607,7 @@ DbMon:BROKER>distinct BROKER_ID -where MODIFIED_DATE=="20221008"
 
 ### Distinct
 
-In this example, the [`distinct`](#dbmon-commands) command is used to find out how many `BROKER` records there are for each unique `COUNTRY_CODE`.
+In the example below, the [`distinct`](#dbmon-commands) command is used to find out how many `BROKER` records there are for each unique `COUNTRY_CODE`.
 
 ```jsx
 DbMon:BROKER>distinct COUNTRY_CODE


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
GSF-5842

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

