### PR TITLE
PTL928: Improve number-field documentation

### DIFF
--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -24,16 +24,16 @@ You can define the following attributes in an `<alpha-number-field>`.
 
 | Name           | Type      | Description                                                                                                              |
 |----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                          |
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                     |
-| hideStep       | `boolean` | Displays the step control of the element                                                                                 |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
+| hideStep       | `boolean` | Hides the step control of the element                                                                                    |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
 | min            | `number`  | Defines minimum number allowed                                                                                           |
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting                                      |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
 | size           | `number`  | Defines the width of the component                                                                                       |
 | step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |
@@ -49,11 +49,11 @@ of this component accordingly.
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
-- **Example 2**: a number-field formatting the number from "de-De" (German/Germany)
+- **Example 2**: a number-field in German format "de-De" (German/Germany)
 ```html title="Example 2"
 <alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
 ```
-- **Example 3**: a number-field with step 0.5
+- **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
 ```

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -4,10 +4,11 @@ sidebar_label: 'Number field'
 id: number-field
 keywords: [web, web components, number field]
 tags:
-    - web
-    - web components
-    - number field
+  - web
+  - web components
+  - number field
 ---
+
 A text field for numeric entry.
 
 ## Set-up
@@ -17,16 +18,83 @@ import { provideDesignSystem, alphaNumberField } from '@genesislcap/alpha-design
 
 provideDesignSystem().register(alphaNumberField());
 ```
+## Attributes
+
+You can define the following attributes in an `<alpha-number-field>`.
+
+| Name           | Type      | Description                                                                                                              |
+|----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
+| appearance     | `string`  | It changes the general view of the element. It can be **filled** or **outline**                                          |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
+| disabled       | `boolean` | It disables this component, not letting the user to change its value                                                     |
+| hideStep       | `boolean` | Displays the step control of the element                                                                                 |
+| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
+| max            | `number`  | Defines maximum number allowed                                                                                           |
+| maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
+| min            | `number`  | Defines minimum number allowed                                                                                           |
+| minlength      | `number`  | The minimum number of characters allowed                                                                                 |
+| placeholder    | `string`  | Sets a placeholder for the element                                                                                       |
+| size           | `number`  | Defines the width of the component                                                                                       |
+| step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
+| value          | `string`  | Defines a value for the component when it is created                                                                     |
+| withFormatting | `boolean` | Allows number formatting                                                                                                 |
+
+These attributes must be defined alongside the declaration of the component.
 
 ## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
 
-The `alpha-number-field` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
-
-```html live
-<alpha-number-field appearance="filled" min="0" max="10"></alpha-number-field>
+- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control
+```html title="Example 1"
+<alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
+- **Example 2**: a number-field formatting the number from "de-De" (German/Germany)
+```html title="Example 2"
+<alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
+```
+- **Example 3**: a number-field with step 0.5
+```html title="Example 3"
+<alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+
+### Get the user input
+In order to use a value input to this component, follow these two steps:
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable number_field: number
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_area`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-number-field value=${sync((x) => x.number_field)}>TEXT</alpha-number-field>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-number-field>Try</alpha-number-field>
+```
+
 
 ## Use cases
 
-* Anywhere where `input[type="number"]` could be used
-
+- Display numbers
+- Insert numbers
+- Search boxes

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -27,7 +27,6 @@ You can define the following attributes in an `<alpha-number-field>`.
 | appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
 | disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
-| hideStep       | `boolean` | Hides the step control of the element                                                                                    |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
@@ -35,11 +34,22 @@ You can define the following attributes in an `<alpha-number-field>`.
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
 | placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
 | size           | `number`  | Defines the width of the component                                                                                       |
-| step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                             |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |
 | withFormatting | `boolean` | Allows number formatting                                                                                                 |
 
 These attributes must be defined alongside the declaration of the component.
+
+### Custom options
+
+The `number-field` has 2 custom options:
+
+| Variable              | Type     | Default | Description                                                                          |
+|-----------------------|----------|---------|--------------------------------------------------------------------------------------|
+| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted                                            |
+| minimumFractionDigits | `number` | 0       | Minimum number of decimal digits. If minimum not reached, it will be filled with `0` |
+
+All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -56,6 +66,10 @@ of this component accordingly.
 - **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+- **Example 4**: a number-field with a maximum digit number of 2 and minimum of 2
+```html title="Example 4"
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -22,34 +22,23 @@ provideDesignSystem().register(alphaNumberField());
 
 You can define the following attributes in an `<alpha-number-field>`.
 
