### PR TITLE
PTL-927: improve text-area documentation

### DIFF
--- a/docs/04_web/02_web-components/01_form/13_text-area.md
+++ b/docs/04_web/02_web-components/01_form/13_text-area.md
@@ -4,14 +4,14 @@ sidebar_label: 'Text area'
 id: text-area
 keywords: [web, web components, text area]
 tags:
-    - web
-    - web components
-    - text area
+  - web
+  - web components
+  - text area
 ---
 
 A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
 
-This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component. 
+This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component.
 ## Set-up
 
 ```ts
@@ -72,7 +72,7 @@ export class TEMPLATE extends FASTElement {
 }
 ```
 
-2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+2. Use the `sync` function to insert the value from the component into the variable `text_area`:
 
 ```typescript tile="Example 4" {1,4}
 import {sync} from '@genesislcap/foundation-utils';

--- a/docs/04_web/02_web-components/01_form/13_text-area.md
+++ b/docs/04_web/02_web-components/01_form/13_text-area.md
@@ -1,5 +1,5 @@
 ---
-title: 'Web Components - Text area'
+title: 'Web Components - text area'
 sidebar_label: 'Text area'
 id: text-area
 keywords: [web, web components, text area]
@@ -9,9 +9,10 @@ tags:
   - text area
 ---
 
-A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
+A text-area is a graphic user-interface element that provides a region where users can input, edit or display text that extends over multiple lines.
 
 This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component.
+
 ## Set-up
 
 ```ts
@@ -26,17 +27,17 @@ You can define the following attributes in an `<alpha-text-area>`.
 
 | Name        | Type      | Description                                                                                                 |
 |-------------|-----------|-------------------------------------------------------------------------------------------------------------|
-| appearance  | `string`  | It change the general view of the element. It can be **filled** or **outline**                              |
+| appearance  | `string`  | Changes the general view of the element; this can be **filled** or **outline**                              |
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
-| cols        | `boolean` | Define the size of the element horizontally. **Default: 20**                                                |
+| cols        | `boolean` | Defines the size of the element horizontally. **Default: 20**                                               |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
 | maxlength   | `number`  | The maximum number of characters allowed                                                                    |
 | minlength   | `number`  | The minimum number of characters allowed                                                                    |
-| name        | `string`  | Define the name of the element                                                                              |
-| placeholder | `string`  | Sets a placeholder for the element                                                                          |
+| name        | `string`  | Defines the name of the element                                                                             |
+| placeholder | `string`  | Sets placeholder text for the element, which disappears when the user starts inputting                          |
 | readonly    | `boolean` | If true, the user cannot change the value of this field                                                     |
-| resize      | `string`  | Allows the user to resize the element. It can be {"none","both","vertical","horizontal"}. **Default: none** |
-| row         | `number`  | Define the size of the element vertically. **Default: 2**                                                   |
+| resize      | `string`  | Allows the user to resize the element; this can be {"none","both","vertical","horizontal"}. **Default: none** |
+| row         | `number`  | Defines the size of the element vertically. **Default: 2**                                                   |
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -44,21 +45,21 @@ These attributes must be defined alongside the declaration of the component.
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
-- **Example 1**: a text-area with 5 rows and 20 columns not allowing the user to resize it.
+- **Example 1**: a text-area with 5 rows and 20 columns, which the user cannot resize
 ```html title="Example 1"
 <alpha-text-area rows="5" cols="20" resize="none">text-area</alpha-text-area>
 ```
-- **Example 2**: a text-area with a placeholder with autofocus
+- **Example 2**: a text-area that is in focus, and which displays the placeholder text **This is a placeholder**
 ```html title="Example 2"
 <alpha-text-area placeholder="This is a placeholder" autofocus>Name</alpha-text-area>
 ```
-- **Example 3**: a disabled text-area with a placeholder
+- **Example 3**: a text-area that displays placeholder text, which the user is unable to change
 ```html title="Example 3"
 <alpha-text-area disabled placeholder="you can't touch me">Name</alpha-text-area>
 ```
 
 ### Get the user input
