### PR TITLE
PTL-929: Improve slider documentation

### DIFF
--- a/docs/04_web/02_web-components/01_form/11_slider.md
+++ b/docs/04_web/02_web-components/01_form/11_slider.md
@@ -7,9 +7,11 @@ tags:
     - web
     - web components
     - slider
+    - slide label
 ---
 
-An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. 
+An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. This component is used alongside with 
+`alpha-slide-label`
 
 ## Set-up
 
@@ -18,21 +20,106 @@ import { provideDesignSystem, alphaSlider, alphaSliderLabel } from '@genesislcap
 
 provideDesignSystem().register(alphaSlider(), alphaSliderLabel());
 ```
+## Attributes
+
+You can define the following attributes in an `<alpha-slider>`.
+
+| Name        | Type      | Description                                                   |
+|-------------|-----------|---------------------------------------------------------------|
+| disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
+| max         | `number`  | Defines maximum number of the slider                          |
+| min         | `number`  | Defines minimum number of the slider                          |
+| step        | `number`  | Defines the step of the slider                                |
+| readonly    | `boolean` | It blocks the user to interact with the element               |
+| value       | `number`  | Defines a value for the component when it is created          |
+| orientation | `string`  | Define the orientation to `vertical` or `horizontal`          |
+
+These attributes must be defined alongside the declaration of the component.
+
+:::note
+If you use the vertical orientation, the height of the component is defined as 160px as default. If you want to change it,
+go to your css and adjust the height of the component.
+:::
+
+### slide-label
+You can use this component with a `<alpha-slide-label>`. This component creates a label along with the slider so you
+can point out some values. 
+
+| Name     | Type     | Description                                                |
+|----------|----------|------------------------------------------------------------|
+| position | `number` | A position relative to min or max value to place the label |
 
 ## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
 
-```html live
-<alpha-slider min="0" max="100" step="10" value="70">
-  <alpha-slider-label position="0"> 0 </alpha-slider-label>
-  <alpha-slider-label position="10"> 10 </alpha-slider-label>
-  <alpha-slider-label position="90"> 90 </alpha-slider-label>
-  <alpha-slider-label position="100"> 100 </alpha-slider-label>
+- **Example 1**: a slider with min = 0 and max = 100 with value set as 70
+```html title="Example 1"
+<alpha-slider min="0" max="100" value="70"></alpha-slider>
+```
+- **Example 2**: a slider with min = 0 and max = 100 with 3 labels positioning in 0, 50 and 100 with step of 5
+```html title="Example 2"
+<alpha-slider min="0" max="100" step="5">
+    <alpha-slider-label position="0"> low </alpha-slider-label>
+    <alpha-slider-label position="50"> mid </alpha-slider-label>
+    <alpha-slider-label position="100"> high </alpha-slider-label>
+</alpha-slider>
+```
+- **Example 3**: a vertical slider
+```html title="Example 3"
+<alpha-slider orientation="vertical"></alpha-slider>
+```
+
+### Get the user input
+In order to use a value input to this component, you may have 2 options: retrieving the information in a number type using `valueAsNumber` or in 
+a string type using: `valueTextFormatter`. For both options, follow the following steps:
+
+1. Create an `@observable` variable where you want to use this value. Remember to choose the right type.
+
+```html {1,5,6}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable slider_value_number: number
+@observable slider_value_string: string
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `slider_value_number` or `slider_value_string`:
+
+```typescript tile="Example 4" {1,7,8}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-slider 
+            min="0" 
+            max="100" 
+            valueAsNumber=${sync((x) => x.slider_value_number)} 
+            valueTextFormatter=${sync((x) => x.slider_value_string)}></alpha-slider>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-slider min="0" max="100" step="10" value="50">
+    <alpha-slider-label position="0"> very low </alpha-slider-label>
+    <alpha-slider-label position="30"> low </alpha-slider-label>
+    <alpha-slider-label position="70"> high </alpha-slider-label>
+    <alpha-slider-label position="100"> very high </alpha-slider-label>
 </alpha-slider>
 ```
 
 ## Use cases
 
-* Adjusting the value by dragging the slider in step increments within the constraints of min/max values.
+- Interact with data visualization
+- Input for numeric values
+- Dynamic filters
 
 ## Additional resources
 

--- a/docs/04_web/02_web-components/01_form/11_slider.md
+++ b/docs/04_web/02_web-components/01_form/11_slider.md
@@ -26,6 +26,7 @@ You can define the following attributes in an `<alpha-slider>`.
 | Name        | Type      | Description                                                   |
 |-------------|-----------|---------------------------------------------------------------|
 | disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | max         | `number`  | Defines maximum number of the slider                          |
 | min         | `number`  | Defines minimum number of the slider                          |
 | step        | `number`  | Defines the value of each step of the slider                  |

--- a/docs/04_web/02_web-components/01_form/11_slider.md
+++ b/docs/04_web/02_web-components/01_form/11_slider.md
@@ -10,8 +10,7 @@ tags:
     - slide label
 ---
 
-An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. This component is used alongside with 
-`alpha-slide-label`
+An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. This component is used together with the `alpha-slide-label`. It displays a slider that the user can move in either direction to reset the value.
 
 ## Set-up
 
@@ -29,10 +28,10 @@ You can define the following attributes in an `<alpha-slider>`.
 | disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
 | max         | `number`  | Defines maximum number of the slider                          |
 | min         | `number`  | Defines minimum number of the slider                          |
-| step        | `number`  | Defines the step of the slider                                |
-| readonly    | `boolean` | It blocks the user to interact with the element               |
+| step        | `number`  | Defines the value of each step of the slider                  |
+| readonly    | `boolean` | The slider is for display only, and cannot be changed by the user |
 | value       | `number`  | Defines a value for the component when it is created          |
-| orientation | `string`  | Define the orientation to `vertical` or `horizontal`          |
+| orientation | `string`  | Defines the orientation: `vertical` or `horizontal`           |
 
 These attributes must be defined alongside the declaration of the component.
 
@@ -42,8 +41,7 @@ go to your css and adjust the height of the component.
 :::
 
 ### slide-label
-You can use this component with a `<alpha-slide-label>`. This component creates a label along with the slider so you
-can point out some values. 
+You can use this component with an `<alpha-slide-label>`. This creates a label for the slider where you can display relevant values. 
 
 | Name     | Type     | Description                                                |
 |----------|----------|------------------------------------------------------------|
@@ -57,7 +55,7 @@ of this component accordingly.
 ```html title="Example 1"
 <alpha-slider min="0" max="100" value="70"></alpha-slider>
 ```
-- **Example 2**: a slider with min = 0 and max = 100 with 3 labels positioning in 0, 50 and 100 with step of 5
+- **Example 2**: a slider with min = 0 and max = 100 with 3 labels positioned at 0, 50 and 100 in steps of 5
 ```html title="Example 2"
 <alpha-slider min="0" max="100" step="5">
     <alpha-slider-label position="0"> low </alpha-slider-label>
