### PR TITLE
feat: Drafted consolidators as object docs. (PTL-674)

### DIFF
--- a/docs/03_server/07_consolidator/01_introduction.md
+++ b/docs/03_server/07_consolidator/01_introduction.md
@@ -47,15 +47,15 @@ If your application is called *Tiresias*, your configuration file is **tiresias-
 
 ## Consolidator on-demand (objects)
 
-Consolidator objects are classes that can be used in code elsewhere in your application. They can be used in custom services, as well as in Request Servers and Event Handlers.
+As an alternative to running a Consolidator as a service, you can create Consolidator objects as classes that can be used in code elsewhere in your application. They can be used in custom services, as well as in Request Servers and Event Handlers.
 
-These Consolidators perform on-demand consolidations where the input can be one of the following:
+These Consolidators perform on-demand consolidations where the input can be:
 
-- it can be read directly from the database
-- it can be provided at runtime
-- it can be a combination of both of these.
+- read directly from the database
+- provided at runtime
+- a combination of both of these
 
-Effectively, that gives you three types of Consolidator objects, which we shall introduce after the following simple example:
+Effectively, that gives you three types of Consolidator object, which we shall introduce after the following simple example:
 
 ```kotlin
 // consolidate database records:
@@ -68,12 +68,13 @@ val orders: List<Order> = tradeConsolidator.consolidate(trade1, trade2, trade3)
 val result = tradeConsolidator.whatIf(Trade.ByOrderId("2"), trade1, trade2)
 ```
 ### Three types of Consolidator object
-You can consider the following types of Consolidator object as different use cases:
+In practice, you can create three types of Consolidator object to cover different use cases:
+
 - **input-output**
 - **read input table**
 - **read output table**
 
-To showcase them the following simplified data models can be considered:
+To showcase them, the following simplified data models can be considered:
 
 **Trade**
 

--- a/docs/03_server/07_consolidator/01_introduction.md
+++ b/docs/03_server/07_consolidator/01_introduction.md
@@ -124,6 +124,23 @@ The consolidator can receive either a Trade or a List of Trades; it returns a Li
 
 Here is a simple example input-output Consolidator that handles this use case:
 
+```kotlin
+val trades:List<Trade> = createTrades()
+val tradeConsolidator = consolidator<Trade, TradeDetails> {
+    select {
+        sum { price * quantity } into TradeDetails::totalNotional
+        sum { quantity } into TradeDetails::totalQuantity
+    }
+    
+    groupBy { TradeDetails.byInstrumentId(currencyId) } into {
+        TradeDetails {
+            tradeDetailsId = groupId.tradeDetailsId
+        }
+    }
+}
+var tradeDetails:List<TradeDetails> = tradeConsolidator.consolidate(trades)
+```
+
 ### Read Input Table Consolidator
 
 This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything. 

--- a/docs/03_server/07_consolidator/01_introduction.md
+++ b/docs/03_server/07_consolidator/01_introduction.md
@@ -20,8 +20,8 @@ A Consolidator exists to aggregate data or perform calculations whenever the und
 Typical use cases are:
 
 - Calculate real-time positions based on intra-day price changes.
-- Calculate snapshot report of number of trades per day
-- Calculate snapshot numbers for a chart
+- Calculate snapshot report of number of trades per day.
+- Calculate snapshot numbers for a chart.
 
 Consolidators listen to updates on an underlying database object: either a view or a table. When there are changes to that object, the Consolidator aggregates those changes and then outputs the aggregated data to a specified type: the output type.
 

--- a/docs/03_server/07_consolidator/01_introduction.md
+++ b/docs/03_server/07_consolidator/01_introduction.md
@@ -74,7 +74,7 @@ In practice, you can create three types of Consolidator object to cover differen
 - **read input table**
 - **read output table**
 
-To showcase them, the following simplified data models can be considered:
+To showcase each of these, we shall use simple examples based on the following simplified data models:
 
 **Trade**
 
@@ -88,7 +88,10 @@ To showcase them, the following simplified data models can be considered:
 
 ### Input - Output Consolidator
 
-This type of Consolidator is not limited to tables. It takes any input and produces any output; the output it creates can be used elsewhere in your application. For example, it could read a table of trades and create the sum of all trade values.
+This type of Consolidator is not limited to tables. It can take any input and produce any output; that output can be used elsewhere in your application. 
+
+For example, your Consolidator object can read a table of trades and create the sum of all trade values.
+
 ````mermaid
 graph LR
     B[Input] --> C[Consolidator on Demand]