-In order to use a value input to this component, follow these two steps:
+Once the value has been input, you need to make it accessible to your application. 
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/docs/04_web/02_web-components/01_form/13_text-area.md
+++ b/docs/04_web/02_web-components/01_form/13_text-area.md
@@ -31,6 +31,7 @@ You can define the following attributes in an `<alpha-text-area>`.
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
 | cols        | `boolean` | Defines the size of the element horizontally. **Default: 20**                                               |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | maxlength   | `number`  | The maximum number of characters allowed                                                                    |
 | minlength   | `number`  | The minimum number of characters allowed                                                                    |
 | name        | `string`  | Defines the name of the element                                                                             |

--- a/docs/04_web/02_web-components/01_form/13_text-area.md
+++ b/docs/04_web/02_web-components/01_form/13_text-area.md
@@ -9,8 +9,9 @@ tags:
     - text area
 ---
 
-An implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component. The `alpha-text-area` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
+A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
 
+This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component. 
 ## Set-up
 
 ```ts
@@ -19,12 +20,81 @@ import { provideDesignSystem, alphaTextArea } from '@genesislcap/alpha-design-sy
 provideDesignSystem().register(alphaTextArea());
 ```
 
-## Usage
+## Attributes
 
-```html live
-<alpha-text-area placeholder="Your feedback">Free-text comment form</alpha-text-area>
+You can define the following attributes in an `<alpha-text-area>`.
+
+| Name        | Type      | Description                                                                                                 |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------------|
+| appearance  | `string`  | It change the general view of the element. It can be **filled** or **outline**                              |
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
+| cols        | `boolean` | Define the size of the element horizontally. **Default: 20**                                                |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
+| maxlength   | `number`  | The maximum number of characters allowed                                                                    |
+| minlength   | `number`  | The minimum number of characters allowed                                                                    |
+| name        | `string`  | Define the name of the element                                                                              |
+| placeholder | `string`  | Sets a placeholder for the element                                                                          |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                                                     |
+| resize      | `string`  | Allows the user to resize the element. It can be {"none","both","vertical","horizontal"}. **Default: none** |
+| row         | `number`  | Define the size of the element vertically. **Default: 2**                                                   |
+
+These attributes must be defined alongside the declaration of the component.
+
+## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
+
+- **Example 1**: a text-area with 5 rows and 20 columns not allowing the user to resize it.
+```html title="Example 1"
+<alpha-text-area rows="5" cols="20" resize="none">text-area</alpha-text-area>
 ```
+- **Example 2**: a text-area with a placeholder with autofocus
+```html title="Example 2"
+<alpha-text-area placeholder="This is a placeholder" autofocus>Name</alpha-text-area>
+```
+- **Example 3**: a disabled text-area with a placeholder
+```html title="Example 3"
+<alpha-text-area disabled placeholder="you can't touch me">Name</alpha-text-area>
+```
+
+### Get the user input
+In order to use a value input to this component, follow these two steps:
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable text_area: string
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-text-area value=${sync((x) => x.text_area)}>TEXT</alpha-text-area>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-text-area placeholder="yourself">try</alpha-text-area>
+```
+
 
 ## Use cases
 
-* Used anywhere `<textarea></textarea>` could be used
+- Comments
+- Descriptions
+- Multi-line text inputs
+- Complex searches

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
@@ -72,7 +72,7 @@ export class TEMPLATE extends FASTElement {
 }
 ```
 
-2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+2. Use the `sync` function to insert the value from the component into the variable `text_area`:
 
 ```typescript tile="Example 4" {1,4}
 import {sync} from '@genesislcap/foundation-utils';

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
@@ -1,5 +1,5 @@
 ---
-title: 'Web Components - Text area'
+title: 'Web Components - text area'
 sidebar_label: 'Text area'
 id: text-area
 keywords: [web, web components, text area]
@@ -9,9 +9,10 @@ tags:
   - text area
 ---
 
-A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
+A text-area is a graphic user-interface element that provides a region where users can input, edit or display text that extends over multiple lines.
 
 This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component.