@@ -71,8 +69,12 @@ of this component accordingly.
 ```
 
 ### Get the user input
-In order to use a value input to this component, you may have 2 options: retrieving the information in a number type using `valueAsNumber` or in 
-a string type using: `valueTextFormatter`. For both options, follow the following steps:
+Once the user has input a value to this component by moving the slider, there are two ways of retrieving the new value so that you can use it in the application:
+
+- as a number type, using `valueAsNumber` 
+- as a string type using: `valueTextFormatter`
+
+Both options work the same way:
 
 1. Create an `@observable` variable where you want to use this value. Remember to choose the right type.
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/10_slider.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/10_slider.md
@@ -7,9 +7,11 @@ tags:
     - web
     - web components
     - slider
+    - slide label
 ---
 
-An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. 
+An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. This component is used alongside with
+`alpha-slide-label`
 
 ## Set-up
 
@@ -18,21 +20,106 @@ import { provideDesignSystem, alphaSlider, alphaSliderLabel } from '@genesislcap
 
 provideDesignSystem().register(alphaSlider(), alphaSliderLabel());
 ```
+## Attributes
+
+You can define the following attributes in an `<alpha-slider>`.
+
+| Name        | Type      | Description                                                   |
+|-------------|-----------|---------------------------------------------------------------|
+| disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
+| max         | `number`  | Defines maximum number of the slider                          |
+| min         | `number`  | Defines minimum number of the slider                          |
+| step        | `number`  | Defines the step of the slider                                |
+| readonly    | `boolean` | It blocks the user to interact with the element               |
+| value       | `number`  | Defines a value for the component when it is created          |
+| orientation | `string`  | Define the orientation to `vertical` or `horizontal`          |
+
+These attributes must be defined alongside the declaration of the component.
+
+:::note
+If you use the vertical orientation, the height of the component is defined as 160px as default. If you want to change it,
+go to your css and adjust the height of the component.
+:::
+
+### slide-label
+You can use this component with a `<alpha-slide-label>`. This component creates a label along with the slider so you
+can point out some values.
+
+| Name     | Type     | Description                                                |
+|----------|----------|------------------------------------------------------------|
+| position | `number` | A position relative to min or max value to place the label |
 
 ## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
 
