### PR TITLE
PTL-926: Improve text-field component page

### DIFF
--- a/docs/04_web/02_web-components/01_form/14_text-field.md
+++ b/docs/04_web/02_web-components/01_form/14_text-field.md
@@ -31,7 +31,7 @@ You can define the following attributes in an `<alpha-text-field>`.
 | maxlength   | `number`  | The maximum number of characters allowed                                             |
 | minlength   | `number`  | The minimum number of characters allowed                                             |
 | name        | `string`  | Define the name of the element                                                       |
-| placeholder | `string`  | Sets a placeholder for the element                                                   |
+| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing) |
 | readonly    | `boolean` | If true, the user cannot change the value of this field                              |
 | size        | `number`  | Sets the width of the component                                                      |
 | step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
@@ -62,7 +62,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-In order to use a value input to this component, follow these two steps:
+Once the user has input a value to this component, you need to make that value or text accessible to the application:
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/docs/04_web/02_web-components/01_form/14_text-field.md
+++ b/docs/04_web/02_web-components/01_form/14_text-field.md
@@ -8,10 +8,9 @@ tags:
     - web components
     - text field
 ---
-An implementation of a [text field](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/text) as a form-connected Web Component. The `alpha-text-field` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
 
-This component filters out slotted _text_ nodes that are only white space to hide the label when it is not in use.
-
+A text field is an interactive or graphical web component that allows users to input and edit textual information.
+It is a fundamental component of forms, dialogs and user interfaces.
 ## Set-up
 
 ```ts
@@ -20,18 +19,79 @@ import { provideDesignSystem, alphaTextField } from '@genesislcap/alpha-design-s
 provideDesignSystem().register(alphaTextField());
 ```
 
-## Usage
+## Attributes
 
-```html live
-<alpha-text-field>Name</alpha-text-field>
+Below you will find the attributes accepted in the `<alpha-text-field>`.
+
+| Name        | Type      | Description                                                                    |
+|-------------|-----------|--------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will focused when the  page finished loading          |
+| appearance  | `string`  | Can be `outline` or `filled`                                                   |
+| maxlength   | `number`  | The maximum number of characters allowed                                       |
+| minlength   | `number`  | The minimum number of characters allowed                                       |
+| placeholder | `string`  | Sets a placeholder for the element                                             |
+| readOnly    | `boolean` | If true, the user cannot change this its value                                 |
+| size        | `number`  | Sets the width of the component                                                |
+| type        | `string`  | Set the type of th text-field. Can be {"email", "password","tel","text","url"} | 
+| value       | `string`  | Set the value for this component                                               | 
+
+These attributes need to be defined alongside the declaration of the component.
+
+## Usage
+All examples below are using the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
+
+- **Example 1**: a text-field with a max length of 10 characters and a placeholder
+```html title="Example 1"
+<alpha-text-field maxlength="10" placeholder="This is a placeholder">Name</alpha-text-field>
+```
+- **Example 2**: a text-field with a size of 30 and type `password`
+```html title="Example 2"
+<alpha-text-field size="30" type="password">Name</alpha-text-field>
+```
+- **Example 3**: a text-field read only wit a placeholder
+```html title="Example 3"
+<alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
+```
+
+### Get the user input
+In order to use the value inputted in this component, you need to follow these two steps
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+    ...
+    @observable text_field: string
+    ...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-text-field value=${sync((x) => x.text_field)}>TEXT</alpha-text-field>
+    ...
+...    
+```
+
+That way, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-text-field placeholder="yourself">try</alpha-text-field>
 ```
 
 ## Use cases
 
-Used anywhere an author might otherwise use:
-
-- input\[type="text"]
-- input\[type="email"]
-- input\[type="password"]
-- input\[type="tel"]
-- input\[type="url"]
+- User registration and login
+- Data entry
+- Search boxes
+- Comment sections
+- Search filters

--- a/docs/04_web/02_web-components/01_form/14_text-field.md
+++ b/docs/04_web/02_web-components/01_form/14_text-field.md
@@ -4,14 +4,13 @@ sidebar_label: 'Text field'
 id: text-field
 keywords: [web, web components, text field]
 tags:
-    - web
-    - web components
-    - text field
+  - web
+  - web components
+  - text field
 ---
 
 A text field is an interactive or graphic web component that enables users to input and edit text.
 It is a fundamental component of forms, dialogs and user interfaces.
-
 ## Set-up
 
 ```ts