+
 ## Set-up
 
 ```ts
@@ -26,17 +27,17 @@ You can define the following attributes in an `<alpha-text-area>`.
 
 | Name        | Type      | Description                                                                                                 |
 |-------------|-----------|-------------------------------------------------------------------------------------------------------------|
-| appearance  | `string`  | It change the general view of the element. It can be **filled** or **outline**                              |
+| appearance  | `string`  | Changes the general view of the element; this can be **filled** or **outline**                              |
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
-| cols        | `boolean` | Define the size of the element horizontally. **Default: 20**                                                |
+| cols        | `boolean` | Defines the size of the element horizontally. **Default: 20**                                               |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
 | maxlength   | `number`  | The maximum number of characters allowed                                                                    |
 | minlength   | `number`  | The minimum number of characters allowed                                                                    |
-| name        | `string`  | Define the name of the element                                                                              |
-| placeholder | `string`  | Sets a placeholder for the element                                                                          |
+| name        | `string`  | Defines the name of the element                                                                             |
+| placeholder | `string`  | Sets placeholder text for the element, which disappears when the user starts inputting                          |
 | readonly    | `boolean` | If true, the user cannot change the value of this field                                                     |
-| resize      | `string`  | Allows the user to resize the element. It can be {"none","both","vertical","horizontal"}. **Default: none** |
-| row         | `number`  | Define the size of the element vertically. **Default: 2**                                                   |
+| resize      | `string`  | Allows the user to resize the element; this can be {"none","both","vertical","horizontal"}. **Default: none** |
+| row         | `number`  | Defines the size of the element vertically. **Default: 2**                                                   |
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -44,21 +45,21 @@ These attributes must be defined alongside the declaration of the component.
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
-- **Example 1**: a text-area with 5 rows and 20 columns not allowing the user to resize it.
+- **Example 1**: a text-area with 5 rows and 20 columns, which the user cannot resize
 ```html title="Example 1"
 <alpha-text-area rows="5" cols="20" resize="none">text-area</alpha-text-area>
 ```
-- **Example 2**: a text-area with a placeholder with autofocus
+- **Example 2**: a text-area that is in focus, and which displays the placeholder text **This is a placeholder**
 ```html title="Example 2"
 <alpha-text-area placeholder="This is a placeholder" autofocus>Name</alpha-text-area>
 ```
-- **Example 3**: a disabled text-area with a placeholder
+- **Example 3**: a text-area that displays placeholder text, which the user is unable to change
 ```html title="Example 3"
 <alpha-text-area disabled placeholder="you can't touch me">Name</alpha-text-area>
 ```
 
 ### Get the user input
-In order to use a value input to this component, follow these two steps:
+Once the value has been input, you need to make it accessible to your application. 
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
@@ -30,6 +30,7 @@ You can define the following attributes in an `<alpha-text-area>`.
 | appearance  | `string`  | Changes the general view of the element; this can be **filled** or **outline**                              |
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
 | cols        | `boolean` | Defines the size of the element horizontally. **Default: 20**                                               |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
 | maxlength   | `number`  | The maximum number of characters allowed                                                                    |
 | minlength   | `number`  | The minimum number of characters allowed                                                                    |

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/12_text-area.md
@@ -4,13 +4,14 @@ sidebar_label: 'Text area'
 id: text-area
 keywords: [web, web components, text area]
 tags:
-    - web
-    - web components
-    - text area
+  - web
+  - web components
+  - text area
 ---
 
-An implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component. The `alpha-text-area` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
+A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
 
+This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component.
 ## Set-up
 
 ```ts
@@ -19,12 +20,81 @@ import { provideDesignSystem, alphaTextArea } from '@genesislcap/alpha-design-sy
 provideDesignSystem().register(alphaTextArea());
 ```
 
-## Usage
+## Attributes
 
-```html live
-<alpha-text-area placeholder="Your feedback">Free-text comment form</alpha-text-area>
+You can define the following attributes in an `<alpha-text-area>`.
+
+| Name        | Type      | Description                                                                                                 |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------------|
+| appearance  | `string`  | It change the general view of the element. It can be **filled** or **outline**                              |
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
+| cols        | `boolean` | Define the size of the element horizontally. **Default: 20**                                                |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
+| maxlength   | `number`  | The maximum number of characters allowed                                                                    |
+| minlength   | `number`  | The minimum number of characters allowed                                                                    |
+| name        | `string`  | Define the name of the element                                                                              |
+| placeholder | `string`  | Sets a placeholder for the element                                                                          |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                                                     |
+| resize      | `string`  | Allows the user to resize the element. It can be {"none","both","vertical","horizontal"}. **Default: none** |
+| row         | `number`  | Define the size of the element vertically. **Default: 2**                                                   |
+
+These attributes must be defined alongside the declaration of the component.
+
+## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
+
+- **Example 1**: a text-area with 5 rows and 20 columns not allowing the user to resize it.
+```html title="Example 1"
+<alpha-text-area rows="5" cols="20" resize="none">text-area</alpha-text-area>
 ```