-```html live
-<alpha-slider min="0" max="100" step="10" value="70">
-  <alpha-slider-label position="0"> 0 </alpha-slider-label>
-  <alpha-slider-label position="10"> 10 </alpha-slider-label>
-  <alpha-slider-label position="90"> 90 </alpha-slider-label>
-  <alpha-slider-label position="100"> 100 </alpha-slider-label>
+- **Example 1**: a slider with min = 0 and max = 100 with value set as 70
+```html title="Example 1"
+<alpha-slider min="0" max="100" value="70"></alpha-slider>
+```
+- **Example 2**: a slider with min = 0 and max = 100 with 3 labels positioning in 0, 50 and 100 with step of 5
+```html title="Example 2"
+<alpha-slider min="0" max="100" step="5">
+    <alpha-slider-label position="0"> low </alpha-slider-label>
+    <alpha-slider-label position="50"> mid </alpha-slider-label>
+    <alpha-slider-label position="100"> high </alpha-slider-label>
+</alpha-slider>
+```
+- **Example 3**: a vertical slider
+```html title="Example 3"
+<alpha-slider orientation="vertical"></alpha-slider>
+```
+
+### Get the user input
+In order to use a value input to this component, you may have 2 options: retrieving the information in a number type using `valueAsNumber` or in
+a string type using: `valueTextFormatter`. For both options, follow the following steps:
+
+1. Create an `@observable` variable where you want to use this value. Remember to choose the right type.
+
+```html {1,5,6}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable slider_value_number: number
+@observable slider_value_string: string
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `slider_value_number` or `slider_value_string`:
+
+```typescript tile="Example 4" {1,7,8}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-slider 
+            min="0" 
+            max="100" 
+            valueAsNumber=${sync((x) => x.slider_value_number)} 
+            valueTextFormatter=${sync((x) => x.slider_value_string)}></alpha-slider>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-slider min="0" max="100" step="10" value="50">
+    <alpha-slider-label position="0"> very low </alpha-slider-label>
+    <alpha-slider-label position="30"> low </alpha-slider-label>
+    <alpha-slider-label position="70"> high </alpha-slider-label>
+    <alpha-slider-label position="100"> very high </alpha-slider-label>
 </alpha-slider>
 ```
 
 ## Use cases
 
-* Adjusting the value by dragging the slider in step increments within the constraints of min/max values.
+- Interact with data visualization
+- Input for numeric values
+- Dynamic filters
 
 ## Additional resources
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/10_slider.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/10_slider.md
@@ -27,6 +27,7 @@ You can define the following attributes in an `<alpha-slider>`.
 | Name        | Type      | Description                                                   |
 |-------------|-----------|---------------------------------------------------------------|
 | disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | max         | `number`  | Defines maximum number of the slider                          |
 | min         | `number`  | Defines minimum number of the slider                          |
 | step        | `number`  | Defines the step of the slider                                |

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/10_slider.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/10_slider.md
@@ -7,9 +7,11 @@ tags:
     - web
     - web components
     - slider
+    - slide label
 ---
 
-An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. 
+An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected Web Component. This component is used alongside with
+`alpha-slide-label`
 
 ## Set-up
 