@@ -22,19 +21,22 @@ provideDesignSystem().register(alphaTextField());
 
 ## Attributes
 
-You define the following attributes in an `<alpha-text-field>`.
+You can define the following attributes in an `<alpha-text-field>`.
 
-| Name        | Type      | Description                                                                    |
-|-------------|-----------|--------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading    |
-| appearance  | `string`  | Can be `outline` or `filled`                                                   |
-| maxlength   | `number`  | The maximum number of characters allowed                                       |
-| minlength   | `number`  | The minimum number of characters allowed                                       |
-| placeholder | `string`  | Sets a placeholder for the element                                             |
-| readOnly    | `boolean` | If true, the user cannot change the value in the field                         |
-| size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Sets the type of text-field. Can be {"email", "password","tel","text","url"}   | 
-| value       | `string`  | Sets the value for this component                                              | 
+| Name        | Type      | Description                                                                          |
+|-------------|-----------|--------------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading          |
+| appearance  | `string`  | Can be `outline` or `filled`                                                         |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                              |
+| maxlength   | `number`  | The maximum number of characters allowed                                             |
+| minlength   | `number`  | The minimum number of characters allowed                                             |
+| name        | `string`  | Define the name of the element                                                       |
+| placeholder | `string`  | Sets a placeholder for the element                                                   |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                              |
+| size        | `number`  | Sets the width of the component                                                      |
+| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}     | 
+| value       | `string`  | Sets the value for this component                                                    | 
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -52,11 +54,15 @@ of this component accordingly.
 ```
 - **Example 3**: a read-only text-field with a placeholder
 ```html title="Example 3"
-<alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
+<alpha-text-field readonly placeholder="you can't touch me">Name</alpha-text-field>
+```
+- **Example 4**: a text-field with type number and step 0.5
+```html title="Example 3"
+<alpha-text-field type="number" step="0.5">Name</alpha-text-field>
 ```
 
 ### Get the user input
-In order to use the value that is input to this component, follow these two steps:
+In order to use a value input to this component, follow these two steps:
 
 1. Create an `@observable` variable where you want to use this value:
 
@@ -64,9 +70,9 @@ In order to use the value that is input to this component, follow these two step
 import {... , observable} from '@microsoft/fast-element';
 ...
 export class TEMPLATE extends FASTElement {
-    ...
-    @observable text_field: string
-    ...
+...
+@observable text_field: string
+...
 }
 ```
 

--- a/docs/04_web/02_web-components/01_form/14_text-field.md
+++ b/docs/04_web/02_web-components/01_form/14_text-field.md
@@ -9,8 +9,9 @@ tags:
     - text field
 ---
 
-A text field is an interactive or graphical web component that allows users to input and edit textual information.
+A text field is an interactive or graphic web component that enables users to input and edit text.
 It is a fundamental component of forms, dialogs and user interfaces.
