### PR TITLE
PTL-926: Includeform as an attribute

### DIFF
--- a/docs/04_web/02_web-components/01_form/14_text-field.md
+++ b/docs/04_web/02_web-components/01_form/14_text-field.md
@@ -23,20 +23,21 @@ provideDesignSystem().register(alphaTextField());
 
 You can define the following attributes in an `<alpha-text-field>`.
 
-| Name        | Type      | Description                                                                          |
-|-------------|-----------|--------------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading          |
-| appearance  | `string`  | Can be `outline` or `filled`                                                         |
-| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                              |
-| maxlength   | `number`  | The maximum number of characters allowed                                             |
-| minlength   | `number`  | The minimum number of characters allowed                                             |
-| name        | `string`  | Define the name of the element                                                       |
-| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing) |
-| readonly    | `boolean` | If true, the user cannot change the value of this field                              |
-| size        | `number`  | Sets the width of the component                                                      |
-| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
-| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}     | 
-| value       | `string`  | Sets the value for this component                                                    | 
+| Name        | Type      | Description                                                                                                                             |
+|-------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
+| appearance  | `string`  | Can be `outline` or `filled`                                                                                                            |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                                                 |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
+| maxlength   | `number`  | The maximum number of characters allowed                                                                                                |
+| minlength   | `number`  | The minimum number of characters allowed                                                                                                |
+| name        | `string`  | Define the name of the element                                                                                                          |
+| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing)                                                    |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                                                                                 |
+| size        | `number`  | Sets the width of the component                                                                                                         |
+| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component                                                    |
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}                                                        | 
+| value       | `string`  | Sets the value for this component                                                                                                       | 
 
 These attributes must be defined alongside the declaration of the component.
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/13_text-field.md
@@ -23,20 +23,21 @@ provideDesignSystem().register(alphaTextField());
 
 You can define the following attributes in an `<alpha-text-field>`.
 
-| Name        | Type      | Description                                                                          |
-|-------------|-----------|--------------------------------------------------------------------------------------|
-| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading          |
-| appearance  | `string`  | Can be `outline` or `filled`                                                         |
-| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                              |
-| maxlength   | `number`  | The maximum number of characters allowed                                             |
-| minlength   | `number`  | The minimum number of characters allowed                                             |
-| name        | `string`  | Define the name of the element                                                       |
-| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing) |
-| readonly    | `boolean` | If true, the user cannot change the value of this field                              |
-| size        | `number`  | Sets the width of the component                                                      |
-| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component |
-| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}     | 
-| value       | `string`  | Sets the value for this component                                                    | 
+| Name        | Type      | Description                                                                                                                             |
+|-------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| autofocus   | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
+| appearance  | `string`  | Can be `outline` or `filled`                                                                                                            |
+| disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                                                                                 |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
+| maxlength   | `number`  | The maximum number of characters allowed                                                                                                |
+| minlength   | `number`  | The minimum number of characters allowed                                                                                                |
+| name        | `string`  | Define the name of the element                                                                                                          |
+| placeholder | `string`  | Sets placeholder text for the element (which disappears when the user starts typing)                                                    |
+| readonly    | `boolean` | If true, the user cannot change the value of this field                                                                                 |
+| size        | `number`  | Sets the width of the component                                                                                                         |
+| step        | `number`  | **Only works with** `type="number`. It defines the incremental step in the component                                                    |
+| type        | `string`  | Sets the type of the text-field. Can be {"email", "password","tel","text","url"}                                                        | 
+| value       | `string`  | Sets the value for this component                                                                                                       | 
 
 These attributes must be defined alongside the declaration of the component.
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/13_text-field.md
@@ -28,6 +28,7 @@ You can define the following attributes in an `<alpha-text-field>`.
 | autofocus   | `boolean` | When true, the component will be focused when the page has finished loading          |
 | appearance  | `string`  | Can be `outline` or `filled`                                                         |
 | disabled    | `boolean` | Similar to `readonly`, but with a blur on the component                              |
+| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | maxlength   | `number`  | The maximum number of characters allowed                                             |
 | minlength   | `number`  | The minimum number of characters allowed                                             |
 | name        | `string`  | Define the name of the element                                                       |


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
Ptl-976

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