@@ -96,7 +99,7 @@ graph LR
   
 ````
 
-The consolidator can receive either a Trade or a List of Trades and returns a List of TradeDetail. The consolidation process would be the following:
+The consolidator can receive either a Trade or a List of Trades; it returns a List of TradeDetail. The consolidation process is:
 
 <table>
 <tr><th>Trade List (Runtime) </th><th></th><th>TradeDetail List (Runtime)</th></tr>
@@ -119,12 +122,13 @@ The consolidator can receive either a Trade or a List of Trades and returns a Li
 
 </td></tr> </table>
 
-
-The following snippet showcases a simple usage of the input-output consolidator:
+Here is a simple example input-output Consolidator that handles this use case:
 
 ### Read Input Table Consolidator
 
-This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything. For example, it could read updates to a table of orders and check the table of trades to find other trades that match that order (by order number or by counterparty, for example).
+This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything. 
+
+For example, the Consolidator could read updates to a table of orders and check the table of trades to find other trades that match that order (by order number or by counterparty, for example).
 ````mermaid
 graph LR
     N[Consolidator On Demand]
@@ -133,7 +137,7 @@ graph LR
     N -->O[Output Runtime Entity]
 ````
 
-The consolidation process would be the following:
+The consolidation process for this is:
 
 <table>
 <tr><th>Trade List (Runtime + DB) </th><th></th><th>TradeDetails List (Runtime)</th></tr>
@@ -161,7 +165,7 @@ The consolidation process would be the following:
 
 </td></tr> </table>
 
-The following snippet showcases a simple usage of the read input table consolidator:
+Here is a simple example read-input-table Consolidator that handles this use case:
 
 ````kotlin
 val runtimeTrades:List<Trade> = createTrades()