-| Name           | Type      | Description                                                                                                              |
-|----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
-| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
-| max            | `number`  | Defines maximum number allowed                                                                                           |
-| maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
-| min            | `number`  | Defines minimum number allowed                                                                                           |
-| minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
-| size           | `number`  | Defines the width of the component                                                                                       |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                             |
-| value          | `string`  | Defines a value for the component when it is created                                                                     |
-| withFormatting | `boolean` | Allows number formatting                                                                                                 |
+| Name           | Type      | Description                                                                          |
+|----------------|-----------|--------------------------------------------------------------------------------------|
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
+| hideStep       | `boolean` | Hides the step control of the element                                                |
+| max            | `number`  | Defines maximum number allowed                                                       |
+| maxlength      | `number`  | The maximum number of characters allowed                                             |
+| min            | `number`  | Defines minimum number allowed                                                       |
+| minlength      | `number`  | The minimum number of characters allowed                                             |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting) |
+| size           | `number`  | Defines the width of the component                                                   |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**         |
+| value          | `string`  | Defines a value for the component when it is created                                 |
+| withFormatting | `boolean` | Allows number formatting                                                             |
 
 These attributes must be defined alongside the declaration of the component.
-
-### Custom options
-
-The `number-field` has 2 custom options:
-
-| Variable              | Type     | Default | Description                                                                          |
-|-----------------------|----------|---------|--------------------------------------------------------------------------------------|
-| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted                                            |
-| minimumFractionDigits | `number` | 0       | Minimum number of decimal digits. If minimum not reached, it will be filled with `0` |
-
-All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -59,17 +48,10 @@ of this component accordingly.
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
-- **Example 2**: a number-field in German format "de-De" (German/Germany)
+
+- **Example 2**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 2"
-<alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
-```
-- **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
-```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
-```
-- **Example 4**: a number-field with a maximum digit number of 2 and minimum of 2
-```html title="Example 4"
-<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -22,21 +22,22 @@ provideDesignSystem().register(alphaNumberField());
 
 You can define the following attributes in an `<alpha-number-field>`.
 
-| Name           | Type      | Description                                                                          |
-|----------------|-----------|--------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
-| hideStep       | `boolean` | Hides the step control of the element                                                |
-| max            | `number`  | Defines maximum number allowed                                                       |
-| maxlength      | `number`  | The maximum number of characters allowed                                             |
-| min            | `number`  | Defines minimum number allowed                                                       |
-| minlength      | `number`  | The minimum number of characters allowed                                             |
-| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting) |
-| size           | `number`  | Defines the width of the component                                                   |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**         |
-| value          | `string`  | Defines a value for the component when it is created                                 |
-| withFormatting | `boolean` | Allows number formatting                                                             |
+| Name           | Type      | Description                                                                                                                             |
+|----------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                                           |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                                     |
+| form           | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
+| hideStep       | `boolean` | Hides the step control of the element                                                                                                   |
+| max            | `number`  | Defines maximum number allowed                                                                                                          |
+| maxlength      | `number`  | The maximum number of characters allowed                                                                                                |
+| min            | `number`  | Defines minimum number allowed                                                                                                          |
+| minlength      | `number`  | The minimum number of characters allowed                                                                                                |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                                    |
+| size           | `number`  | Defines the width of the component                                                                                                      |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                                            |
+| value          | `string`  | Defines a value for the component when it is created                                                                                    |
+| withFormatting | `boolean` | Allows number formatting                                                                                                                |
 
 These attributes must be defined alongside the declaration of the component.
 

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -24,16 +24,16 @@ You can define the following attributes in an `<alpha-number-field>`.
 
 | Name           | Type      | Description                                                                                                              |
 |----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | It changes the general view of the element. It can be **filled** or **outline**                                          |
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                          |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | It disables this component, not letting the user to change its value                                                     |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                     |
 | hideStep       | `boolean` | Displays the step control of the element                                                                                 |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
 | min            | `number`  | Defines minimum number allowed                                                                                           |
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element                                                                                       |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting                                      |
 | size           | `number`  | Defines the width of the component                                                                                       |
 | step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