@@ -18,21 +20,106 @@ import { provideDesignSystem, alphaSlider, alphaSliderLabel } from '@genesislcap
 
 provideDesignSystem().register(alphaSlider(), alphaSliderLabel());
 ```
+## Attributes
+
+You can define the following attributes in an `<alpha-slider>`.
+
+| Name        | Type      | Description                                                   |
+|-------------|-----------|---------------------------------------------------------------|
+| disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
+| max         | `number`  | Defines maximum number of the slider                          |
+| min         | `number`  | Defines minimum number of the slider                          |
+| step        | `number`  | Defines the step of the slider                                |
+| readonly    | `boolean` | It blocks the user to interact with the element               |
+| value       | `number`  | Defines a value for the component when it is created          |
+| orientation | `string`  | Define the orientation to `vertical` or `horizontal`          |
+
+These attributes must be defined alongside the declaration of the component.
+
+:::note
+If you use the vertical orientation, the height of the component is defined as 160px as default. If you want to change it,
+go to your css and adjust the height of the component.
+:::
+
+### slide-label
+You can use this component with a `<alpha-slide-label>`. This component creates a label along with the slider so you
+can point out some values.
+
+| Name     | Type     | Description                                                |
+|----------|----------|------------------------------------------------------------|
+| position | `number` | A position relative to min or max value to place the label |
 
 ## Usage
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
+of this component accordingly.
 
-```html live
-<alpha-slider min="0" max="100" step="10" value="70">
-  <alpha-slider-label position="0"> 0 </alpha-slider-label>
-  <alpha-slider-label position="10"> 10 </alpha-slider-label>
-  <alpha-slider-label position="90"> 90 </alpha-slider-label>
-  <alpha-slider-label position="100"> 100 </alpha-slider-label>
+- **Example 1**: a slider with min = 0 and max = 100 with value set as 70
+```html title="Example 1"
+<alpha-slider min="0" max="100" value="70"></alpha-slider>
+```
+- **Example 2**: a slider with min = 0 and max = 100 with 3 labels positioning in 0, 50 and 100 with step of 5
+```html title="Example 2"
+<alpha-slider min="0" max="100" step="5">
+    <alpha-slider-label position="0"> low </alpha-slider-label>
+    <alpha-slider-label position="50"> mid </alpha-slider-label>
+    <alpha-slider-label position="100"> high </alpha-slider-label>
+</alpha-slider>
+```
+- **Example 3**: a vertical slider
+```html title="Example 3"
+<alpha-slider orientation="vertical"></alpha-slider>
+```
+
+### Get the user input
+In order to use a value input to this component, you may have 2 options: retrieving the information in a number type using `valueAsNumber` or in
+a string type using: `valueTextFormatter`. For both options, follow the following steps:
+
+1. Create an `@observable` variable where you want to use this value. Remember to choose the right type.
+
+```html {1,5,6}
+import {... , observable} from '@microsoft/fast-element';
+...
+export class TEMPLATE extends FASTElement {
+...
+@observable slider_value_number: number
+@observable slider_value_string: string
+...
+}
+```
+
+2. Use the `sync` function to insert the value from the component into the variable `slider_value_number` or `slider_value_string`:
+
+```typescript tile="Example 4" {1,7,8}
+import {sync} from '@genesislcap/foundation-utils';
+...
+    ...
+        <alpha-slider 
+            min="0" 
+            max="100" 
+            valueAsNumber=${sync((x) => x.slider_value_number)} 
+            valueTextFormatter=${sync((x) => x.slider_value_string)}></alpha-slider>
+    ...
+...    
+```
+
+From this point, you can access the value of the component in your application.
+
+## Try yourself
+
+```html title="try yourself" live
+<alpha-slider min="0" max="100" step="10" value="50">
+    <alpha-slider-label position="0"> very low </alpha-slider-label>
+    <alpha-slider-label position="30"> low </alpha-slider-label>
+    <alpha-slider-label position="70"> high </alpha-slider-label>
+    <alpha-slider-label position="100"> very high </alpha-slider-label>
 </alpha-slider>
 ```
 
 ## Use cases
 
-* Adjusting the value by dragging the slider in step increments within the constraints of min/max values.
+- Interact with data visualization
+- Input for numeric values
+- Dynamic filters
 
 ## Additional resources
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/10_slider.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/10_slider.md
@@ -27,6 +27,7 @@ You can define the following attributes in an `<alpha-slider>`.
 | Name        | Type      | Description                                                   |
 |-------------|-----------|---------------------------------------------------------------|
 | disabled    | `boolean` | Similar to `readonly`, but with a blur layer in the component |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | max         | `number`  | Defines maximum number of the slider                          |
 | min         | `number`  | Defines minimum number of the slider                          |
 | step        | `number`  | Defines the step of the slider                                |


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-929

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