+- **Example 2**: a text-area with a placeholder with autofocus
+```html title="Example 2"
+<alpha-text-area placeholder="This is a placeholder" autofocus>Name</alpha-text-area>
+```
+- **Example 3**: a disabled text-area with a placeholder
+```html title="Example 3"
+<alpha-text-area disabled placeholder="you can't touch me">Name</alpha-text-area>
+```
+
+### Get the user input
+In order to use a value input to this component, follow these two steps:
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable text_area: string
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-text-area value=${sync((x) => x.text_area)}>TEXT</alpha-text-area>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-text-area placeholder="yourself">try</alpha-text-area>
+```
+
 
 ## Use cases
 
-* Used anywhere `<textarea></textarea>` could be used
+- Comments
+- Descriptions
+- Multi-line text inputs
+- Complex searches

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
@@ -72,7 +72,7 @@ export class TEMPLATE extends FASTElement {
 }
 ```
 
-2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+2. Use the `sync` function to insert the value from the component into the variable `text_area`:
 
 ```typescript tile="Example 4" {1,4}
 import {sync} from '@genesislcap/foundation-utils';

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
@@ -1,5 +1,5 @@
 ---
-title: 'Web Components - Text area'
+title: 'Web Components - text area'
 sidebar_label: 'Text area'
 id: text-area
 keywords: [web, web components, text area]
@@ -9,9 +9,10 @@ tags:
   - text area
 ---
 
-A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
+A text-area is a graphic user-interface element that provides a region where users can input, edit or display text that extends over multiple lines.
 
 This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component.
+
 ## Set-up
 
 ```ts
@@ -26,17 +27,17 @@ You can define the following attributes in an `<alpha-text-area>`.
 
 | Name        | Type      | Description                                                                                                 |
 |-------------|-----------|-------------------------------------------------------------------------------------------------------------|
-| appearance  | `string`  | It change the general view of the element. It can be **filled** or **outline**                              |
+| appearance  | `string`  | Changes the general view of the element; this can be **filled** or **outline**                              |
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
-| cols        | `boolean` | Define the size of the element horizontally. **Default: 20**                                                |
+| cols        | `boolean` | Defines the size of the element horizontally. **Default: 20**                                               |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
 | maxlength   | `number`  | The maximum number of characters allowed                                                                    |
 | minlength   | `number`  | The minimum number of characters allowed                                                                    |
-| name        | `string`  | Define the name of the element                                                                              |
-| placeholder | `string`  | Sets a placeholder for the element                                                                          |
+| name        | `string`  | Defines the name of the element                                                                             |
+| placeholder | `string`  | Sets placeholder text for the element, which disappears when the user starts inputting                          |
 | readonly    | `boolean` | If true, the user cannot change the value of this field                                                     |
-| resize      | `string`  | Allows the user to resize the element. It can be {"none","both","vertical","horizontal"}. **Default: none** |
-| row         | `number`  | Define the size of the element vertically. **Default: 2**                                                   |
+| resize      | `string`  | Allows the user to resize the element; this can be {"none","both","vertical","horizontal"}. **Default: none** |
+| row         | `number`  | Defines the size of the element vertically. **Default: 2**                                                   |
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -44,21 +45,21 @@ These attributes must be defined alongside the declaration of the component.
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
-- **Example 1**: a text-area with 5 rows and 20 columns not allowing the user to resize it.
+- **Example 1**: a text-area with 5 rows and 20 columns, which the user cannot resize
 ```html title="Example 1"
 <alpha-text-area rows="5" cols="20" resize="none">text-area</alpha-text-area>
 ```