@@ -24,16 +24,16 @@ You can define the following attributes in an `<alpha-number-field>`.
 
 | Name           | Type      | Description                                                                                                              |
 |----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | It changes the general view of the element. It can be **filled** or **outline**                                          |
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | It disables this component, not letting the user to change its value                                                     |
-| hideStep       | `boolean` | Displays the step control of the element                                                                                 |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
+| hideStep       | `boolean` | Hides the step control of the element                                                                                    |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
 | min            | `number`  | Defines minimum number allowed                                                                                           |
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element                                                                                       |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
 | size           | `number`  | Defines the width of the component                                                                                       |
 | step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |
@@ -49,11 +49,11 @@ of this component accordingly.
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
-- **Example 2**: a number-field formatting the number from "de-De" (German/Germany)
+- **Example 2**: a number-field in German format "de-De" (German/Germany)
 ```html title="Example 2"
 <alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
 ```
-- **Example 3**: a number-field with step 0.5
+- **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
 ```
@@ -98,4 +98,3 @@ From this point, you can access the value of the component in your application.
 - Display numbers
 - Insert numbers
 - Search boxes
-

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
@@ -27,6 +27,7 @@ You can define the following attributes in an `<alpha-number-field>`.
 | appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
 | disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | hideStep       | `boolean` | Hides the step control of the element                                                |
 | max            | `number`  | Defines maximum number allowed                                                       |
 | maxlength      | `number`  | The maximum number of characters allowed                                             |

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
@@ -27,7 +27,6 @@ You can define the following attributes in an `<alpha-number-field>`.
 | appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
 | disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
-| hideStep       | `boolean` | Hides the step control of the element                                                                                    |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
@@ -35,11 +34,22 @@ You can define the following attributes in an `<alpha-number-field>`.
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
 | placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
 | size           | `number`  | Defines the width of the component                                                                                       |
-| step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                             |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |
 | withFormatting | `boolean` | Allows number formatting                                                                                                 |
 
 These attributes must be defined alongside the declaration of the component.
+
+### Custom options
+
+The `number-field` has 2 custom options:
+
+| Variable              | Type     | Default | Description                                                                          |
+|-----------------------|----------|---------|--------------------------------------------------------------------------------------|
+| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted                                            |
+| minimumFractionDigits | `number` | 0       | Minimum number of decimal digits. If minimum not reached, it will be filled with `0` |
+
+All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -56,6 +66,10 @@ of this component accordingly.
 - **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+- **Example 4**: a number-field with a maximum digit number of 2 and minimum of 2
+```html title="Example 4"
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
@@ -22,34 +22,23 @@ provideDesignSystem().register(alphaNumberField());
 
 You can define the following attributes in an `<alpha-number-field>`.
 