+
 ## Set-up
 
 ```ts
@@ -21,24 +22,24 @@ provideDesignSystem().register(alphaTextField());
 
 ## Attributes
 
-Below you will find the attributes accepted in the `<alpha-text-field>`.
+You define the following attributes in an `<alpha-text-field>`.
 
 | Name        | Type      | Description                                                                    |
 |-------------|-----------|--------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will focused when the  page finished loading          |
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading    |
 | appearance  | `string`  | Can be `outline` or `filled`                                                   |
 | maxlength   | `number`  | The maximum number of characters allowed                                       |
 | minlength   | `number`  | The minimum number of characters allowed                                       |
 | placeholder | `string`  | Sets a placeholder for the element                                             |
-| readOnly    | `boolean` | If true, the user cannot change this its value                                 |
+| readOnly    | `boolean` | If true, the user cannot change the value in the field                         |
 | size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Set the type of th text-field. Can be {"email", "password","tel","text","url"} | 
-| value       | `string`  | Set the value for this component                                               | 
+| type        | `string`  | Sets the type of text-field. Can be {"email", "password","tel","text","url"}   | 
+| value       | `string`  | Sets the value for this component                                              | 
 
-These attributes need to be defined alongside the declaration of the component.
+These attributes must be defined alongside the declaration of the component.
 
 ## Usage
-All examples below are using the `alpha-design-system`. If you are using any other design system, change the declaration
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
 - **Example 1**: a text-field with a max length of 10 characters and a placeholder
@@ -49,13 +50,13 @@ of this component accordingly.
 ```html title="Example 2"
 <alpha-text-field size="30" type="password">Name</alpha-text-field>
 ```
-- **Example 3**: a text-field read only wit a placeholder
+- **Example 3**: a read-only text-field with a placeholder
 ```html title="Example 3"
 <alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
 ```
 
 ### Get the user input
-In order to use the value inputted in this component, you need to follow these two steps
+In order to use the value that is input to this component, follow these two steps:
 
 1. Create an `@observable` variable where you want to use this value:
 
@@ -80,7 +81,7 @@ import {sync} from '@genesislcap/foundation-utils';
 ...    
 ```
 
-That way, you can access the value of the component in your application.
+From this point, you can access the value of the component in your application.
 
 ## Try yourself
 

--- a/docs/04_web/02_web-components/01_form/14_text-field.md
+++ b/docs/04_web/02_web-components/01_form/14_text-field.md
@@ -62,7 +62,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-Once the user has input a value to this component, you need to make that value or text accessible to the application:
+Once the user has input a value to this component, you need to make it accessible to the application:
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -31,7 +31,7 @@ You can define the following attributes in an `<alpha-text-field>`.
 | maxlength   | `number`  | The maximum number of characters allowed                                             |
 | minlength   | `number`  | The minimum number of characters allowed                                             |
 | name        | `string`  | Define the name of the element                                                       |
-| placeholder | `string`  | Sets a placeholder for the element                                                   |
+| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing) |
 | readonly    | `boolean` | If true, the user cannot change the value of this field                              |
 | size        | `number`  | Sets the width of the component                                                      |
 | step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