@@ -193,7 +197,9 @@ var tradeDetails:List<TradeDetails> = tradeConsolidator.consolidate(runtimeTrade
 
 ### Read Output Table Consolidator
 
-This type of Consolidator can read any type of input, but the output must be a table. For example, it could read the output from a trade table (a new trade), and compare to an order in the order table. It could then calculate the effect of the change in terms of how much is outstanding and fulfilled in the order.
+This type of Consolidator can read any type of input, but the output must be a table. 
+
+For example, the Consolidator could read the output from a trade table (a new trade), and compare this to an order in the order table. It can then calculate the effect of the change in terms of how much of the order is outstanding and fulfilled.
 
 ````mermaid
 graph LR
@@ -202,7 +208,7 @@ L[Input Data] --> N[Consolidator On Demand]
 N -->O[Output Table]
 ````
 
-An example of this type of consolidation could be the following:
+The consolidation process for this is:
 
 <table>
 <tr><th>Trade List (Runtime) + TradeDetails(DB) </th><th></th><th>TradeDetails List (Runtime)</th></tr>
@@ -230,7 +236,7 @@ An example of this type of consolidation could be the following:
 </td></tr> </table>
 
 
-The following snippet showcases a simple usage of the read output table consolidator:
+Here is a simple example read-output-table Consolidator that handles this use case:
 
 ````kotlin
 val runtimeTrades:List<Trade> = createTrades()

--- a/docs/03_server/07_consolidator/01_introduction.md
+++ b/docs/03_server/07_consolidator/01_introduction.md
@@ -27,7 +27,7 @@ Consolidators listen to updates on an underlying database object: either a view 
 
 There are two ways to use GPAL Consolidators:
 
-- as a service: in this case, the output type must always be a table entity. The Consolidator service listens to table updates, and updates a target table. 
+- as a service: in this case, the output type must always be a table entity. The Consolidator service listens to table updates, and updates a target table.
 - on demand (as a Consolidator object): the object can be used in code in other parts of your application to perform on-demand consolidations and what-if analysis. The output is not saved in your application's database.
 
 ## Consolidator as a service
@@ -38,19 +38,22 @@ graph TD
     B -->|Stores Consolidated data| C[OUTPUT - Table]
 ````
 
-This is the standard method of using Consolidators. The Consolidator runs as a process (service) that you can monitor using the `mon` command. An individual Consolidator in your **consolidator.kts** file listens to a specific table and automatically updates an output table. 
+This is the standard method of using Consolidators. The Consolidator runs as a process (service) that you can monitor using the `mon` command. An individual Consolidator in your **consolidator.kts** file listens to a specific table and automatically updates an output table.
 
+Consolidators are conventionally defined in the file **_application_-consolidator.kts**.
+
+If your application is called *Tiresias*, your configuration file is **tiresias-consolidator.kts**.
 
 
 ## Consolidator on-demand (objects)
 
-Consolidator objects are classes that can be used in code elsewhere in your application. They can be used in custom services, as well as in Request Servers and Event Handlers. 
+Consolidator objects are classes that can be used in code elsewhere in your application. They can be used in custom services, as well as in Request Servers and Event Handlers.
 
 These Consolidators perform on-demand consolidations where the input can be one of the following:
 
 - it can be read directly from the database
 - it can be provided at runtime
-- it can be a combination of both of these. 
+- it can be a combination of both of these.
 
 Effectively, that gives you three types of Consolidator objects, which we shall introduce after the following simple example:
 
@@ -65,35 +68,193 @@ val orders: List<Order> = tradeConsolidator.consolidate(trade1, trade2, trade3)
 val result = tradeConsolidator.whatIf(Trade.ByOrderId("2"), trade1, trade2)
 ```
 ### Three types of Consolidator object
-You can consider the following types of Consolidator object as different use cases.
+You can consider the following types of Consolidator object as different use cases:
+- **input-output**
+- **read input table**
+- **read output table**
 
-- **input-output**. This type of Consolidator is not limited to tables. It takes any input and produces any output; the output it creates can be used elsewhere in your application. For example, it could read a table of trades and create the sum of all trade values.
+To showcase them the following simplified data models can be considered:
+
+**Trade**
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+
+**TradeDetails**
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+
+### Input - Output Consolidator
+
+This type of Consolidator is not limited to tables. It takes any input and produces any output; the output it creates can be used elsewhere in your application. For example, it could read a table of trades and create the sum of all trade values.
 ````mermaid
-graph TD
+graph LR
     B[Input] --> C[Consolidator on Demand]
     C --> D[Output]
   
 ````
-- **read input table**. This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything. For example, it could read updates to a table of orders and check the table of trades to find other trades that match that order (by order number or by counterparty, for example).
+
+The consolidator can receive either a Trade or a List of Trades and returns a List of TradeDetail. The consolidation process would be the following:
+
+<table>
+<tr><th>Trade List (Runtime) </th><th></th><th>TradeDetail List (Runtime)</th></tr>
+<tr><td>
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 1  | VOD          | 1        | 5     |
+| 3  | BARC         | 2        | 2     |
+| 4  | BARC         | 1        | 4     |
+
+</td><td>
+ &rarr;
+</td><td>
+
+| ID | InstrumentID | totalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 1  | VOD          | 1             | 5        |
+| 2  | BARC         | 3             | 8        |
+
+</td></tr> </table>
+
+
+The following snippet showcases a simple usage of the input-output consolidator:
+
+### Read Input Table Consolidator
+
+This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything. For example, it could read updates to a table of orders and check the table of trades to find other trades that match that order (by order number or by counterparty, for example).
 ````mermaid
-graph TD
-G --> I
-subgraph ide1 [ ]
-H[Input Data] --> I[Consolidator On Demand]
-I -->J[Output]
-end
-subgraph ide2 [ ]
-G[Input Table - from DB]
-end
+graph LR
+    N[Consolidator On Demand]
+    M[Input Data] -->  N
+    L[Input Table - from DB] --> N
+    N -->O[Output Runtime Entity]
 ````
-- **read output table**. This type of Consolidator can read any type of input, but the output must be a table. For example, it could read the output from a trade table (a new trade), and compare to an order in the order table. It could then calculate the effect of the change in terms of how much is outstanding and fulfilled in the order.
+
+The consolidation process would be the following:
+
+<table>
+<tr><th>Trade List (Runtime + DB) </th><th></th><th>TradeDetails List (Runtime)</th></tr>
+<tr><td>
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 1  | VOD          | 1        | 5     |
+| 3  | BARC         | 2        | 2     |
+| 4  | BARC         | 1        | 4     |
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 8  | VOD          | 5        | 2     |
+| 9  | BARC         | 5        | 3     |
+
+</td><td>
+ &rarr;
+</td><td>
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 1  | VOD          | 6             | 15       |
+| 2  | BARC         | 8             | 23       |
+
+</td></tr> </table>
+
+The following snippet showcases a simple usage of the read input table consolidator:
+
+````kotlin
+val runtimeTrades:List<Trade> = createTrades()
+val dbTrades:List<Trade> = createDbTrades()
+
+val db by lazy { asyncEntityDb }
+
+val tradeConsolidator by lazy {
+    db.dualConsolidator<TRADE, POSITION_DETAILS> {
+        select {
+            POSITION_DETAILS {
+                sum { price * quantity } into NOTIONAL
+                sum { quantity } into TOTAL_QUANTITY
+            }
+        }
+
+        groupBy { TradeDetails.byInstrumentId(currencyId) }
+        into {
+            TradeDetails {
+                tradeDetailsId = groupId.tradeDetailsId
+            }
+        }
+    }
+}
+db.insertAll(dbTrades)
+
+var tradeDetails:List<TradeDetails> = tradeConsolidator.consolidate(runtimeTrades)
+````
+
+### Read Output Table Consolidator
+
+This type of Consolidator can read any type of input, but the output must be a table. For example, it could read the output from a trade table (a new trade), and compare to an order in the order table. It could then calculate the effect of the change in terms of how much is outstanding and fulfilled in the order.
+
 ````mermaid
-graph TD
+graph LR
 M[Input Data] -->  N[Consolidator On Demand]
 L[Input Data] --> N[Consolidator On Demand]
 N -->O[Output Table]
 ````
 
-Consolidators are conventionally defined in the file **_application_-consolidator.kts**. 
+An example of this type of consolidation could be the following:
 
-If your application is called *Tiresias*, your configuration file is **tiresias-consolidator.kts**.
+<table>
+<tr><th>Trade List (Runtime) + TradeDetails(DB) </th><th></th><th>TradeDetails List (Runtime)</th></tr>
+<tr><td>
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 1  | VOD          | 1        | 5     |
+| 3  | BARC         | 2        | 2     |
+| 4  | BARC         | 1        | 4     |
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 8  | VOD          | 100           | 1000     |
+
+</td><td>
+ &rarr;
+</td><td>
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 1  | VOD          | 101           | 1005     |
+| 2  | BARC         | 3             | 8        |
+
+</td></tr> </table>
+
+
+The following snippet showcases a simple usage of the read output table consolidator:
+
+````kotlin
+val runtimeTrades:List<Trade> = createTrades()
+
+val db by lazy { asyncEntityDb }
+val dbTradeDetails:List<TradeDetails> = createDbTradeDetails()
+
+val tradeConsolidator by lazy {
+    db.simulatingConsolidator<TRADE, TRADE_DETAILS> {
+        select {
+            TRADE_DETAILS {
+                sum { price * quantity } into NOTIONAL
+                sum { quantity } into TOTAL_QUANTITY
+            }
+        }
+
+        groupBy { TradeDetails.byInstrumentId(instrumentId) } into {
+            TradeDetails {
+                tradeDetailsId = groupId.tradeDetailsId
+            }
+        }
+    }
+}
+db.insertAll(dbTradeDetails)
+
+var tradeDetails:List<TradeDetails> = consolidator.whatIf(runtimeTrades)
+
+````

--- a/versioned_docs/version-2023.1/03_server/07_consolidator/01_introduction.md
+++ b/versioned_docs/version-2023.1/03_server/07_consolidator/01_introduction.md
@@ -4,9 +4,9 @@ sidebar_label: 'Introduction'
 id: introduction
 keywords: [server, consolidator, introduction]
 tags:
-  - server
-  - consolidator
-  - introduction
+- server
+- consolidator
+- introduction
 
 
 
@@ -20,14 +20,14 @@ A Consolidator exists to aggregate data or perform calculations whenever the und
 Typical use cases are:
 
 - Calculate real-time positions based on intra-day price changes.
-- Calculate snapshot report of number of trades per day
-- Calculate snapshot numbers for a chart
+- Calculate snapshot report of number of trades per day.
+- Calculate snapshot numbers for a chart.
 
 Consolidators listen to updates on an underlying database object: either a view or a table. When there are changes to that object, the Consolidator aggregates those changes and then outputs the aggregated data to a specified type: the output type.
 
 There are two ways to use GPAL Consolidators:
 
-- as a service: in this case, the output type must always be a table entity. The Consolidator service listens to table updates, and updates a target table. 
+- as a service: in this case, the output type must always be a table entity. The Consolidator service listens to table updates, and updates a target table.
 - on demand (as a Consolidator object): the object can be used in code in other parts of your application to perform on-demand consolidations and what-if analysis. The output is not saved in your application's database.
 
 ## Consolidator as a service
@@ -38,21 +38,24 @@ graph TD
     B -->|Stores Consolidated data| C[OUTPUT - Table]
 ````
 
-This is the standard method of using Consolidators. The Consolidator runs as a process (service) that you can monitor using the `mon` command. An individual Consolidator in your **consolidator.kts** file listens to a specific table and automatically updates an output table. 
+This is the standard method of using Consolidators. The Consolidator runs as a process (service) that you can monitor using the `mon` command. An individual Consolidator in your **consolidator.kts** file listens to a specific table and automatically updates an output table.
 
+Consolidators are conventionally defined in the file **_application_-consolidator.kts**.
+
+If your application is called *Tiresias*, your configuration file is **tiresias-consolidator.kts**.
 
 
 ## Consolidator on-demand (objects)
 
-Consolidator objects are classes that can be used in code elsewhere in your application. They can be used in custom services, as well as in Request Servers and Event Handlers. 
+As an alternative to running a Consolidator as a service, you can create Consolidator objects as classes that can be used in code elsewhere in your application. They can be used in custom services, as well as in Request Servers and Event Handlers.
 
-These Consolidators perform on-demand consolidations where the input can be one of the following:
+These Consolidators perform on-demand consolidations where the input can be:
 
-- it can be read directly from the database
-- it can be provided at runtime
-- it can be a combination of both of these. 
+- read directly from the database
+- provided at runtime
+- a combination of both of these
 
-Effectively, that gives you three types of Consolidator objects, which we shall introduce after the following simple example:
+Effectively, that gives you three types of Consolidator object, which we shall introduce after the following simple example:
 
 ```kotlin
 // consolidate database records:
@@ -65,35 +68,217 @@ val orders: List<Order> = tradeConsolidator.consolidate(trade1, trade2, trade3)
 val result = tradeConsolidator.whatIf(Trade.ByOrderId("2"), trade1, trade2)
 ```
 ### Three types of Consolidator object
-You can consider the following types of Consolidator object as different use cases.
+In practice, you can create three types of Consolidator object to cover different use cases:
 
-- **input-output**. This type of Consolidator is not limited to tables. It takes any input and produces any output; the output it creates can be used elsewhere in your application. For example, it could read a table of trades and create the sum of all trade values.
+- **input-output**
+- **read input table**
+- **read output table**
+
+To showcase each of these, we shall use simple examples based on the following simplified data models:
+
+**Trade**
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+
+**TradeDetails**
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+
+### Input - Output Consolidator
+
+This type of Consolidator is not limited to tables. It can take any input and produce any output; that output can be used elsewhere in your application.
+
+For example, your Consolidator object can read a table of trades and create the sum of all trade values.
+
 ````mermaid
-graph TD
+graph LR
     B[Input] --> C[Consolidator on Demand]
     C --> D[Output]
   
 ````
-- **read input table**. This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything. For example, it could read updates to a table of orders and check the table of trades to find other trades that match that order (by order number or by counterparty, for example).
+
+The consolidator can receive either a Trade or a List of Trades; it returns a List of TradeDetail. The consolidation process is:
+
+<table>
+<tr><th>Trade List (Runtime) </th><th></th><th>TradeDetail List (Runtime)</th></tr>
+<tr><td>
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 1  | VOD          | 1        | 5     |
+| 3  | BARC         | 2        | 2     |
+| 4  | BARC         | 1        | 4     |
+
+</td><td>
+ &rarr;
+</td><td>
+
+| ID | InstrumentID | totalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 1  | VOD          | 1             | 5        |
+| 2  | BARC         | 3             | 8        |
+
+</td></tr> </table>
+
+Here is a simple example input-output Consolidator that handles this use case:
+
+```kotlin
+val trades:List<Trade> = createTrades()
+val tradeConsolidator = consolidator<Trade, TradeDetails> {
+    select {
+        sum { price * quantity } into TradeDetails::totalNotional
+        sum { quantity } into TradeDetails::totalQuantity
+    }
+    
+    groupBy { TradeDetails.byInstrumentId(currencyId) } into {
+        TradeDetails {
+            tradeDetailsId = groupId.tradeDetailsId
+        }
+    }
+}
+var tradeDetails:List<TradeDetails> = tradeConsolidator.consolidate(trades)
+```
+
+### Read Input Table Consolidator
+
+This type of Consolidator reads a table where data is changed and then creates an output; the output can be anything.
+
+For example, the Consolidator could read updates to a table of orders and check the table of trades to find other trades that match that order (by order number or by counterparty, for example).
 ````mermaid
-graph TD
-G --> I
-subgraph ide1 [ ]
-H[Input Data] --> I[Consolidator On Demand]
-I -->J[Output]
-end
-subgraph ide2 [ ]
-G[Input Table - from DB]
-end
+graph LR
+    N[Consolidator On Demand]
+    M[Input Data] -->  N
+    L[Input Table - from DB] --> N
+    N -->O[Output Runtime Entity]
 ````
-- **read output table**. This type of Consolidator can read any type of input, but the output must be a table. For example, it could read the output from a trade table (a new trade), and compare to an order in the order table. It could then calculate the effect of the change in terms of how much is outstanding and fulfilled in the order.
+
+The consolidation process for this is:
+
+<table>
+<tr><th>Trade List (Runtime + DB) </th><th></th><th>TradeDetails List (Runtime)</th></tr>
+<tr><td>
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 1  | VOD          | 1        | 5     |
+| 3  | BARC         | 2        | 2     |
+| 4  | BARC         | 1        | 4     |
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 8  | VOD          | 5        | 2     |
+| 9  | BARC         | 5        | 3     |
+
+</td><td>
+ &rarr;
+</td><td>
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 1  | VOD          | 6             | 15       |
+| 2  | BARC         | 8             | 23       |
+
+</td></tr> </table>
+
+Here is a simple example read-input-table Consolidator that handles this use case:
+
+````kotlin
+val runtimeTrades:List<Trade> = createTrades()
+val dbTrades:List<Trade> = createDbTrades()
+
+val db by lazy { asyncEntityDb }
+
+val tradeConsolidator by lazy {
+    db.dualConsolidator<TRADE, POSITION_DETAILS> {
+        select {
+            POSITION_DETAILS {
+                sum { price * quantity } into NOTIONAL
+                sum { quantity } into TOTAL_QUANTITY
+            }
+        }
+
+        groupBy { TradeDetails.byInstrumentId(currencyId) }
+        into {
+            TradeDetails {
+                tradeDetailsId = groupId.tradeDetailsId
+            }
+        }
+    }
+}
+db.insertAll(dbTrades)
+
+var tradeDetails:List<TradeDetails> = tradeConsolidator.consolidate(runtimeTrades)
+````
+
+### Read Output Table Consolidator
+
+This type of Consolidator can read any type of input, but the output must be a table.
+
+For example, the Consolidator could read the output from a trade table (a new trade), and compare this to an order in the order table. It can then calculate the effect of the change in terms of how much of the order is outstanding and fulfilled.
+
 ````mermaid
-graph TD
+graph LR
 M[Input Data] -->  N[Consolidator On Demand]
 L[Input Data] --> N[Consolidator On Demand]
 N -->O[Output Table]
 ````
 
-Consolidators are conventionally defined in the file **_application_-consolidator.kts**. 
+The consolidation process for this is:
 
-If your application is called *Tiresias*, your configuration file is **tiresias-consolidator.kts**.
+<table>
+<tr><th>Trade List (Runtime) + TradeDetails(DB) </th><th></th><th>TradeDetails List (Runtime)</th></tr>
+<tr><td>
+
+| ID | InstrumentID | Quantity | Price |
+|----|--------------|----------|-------|
+| 1  | VOD          | 1        | 5     |
+| 3  | BARC         | 2        | 2     |
+| 4  | BARC         | 1        | 4     |
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 8  | VOD          | 100           | 1000     |
+
+</td><td>
+ &rarr;
+</td><td>
+
+| ID | InstrumentID | TotalQuantity | Notional |
+|----|--------------|---------------|----------|
+| 1  | VOD          | 101           | 1005     |
+| 2  | BARC         | 3             | 8        |
+
+</td></tr> </table>
+
+
+Here is a simple example read-output-table Consolidator that handles this use case:
+
+````kotlin
+val runtimeTrades:List<Trade> = createTrades()
+
+val db by lazy { asyncEntityDb }
+val dbTradeDetails:List<TradeDetails> = createDbTradeDetails()
+
+val tradeConsolidator by lazy {
+    db.simulatingConsolidator<TRADE, TRADE_DETAILS> {
+        select {
+            TRADE_DETAILS {
+                sum { price * quantity } into NOTIONAL
+                sum { quantity } into TOTAL_QUANTITY
+            }
+        }
+
+        groupBy { TradeDetails.byInstrumentId(instrumentId) } into {
+            TradeDetails {
+                tradeDetailsId = groupId.tradeDetailsId
+            }
+        }
+    }
+}
+db.insertAll(dbTradeDetails)
+
+var tradeDetails:List<TradeDetails> = consolidator.whatIf(runtimeTrades)
+
+````


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-674

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