-| Name           | Type      | Description                                                                                                              |
-|----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
-| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
-| max            | `number`  | Defines maximum number allowed                                                                                           |
-| maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
-| min            | `number`  | Defines minimum number allowed                                                                                           |
-| minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
-| size           | `number`  | Defines the width of the component                                                                                       |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                             |
-| value          | `string`  | Defines a value for the component when it is created                                                                     |
-| withFormatting | `boolean` | Allows number formatting                                                                                                 |
+| Name           | Type      | Description                                                                          |
+|----------------|-----------|--------------------------------------------------------------------------------------|
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
+| hideStep       | `boolean` | Hides the step control of the element                                                |
+| max            | `number`  | Defines maximum number allowed                                                       |
+| maxlength      | `number`  | The maximum number of characters allowed                                             |
+| min            | `number`  | Defines minimum number allowed                                                       |
+| minlength      | `number`  | The minimum number of characters allowed                                             |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting) |
+| size           | `number`  | Defines the width of the component                                                   |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**         |
+| value          | `string`  | Defines a value for the component when it is created                                 |
+| withFormatting | `boolean` | Allows number formatting                                                             |
 
 These attributes must be defined alongside the declaration of the component.
-
-### Custom options
-
-The `number-field` has 2 custom options:
-
-| Variable              | Type     | Default | Description                                                                          |
-|-----------------------|----------|---------|--------------------------------------------------------------------------------------|
-| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted                                            |
-| minimumFractionDigits | `number` | 0       | Minimum number of decimal digits. If minimum not reached, it will be filled with `0` |
-
-All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -59,17 +48,10 @@ of this component accordingly.
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
-- **Example 2**: a number-field in German format "de-De" (German/Germany)
+
+- **Example 2**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 2"
-<alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
-```
-- **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
-```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
-```
-- **Example 4**: a number-field with a maximum digit number of 2 and minimum of 2
-```html title="Example 4"
-<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/04_number-field.md
@@ -4,10 +4,11 @@ sidebar_label: 'Number field'
 id: number-field
 keywords: [web, web components, number field]
 tags:
-    - web
-    - web components
-    - number field
+  - web
+  - web components
+  - number field
 ---
+
 A text field for numeric entry.
 
 ## Set-up
@@ -17,16 +18,84 @@ import { provideDesignSystem, alphaNumberField } from '@genesislcap/alpha-design
 
 provideDesignSystem().register(alphaNumberField());
 ```
+## Attributes
+
+You can define the following attributes in an `<alpha-number-field>`.
+
+| Name           | Type      | Description                                                                                                              |
+|----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
+| appearance     | `string`  | It changes the general view of the element. It can be **filled** or **outline**                                          |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
+| disabled       | `boolean` | It disables this component, not letting the user to change its value                                                     |
+| hideStep       | `boolean` | Displays the step control of the element                                                                                 |
+| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
+| max            | `number`  | Defines maximum number allowed                                                                                           |
+| maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
+| min            | `number`  | Defines minimum number allowed                                                                                           |
+| minlength      | `number`  | The minimum number of characters allowed                                                                                 |
+| placeholder    | `string`  | Sets a placeholder for the element                                                                                       |
+| size           | `number`  | Defines the width of the component                                                                                       |
+| step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
+| value          | `string`  | Defines a value for the component when it is created                                                                     |
+| withFormatting | `boolean` | Allows number formatting                                                                                                 |
+
+These attributes must be defined alongside the declaration of the component.
 
 ## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
 
-The `alpha-number-field` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
-
-```html live
-<alpha-number-field appearance="filled" min="0" max="10"></alpha-number-field>
+- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control
+```html title="Example 1"
+<alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
+- **Example 2**: a number-field formatting the number from "de-De" (German/Germany)
+```html title="Example 2"
+<alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
+```
+- **Example 3**: a number-field with step 0.5
+```html title="Example 3"
+<alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+
+### Get the user input
+In order to use a value input to this component, follow these two steps:
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable number_field: number
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_area`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-number-field value=${sync((x) => x.number_field)}>TEXT</alpha-number-field>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-number-field>Try</alpha-number-field>
+```
+
 
 ## Use cases
 
-* Anywhere where `input[type="number"]` could be used
+- Display numbers
+- Insert numbers
+- Search boxes
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -27,7 +27,6 @@ You can define the following attributes in an `<alpha-number-field>`.
 | appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
 | disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