@@ -62,7 +62,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-In order to use a value input to this component, follow these two steps:
+Once the user has input a value to this component, you need to make that value or text accessible to the application:
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -32,8 +32,8 @@ You can define the following attributes in an `<alpha-text-field>`.
 | placeholder | `string`  | Sets a placeholder for the element                                             |
 | readOnly    | `boolean` | If true, the user cannot change the value of this field                        |
 | size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Set the type of the text-field. Can be {"email", "password","tel","text","url" | 
-| value       | `string`  | Set the value for this component                                               | 
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"| 
+| value       | `string`  | Sets the value for this component                                              | 
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -55,7 +55,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-In order to use the value input to this component, follow these two steps:
+In order to use a value input to this component, follow these two steps:
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -9,7 +9,7 @@ tags:
   - text field
 ---
 
-A text field is an interactive or graphical web component that allows users to input and edit textual information.
+A text field is an interactive or graphic web component that enables users to input and edit text.
 It is a fundamental component of forms, dialogs and user interfaces.
 ## Set-up
 
@@ -21,24 +21,24 @@ provideDesignSystem().register(alphaTextField());
 
 ## Attributes
 
-Below you will find the attributes accepted in the `<alpha-text-field>`.
+You can define the following attributes in an `<alpha-text-field>`.
 
 | Name        | Type      | Description                                                                    |
 |-------------|-----------|--------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will focused when the  page finished loading          |
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading    |
 | appearance  | `string`  | Can be `outline` or `filled`                                                   |
 | maxlength   | `number`  | The maximum number of characters allowed                                       |
 | minlength   | `number`  | The minimum number of characters allowed                                       |
 | placeholder | `string`  | Sets a placeholder for the element                                             |
-| readOnly    | `boolean` | If true, the user cannot change this its value                                 |
+| readOnly    | `boolean` | If true, the user cannot change the value of this field                        |
 | size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Set the type of th text-field. Can be {"email", "password","tel","text","url"} | 
+| type        | `string`  | Set the type of the text-field. Can be {"email", "password","tel","text","url" | 
 | value       | `string`  | Set the value for this component                                               | 
 
-These attributes need to be defined alongside the declaration of the component.
+These attributes must be defined alongside the declaration of the component.
 
 ## Usage
-All examples below are using the `alpha-design-system`. If you are using any other design system, change the declaration
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
 - **Example 1**: a text-field with a max length of 10 characters and a placeholder
@@ -49,13 +49,13 @@ of this component accordingly.
 ```html title="Example 2"
 <alpha-text-field size="30" type="password">Name</alpha-text-field>
 ```
-- **Example 3**: a text-field read only wit a placeholder
+- **Example 3**: a read-only text-field with a placeholder
 ```html title="Example 3"
 <alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
 ```
 
 ### Get the user input
-In order to use the value inputted in this component, you need to follow these two steps
+In order to use the value input to this component, follow these two steps:
 
 1. Create an `@observable` variable where you want to use this value:
 
@@ -80,7 +80,7 @@ import {sync} from '@genesislcap/foundation-utils';
 ...    
 ```
 
-That way, you can access the value of the component in your application.
+From this point, you can access the value of the component in your application.
 
 ## Try yourself
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -23,17 +23,20 @@ provideDesignSystem().register(alphaTextField());
 
 You can define the following attributes in an `<alpha-text-field>`.
 
-| Name        | Type      | Description                                                                    |
-|-------------|-----------|--------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading    |
-| appearance  | `string`  | Can be `outline` or `filled`                                                   |
-| maxlength   | `number`  | The maximum number of characters allowed                                       |
-| minlength   | `number`  | The minimum number of characters allowed                                       |
-| placeholder | `string`  | Sets a placeholder for the element                                             |
-| readOnly    | `boolean` | If true, the user cannot change the value of this field                        |
-| size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"| 
-| value       | `string`  | Sets the value for this component                                              | 
+| Name        | Type      | Description                                                                          |
+|-------------|-----------|--------------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading          |
+| appearance  | `string`  | Can be `outline` or `filled`                                                         |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                              |
+| maxlength   | `number`  | The maximum number of characters allowed                                             |
+| minlength   | `number`  | The minimum number of characters allowed                                             |
+| name        | `string`  | Define the name of the element                                                       |
+| placeholder | `string`  | Sets a placeholder for the element                                                   |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                              |
+| size        | `number`  | Sets the width of the component                                                      |
+| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}     | 
+| value       | `string`  | Sets the value for this component                                                    | 
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -51,7 +54,11 @@ of this component accordingly.
 ```
 - **Example 3**: a read-only text-field with a placeholder
 ```html title="Example 3"
-<alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
+<alpha-text-field readonly placeholder="you can't touch me">Name</alpha-text-field>
+```
+- **Example 4**: a text-field with type number and step 0.5
+```html title="Example 3"
+<alpha-text-field type="number" step="0.5">Name</alpha-text-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -4,14 +4,13 @@ sidebar_label: 'Text field'
 id: text-field
 keywords: [web, web components, text field]
 tags:
-    - web
-    - web components
-    - text field
+  - web
+  - web components
+  - text field
 ---
-An implementation of a [text field](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/text) as a form-connected Web Component. The `alpha-text-field` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
 
-This component filters out slotted _text_ nodes that are only white space to hide the label when it is not in use.
-
+A text field is an interactive or graphical web component that allows users to input and edit textual information.
+It is a fundamental component of forms, dialogs and user interfaces.
 ## Set-up
 
 ```ts
@@ -20,18 +19,79 @@ import { provideDesignSystem, alphaTextField } from '@genesislcap/alpha-design-s
 provideDesignSystem().register(alphaTextField());
 ```
 
-## Usage
+## Attributes
 
-```html live
-<alpha-text-field>Name</alpha-text-field>
+Below you will find the attributes accepted in the `<alpha-text-field>`.
+
+| Name        | Type      | Description                                                                    |
+|-------------|-----------|--------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will focused when the  page finished loading          |
+| appearance  | `string`  | Can be `outline` or `filled`                                                   |
+| maxlength   | `number`  | The maximum number of characters allowed                                       |
+| minlength   | `number`  | The minimum number of characters allowed                                       |
+| placeholder | `string`  | Sets a placeholder for the element                                             |
+| readOnly    | `boolean` | If true, the user cannot change this its value                                 |
+| size        | `number`  | Sets the width of the component                                                |
+| type        | `string`  | Set the type of th text-field. Can be {"email", "password","tel","text","url"} | 
+| value       | `string`  | Set the value for this component                                               | 
+
+These attributes need to be defined alongside the declaration of the component.
+
+## Usage
+All examples below are using the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
+
+- **Example 1**: a text-field with a max length of 10 characters and a placeholder
+```html title="Example 1"
+<alpha-text-field maxlength="10" placeholder="This is a placeholder">Name</alpha-text-field>
+```
+- **Example 2**: a text-field with a size of 30 and type `password`
+```html title="Example 2"
+<alpha-text-field size="30" type="password">Name</alpha-text-field>
+```
+- **Example 3**: a text-field read only wit a placeholder
+```html title="Example 3"
+<alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
+```
+
+### Get the user input
+In order to use the value inputted in this component, you need to follow these two steps
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+    ...
+    @observable text_field: string
+    ...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-text-field value=${sync((x) => x.text_field)}>TEXT</alpha-text-field>
+    ...
+...    
+```
+
+That way, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-text-field placeholder="yourself">try</alpha-text-field>
 ```
 
 ## Use cases
 
-Used anywhere an author might otherwise use:
-
-- input\[type="text"]
-- input\[type="email"]
-- input\[type="password"]
-- input\[type="tel"]
-- input\[type="url"]
+- User registration and login
+- Data entry
+- Search boxes
+- Comment sections
+- Search filters

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -62,7 +62,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-Once the user has input a value to this component, you need to make that value or text accessible to the application:
+Once the user has input a value to this component, you need to make it accessible to the application:
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -31,7 +31,7 @@ You can define the following attributes in an `<alpha-text-field>`.
 | maxlength   | `number`  | The maximum number of characters allowed                                             |
 | minlength   | `number`  | The minimum number of characters allowed                                             |
 | name        | `string`  | Define the name of the element                                                       |
-| placeholder | `string`  | Sets a placeholder for the element                                                   |
+| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing) |
 | readonly    | `boolean` | If true, the user cannot change the value of this field                              |
 | size        | `number`  | Sets the width of the component                                                      |
 | step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
@@ -62,7 +62,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-In order to use a value input to this component, follow these two steps:
+Once the user has input a value to this component, you need to make that value or text accessible to the application:
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -9,7 +9,7 @@ tags:
   - text field
 ---
 
-A text field is an interactive or graphic web component that enables users to input and edit textual information.
+A text field is an interactive or graphic web component that enables users to input and edit text.
 It is a fundamental component of forms, dialogs and user interfaces.
 ## Set-up
 
@@ -33,7 +33,7 @@ You can define the following attributes in the `<alpha-text-field>`.
 | readOnly    | `boolean` | If true, the user cannot change this its value                                 |
 | size        | `number`  | Sets the width of the component                                                |
 | type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}| 