-- **Example 2**: a text-area with a placeholder with autofocus
+- **Example 2**: a text-area that is in focus, and which displays the placeholder text **This is a placeholder**
 ```html title="Example 2"
 <alpha-text-area placeholder="This is a placeholder" autofocus>Name</alpha-text-area>
 ```
-- **Example 3**: a disabled text-area with a placeholder
+- **Example 3**: a text-area that displays placeholder text, which the user is unable to change
 ```html title="Example 3"
 <alpha-text-area disabled placeholder="you can't touch me">Name</alpha-text-area>
 ```
 
 ### Get the user input
-In order to use a value input to this component, follow these two steps:
+Once the value has been input, you need to make it accessible to your application. 
 
 1. Create an `@observable` variable where you want to use this value:
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
@@ -31,6 +31,7 @@ You can define the following attributes in an `<alpha-text-area>`.
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
 | cols        | `boolean` | Defines the size of the element horizontally. **Default: 20**                                               |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | maxlength   | `number`  | The maximum number of characters allowed                                                                    |
 | minlength   | `number`  | The minimum number of characters allowed                                                                    |
 | name        | `string`  | Defines the name of the element                                                                             |

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/12_text-area.md
@@ -4,13 +4,14 @@ sidebar_label: 'Text area'
 id: text-area
 keywords: [web, web components, text area]
 tags:
-    - web
-    - web components
-    - text area
+  - web
+  - web components
+  - text area
 ---
 
-An implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component. The `alpha-text-area` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
+A text-area is a graphical user interface element that provides a region where users can input, edit or display text that spans in multiple lines.
 
+This component is an implementation of an [HTML textarea element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) as a form-connected Web Component.
 ## Set-up
 
 ```ts
@@ -19,12 +20,81 @@ import { provideDesignSystem, alphaTextArea } from '@genesislcap/alpha-design-sy
 provideDesignSystem().register(alphaTextArea());
 ```
 
-## Usage
+## Attributes
 
-```html live
-<alpha-text-area placeholder="Your feedback">Free-text comment form</alpha-text-area>
+You can define the following attributes in an `<alpha-text-area>`.
+
+| Name        | Type      | Description                                                                                                 |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------------|
+| appearance  | `string`  | It change the general view of the element. It can be **filled** or **outline**                              |
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                 |
+| cols        | `boolean` | Define the size of the element horizontally. **Default: 20**                                                |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                     |
+| maxlength   | `number`  | The maximum number of characters allowed                                                                    |
+| minlength   | `number`  | The minimum number of characters allowed                                                                    |
+| name        | `string`  | Define the name of the element                                                                              |
+| placeholder | `string`  | Sets a placeholder for the element                                                                          |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                                                     |
+| resize      | `string`  | Allows the user to resize the element. It can be {"none","both","vertical","horizontal"}. **Default: none** |
+| row         | `number`  | Define the size of the element vertically. **Default: 2**                                                   |
+
+These attributes must be defined alongside the declaration of the component.
+
+## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
+
+- **Example 1**: a text-area with 5 rows and 20 columns not allowing the user to resize it.
+```html title="Example 1"
+<alpha-text-area rows="5" cols="20" resize="none">text-area</alpha-text-area>
 ```
+- **Example 2**: a text-area with a placeholder with autofocus
+```html title="Example 2"
+<alpha-text-area placeholder="This is a placeholder" autofocus>Name</alpha-text-area>
+```
+- **Example 3**: a disabled text-area with a placeholder
+```html title="Example 3"
+<alpha-text-area disabled placeholder="you can't touch me">Name</alpha-text-area>
+```
+
+### Get the user input
+In order to use a value input to this component, follow these two steps:
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable text_area: string
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_field`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-text-area value=${sync((x) => x.text_area)}>TEXT</alpha-text-area>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-text-area placeholder="yourself">try</alpha-text-area>
+```
+
 
 ## Use cases
 
-* Used anywhere `<textarea></textarea>` could be used
+- Comments
+- Descriptions
+- Multi-line text inputs
+- Complex searches


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-927

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