-| hideStep       | `boolean` | Hides the step control of the element                                                                                    |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
@@ -35,11 +34,22 @@ You can define the following attributes in an `<alpha-number-field>`.
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
 | placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
 | size           | `number`  | Defines the width of the component                                                                                       |
-| step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                             |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |
 | withFormatting | `boolean` | Allows number formatting                                                                                                 |
 
 These attributes must be defined alongside the declaration of the component.
+
+### Custom options
+
+The `number-field` has 2 custom options:
+
+| Variable              | Type     | Default | Description                                                                          |
+|-----------------------|----------|---------|--------------------------------------------------------------------------------------|
+| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted                                            |
+| minimumFractionDigits | `number` | 0       | Minimum number of decimal digits. If minimum not reached, it will be filled with `0` |
+
+All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -56,6 +66,10 @@ of this component accordingly.
 - **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+- **Example 4**: a number-field with a maximum digit number of 2 and minimum of 2
+```html title="Example 4"
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -8,6 +8,7 @@ tags:
     - web components
     - number field
 ---
+
 A text field for numeric entry.
 
 ## Set-up
@@ -17,16 +18,84 @@ import { provideDesignSystem, alphaNumberField } from '@genesislcap/alpha-design
 
 provideDesignSystem().register(alphaNumberField());
 ```
+## Attributes
+
+You can define the following attributes in an `<alpha-number-field>`.
+
+| Name           | Type      | Description                                                                                                              |
+|----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
+| appearance     | `string`  | It changes the general view of the element. It can be **filled** or **outline**                                          |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
+| disabled       | `boolean` | It disables this component, not letting the user to change its value                                                     |
+| hideStep       | `boolean` | Displays the step control of the element                                                                                 |
+| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
+| max            | `number`  | Defines maximum number allowed                                                                                           |
+| maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
+| min            | `number`  | Defines minimum number allowed                                                                                           |
+| minlength      | `number`  | The minimum number of characters allowed                                                                                 |
+| placeholder    | `string`  | Sets a placeholder for the element                                                                                       |
+| size           | `number`  | Defines the width of the component                                                                                       |
+| step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
+| value          | `string`  | Defines a value for the component when it is created                                                                     |
+| withFormatting | `boolean` | Allows number formatting                                                                                                 |
+
+These attributes must be defined alongside the declaration of the component.
 
 ## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
 
-The `alpha-number-field` supports two visual appearances: outline and filled, with the control defaulting to the outline appearance.
-
-```html live
-<alpha-number-field appearance="filled" min="0" max="10"></alpha-number-field>
+- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control 
+```html title="Example 1"
+<alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
+- **Example 2**: a number-field formatting the number from "de-De" (German/Germany)   
+```html title="Example 2"
+<alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
+```
+- **Example 3**: a number-field with step 0.5 
+```html title="Example 3"
+<alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+
+### Get the user input
+In order to use a value input to this component, follow these two steps:
+
+1. Create an `@observable` variable where you want to use this value:
+
+```html {1,5}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable number_field: number
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `text_area`:
+
+```typescript tile="Example 4" {1,4}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-number-field value=${sync((x) => x.number_field)}>TEXT</alpha-number-field>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-number-field>Try</alpha-number-field>
+```
+
 
 ## Use cases
 
-* Anywhere where `input[type="number"]` could be used
+- Display numbers
+- Insert numbers
+- Search boxes
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -22,34 +22,23 @@ provideDesignSystem().register(alphaNumberField());
 
 You can define the following attributes in an `<alpha-number-field>`.
 