-| value       | `string`  | Set the value for this component                                               | 
+| value       | `string`  | Sets the value for this component                                              | 
 
 These attributes must be defined alongside the declaration of the component.
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -21,19 +21,22 @@ provideDesignSystem().register(alphaTextField());
 
 ## Attributes
 
-You can define the following attributes in the `<alpha-text-field>`.
+You can define the following attributes in an `<alpha-text-field>`.
 
-| Name        | Type      | Description                                                                    |
-|-------------|-----------|--------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading    |
-| appearance  | `string`  | Can be `outline` or `filled`                                                   |
-| maxlength   | `number`  | The maximum number of characters allowed                                       |
-| minlength   | `number`  | The minimum number of characters allowed                                       |
-| placeholder | `string`  | Sets a placeholder for the element                                             |
-| readOnly    | `boolean` | If true, the user cannot change this its value                                 |
-| size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}| 
-| value       | `string`  | Sets the value for this component                                              | 
+| Name        | Type      | Description                                                                          |
+|-------------|-----------|--------------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading          |
+| appearance  | `string`  | Can be `outline` or `filled`                                                         |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                              |
+| maxlength   | `number`  | The maximum number of characters allowed                                             |
+| minlength   | `number`  | The minimum number of characters allowed                                             |
+| name        | `string`  | Define the name of the element                                                       |
+| placeholder | `string`  | Sets a placeholder for the element                                                   |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                              |
+| size        | `number`  | Sets the width of the component                                                      |
+| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}     | 
+| value       | `string`  | Sets the value for this component                                                    | 
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -51,11 +54,15 @@ of this component accordingly.
 ```
 - **Example 3**: a read-only text-field with a placeholder
 ```html title="Example 3"
-<alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
+<alpha-text-field readonly placeholder="you can't touch me">Name</alpha-text-field>
+```
+- **Example 4**: a text-field with type number and step 0.5
+```html title="Example 3"
+<alpha-text-field type="number" step="0.5">Name</alpha-text-field>
 ```
 
 ### Get the user input
-In order to use a value that has been input to this component, follow these two steps
+In order to use a value input to this component, follow these two steps:
 
 1. Create an `@observable` variable where you want to use this value:
 
@@ -63,9 +70,9 @@ In order to use a value that has been input to this component, follow these two 
 import {... , observable} from '@microsoft/fast-element';
 ...
 export class TEMPLATE extends FASTElement {
-    ...
-    @observable text_field: string
-    ...
+...
+@observable text_field: string
+...
 }
 ```
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -9,7 +9,7 @@ tags:
   - text field
 ---
 
-A text field is an interactive or graphical web component that allows users to input and edit textual information.
+A text field is an interactive or graphic web component that enables users to input and edit textual information.
 It is a fundamental component of forms, dialogs and user interfaces.
 ## Set-up
 
@@ -21,24 +21,24 @@ provideDesignSystem().register(alphaTextField());
 
 ## Attributes
 
-Below you will find the attributes accepted in the `<alpha-text-field>`.
+You can define the following attributes in the `<alpha-text-field>`.
 
 | Name        | Type      | Description                                                                    |
 |-------------|-----------|--------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will focused when the  page finished loading          |
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading    |
 | appearance  | `string`  | Can be `outline` or `filled`                                                   |
 | maxlength   | `number`  | The maximum number of characters allowed                                       |
 | minlength   | `number`  | The minimum number of characters allowed                                       |
 | placeholder | `string`  | Sets a placeholder for the element                                             |
 | readOnly    | `boolean` | If true, the user cannot change this its value                                 |
 | size        | `number`  | Sets the width of the component                                                |
-| type        | `string`  | Set the type of th text-field. Can be {"email", "password","tel","text","url"} | 
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}| 
 | value       | `string`  | Set the value for this component                                               | 
 
-These attributes need to be defined alongside the declaration of the component.
+These attributes must be defined alongside the declaration of the component.
 
 ## Usage
-All examples below are using the `alpha-design-system`. If you are using any other design system, change the declaration
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
 - **Example 1**: a text-field with a max length of 10 characters and a placeholder
@@ -49,13 +49,13 @@ of this component accordingly.
 ```html title="Example 2"
 <alpha-text-field size="30" type="password">Name</alpha-text-field>
 ```