-| Name           | Type      | Description                                                                                                              |
-|----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
-| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
-| max            | `number`  | Defines maximum number allowed                                                                                           |
-| maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
-| min            | `number`  | Defines minimum number allowed                                                                                           |
-| minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
-| size           | `number`  | Defines the width of the component                                                                                       |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                             |
-| value          | `string`  | Defines a value for the component when it is created                                                                     |
-| withFormatting | `boolean` | Allows number formatting                                                                                                 |
+| Name           | Type      | Description                                                                          |
+|----------------|-----------|--------------------------------------------------------------------------------------|
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
+| hideStep       | `boolean` | Hides the step control of the element                                                |
+| max            | `number`  | Defines maximum number allowed                                                       |
+| maxlength      | `number`  | The maximum number of characters allowed                                             |
+| min            | `number`  | Defines minimum number allowed                                                       |
+| minlength      | `number`  | The minimum number of characters allowed                                             |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting) |
+| size           | `number`  | Defines the width of the component                                                   |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**         |
+| value          | `string`  | Defines a value for the component when it is created                                 |
+| withFormatting | `boolean` | Allows number formatting                                                             |
 
 These attributes must be defined alongside the declaration of the component.
-
-### Custom options
-
-The `number-field` has 2 custom options:
-
-| Variable              | Type     | Default | Description                                                                          |
-|-----------------------|----------|---------|--------------------------------------------------------------------------------------|
-| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted                                            |
-| minimumFractionDigits | `number` | 0       | Minimum number of decimal digits. If minimum not reached, it will be filled with `0` |
-
-All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -59,17 +48,10 @@ of this component accordingly.
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
-- **Example 2**: a number-field in German format "de-De" (German/Germany)
+
+- **Example 2**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 2"
-<alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
-```
-- **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
-```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
-```
-- **Example 4**: a number-field with a maximum digit number of 2 and minimum of 2
-```html title="Example 4"
-<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -4,9 +4,9 @@ sidebar_label: 'Number field'
 id: number-field
 keywords: [web, web components, number field]
 tags:
-    - web
-    - web components
-    - number field
+  - web
+  - web components
+  - number field
 ---
 
 A text field for numeric entry.
@@ -24,16 +24,16 @@ You can define the following attributes in an `<alpha-number-field>`.
 
 | Name           | Type      | Description                                                                                                              |
 |----------------|-----------|--------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | It changes the general view of the element. It can be **filled** or **outline**                                          |
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                            |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                              |
-| disabled       | `boolean` | It disables this component, not letting the user to change its value                                                     |
-| hideStep       | `boolean` | Displays the step control of the element                                                                                 |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                      |
+| hideStep       | `boolean` | Hides the step control of the element                                                                                    |
 | locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting` |
 | max            | `number`  | Defines maximum number allowed                                                                                           |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                 |
 | min            | `number`  | Defines minimum number allowed                                                                                           |
 | minlength      | `number`  | The minimum number of characters allowed                                                                                 |
-| placeholder    | `string`  | Sets a placeholder for the element                                                                                       |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                     |
 | size           | `number`  | Defines the width of the component                                                                                       |
 | step           | `number`  | Defines the step rate when using the arrows in the element                                                               |
 | value          | `string`  | Defines a value for the component when it is created                                                                     |
@@ -45,15 +45,15 @@ These attributes must be defined alongside the declaration of the component.
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
-- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control 
+- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
-- **Example 2**: a number-field formatting the number from "de-De" (German/Germany)   
+- **Example 2**: a number-field in German format "de-De" (German/Germany)
 ```html title="Example 2"
 <alpha-number-field withFormatting locale="de-De">Number-field</alpha-number-field>
 ```
-- **Example 3**: a number-field with step 0.5 
+- **Example 3**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 3"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
 ```
@@ -98,4 +98,3 @@ From this point, you can access the value of the component in your application.
 - Display numbers
 - Insert numbers
 - Search boxes
-

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -26,6 +26,7 @@ You can define the following attributes in an `<alpha-number-field>`.
 |----------------|-----------|--------------------------------------------------------------------------------------|
 | appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
 | hideStep       | `boolean` | Hides the step control of the element                                                |
 | max            | `number`  | Defines maximum number allowed                                                       |


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-928

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