-- **Example 3**: a text-field read only wit a placeholder
+- **Example 3**: a read-only text-field with a placeholder
 ```html title="Example 3"
 <alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
 ```
 
 ### Get the user input
-In order to use the value inputted in this component, you need to follow these two steps
+In order to use a value that has been input to this component, follow these two steps
 
 1. Create an `@observable` variable where you want to use this value:
 
@@ -80,7 +80,7 @@ import {sync} from '@genesislcap/foundation-utils';
 ...    
 ```
 
-That way, you can access the value of the component in your application.
+From this point, you can access the value of the component in your application.
 
 ## Try yourself
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -4,14 +4,13 @@ sidebar_label: 'Text field'
 id: text-field
 keywords: [web, web components, text field]
 tags:
-    - web
-    - web components
-    - text field
+  - web
+  - web components
+  - text field
 ---
-An implementation of a [text field](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/text) as a form-connected Web Component. The `alpha-text-field` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
 
-This component filters out slotted _text_ nodes that are only white space to hide the label when it is not in use.
-
+A text field is an interactive or graphical web component that allows users to input and edit textual information.
+It is a fundamental component of forms, dialogs and user interfaces.
 ## Set-up
 
 ```ts
@@ -20,18 +19,79 @@ import { provideDesignSystem, alphaTextField } from '@genesislcap/alpha-design-s
 provideDesignSystem().register(alphaTextField());
 ```
 
-## Usage
+## Attributes
 
-```html live
-<alpha-text-field>Name</alpha-text-field>
+Below you will find the attributes accepted in the `<alpha-text-field>`.
+
+| Name        | Type      | Description                                                                    |
+|-------------|-----------|--------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will focused when the  page finished loading          |
+| appearance  | `string`  | Can be `outline` or `filled`                                                   |
+| maxlength   | `number`  | The maximum number of characters allowed                                       |
+| minlength   | `number`  | The minimum number of characters allowed                                       |
+| placeholder | `string`  | Sets a placeholder for the element                                             |
+| readOnly    | `boolean` | If true, the user cannot change this its value                                 |
+| size        | `number`  | Sets the width of the component                                                |
+| type        | `string`  | Set the type of th text-field. Can be {"email", "password","tel","text","url"} | 
+| value       | `string`  | Set the value for this component                                               | 
+
+These attributes need to be defined alongside the declaration of the component.
+
+## Usage
+All examples below are using the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
+
+- **Example 1**: a text-field with a max length of 10 characters and a placeholder
+```html title="Example 1"
+<alpha-text-field maxlength="10" placeholder="This is a placeholder">Name</alpha-text-field>
+```
+- **Example 2**: a text-field with a size of 30 and type `password`
+```html title="Example 2"
+<alpha-text-field size="30" type="password">Name</alpha-text-field>
+```
+- **Example 3**: a text-field read only wit a placeholder
+```html title="Example 3"
+<alpha-text-field readOnly placeholder="you can't touch me">Name</alpha-text-field>
+```
+
+### Get the user input
+In order to use the value inputted in this component, you need to follow these two steps
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+    ...
+    @observable text_field: string
+    ...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-text-field value=${sync((x) => x.text_field)}>TEXT</alpha-text-field>
+    ...
+...    
+```
+
+That way, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-text-field placeholder="yourself">try</alpha-text-field>
 ```
 
 ## Use cases
 
-Used anywhere an author might otherwise use:
-
-- input\[type="text"]
-- input\[type="email"]
-- input\[type="password"]
-- input\[type="tel"]
-- input\[type="url"]
+- User registration and login
+- Data entry
+- Search boxes
+- Comment sections
+- Search filters

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -62,7 +62,7 @@ of this component accordingly.
 ```
 
 ### Get the user input
-Once the user has input a value to this component, you need to make that value or text accessible to the application:
+Once the user has input a value to this component, you need to make it accessible to the application:
 
 1. Create an `@observable` variable where you want to use this value:
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-926

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
N/A

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

