### PR TITLE
Add more information in select page

### DIFF
--- a/docs/04_web/02_web-components/01_form/10_select.md
+++ b/docs/04_web/02_web-components/01_form/10_select.md
@@ -38,12 +38,11 @@ This component needs to be used in combination with `<alpha-option>`. You can de
 | name     | `string`  | Gives this component a name                                                                                                              |
 | open     | `boolean` | Defines whether the list starts opened or not. **Default:** `false`                                                                      |
 | position | `string`  | Places the list **above** or **below** the component; can be `above` or `below`. **Default:** it will try to fit with the page           | 
-| size     | `number`  | Defines the maximum number of options to be displayed. **Default:** it will try to fit with the page                                     | 
+| size     | `number`  | Defines the display size of the list. For example, if you set `size="2"`, then the list displays two items at a time for the user to scroll through; **Default:** it will try to fit with the page | 
 | value    | `string`  | Sets a value for this component                                                                                                          | 
 
 :::note
-Setting the `size` attribute will cause the component to display the number of options you defined in this attribute whether you
-click on it or not.
+If you set the `size`, the list is displayed by default (the user does not need to click to view it). This overrides any setting you make for `open`.
 :::
 
 ### Option attributes

--- a/docs/04_web/02_web-components/01_form/10_select.md
+++ b/docs/04_web/02_web-components/01_form/10_select.md
@@ -41,6 +41,10 @@ This component needs to be used in combination with `<alpha-option>`. You can de
 | size     | `number`  | Defines the maximum number of options to be displayed. **Default:** it will try to fit with the page                                     | 
 | value    | `string`  | Sets a value for this component                                                                                                          | 
 
+:::note
+Setting the `size` attribute will cause the component to display the number of options you defined in this attribute whether you
+click on it or not.
+:::
 
 ### Option attributes
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/09_select.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/09_select.md
@@ -4,9 +4,9 @@ sidebar_label: 'Select'
 id: select
 keywords: [web, web components, select]
 tags:
-    - web
-    - web components
-    - select
+  - web
+  - web components
+  - select
 ---
 
 <div class="select-examples">
@@ -28,7 +28,7 @@ provideDesignSystem().register(alphaSelect(), alphaOption());
 
 ## Attributes
 
-This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`: 
+This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`:
 
 | Name     | Type      | Description                                                                                                                              |
 |----------|-----------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -41,6 +41,10 @@ This component needs to be used in combination with `<alpha-option>`. You can de
 | size     | `number`  | Defines the maximum number of options to be displayed. **Default:** it will try to fit with the page                                     | 
 | value    | `string`  | Sets a value for this component                                                                                                          | 
 
+:::note
+Setting the `size` attribute will cause the component to display the number of options you defined in this attribute whether you
+click on it or not.
+:::
 
 ### Option attributes
 
@@ -53,7 +57,7 @@ In order to use the select component, you need to create a list of options for t
 
 :::note
 - If you specify a `selected` or `value` to more than one `option` while `multiple = false`, then the component selects only the first in the `alpha-option` list
-:::
+  :::
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
@@ -130,9 +134,9 @@ To do this, follow the steps below:
 import {... , observable} from '@microsoft/fast-element';
 ...
 export class TEMPLATE extends FASTElement {
-    ...
-    @observable options: Array<{value: string, label: string}> = []
-    ...
+...
+@observable options: Array<{value: string, label: string}> = []
+...
 }
 ```
 
@@ -151,11 +155,11 @@ With this variable created, you can generate any array you wish using a loop. He
 ```html {1,5}
 import {... , repeat} from '@microsoft/fast-element';
 ...
-    ...
-        <alpha-select>
-            ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
-        </alpha-select>
-    ...
+...
+<alpha-select>
+    ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
+</alpha-select>
+...
 ...    
 ```
 
@@ -170,10 +174,10 @@ If you are not familiar with the `repeat` directive, take a look at the [Microso
 
 ```html title="try yourself" live
 <alpha-select>
-  <alpha-option value="s">Small</alpha-option>
-  <alpha-option value="m">Medium</alpha-option>
-  <alpha-option value="l">Large</alpha-option>
-  <alpha-option value="xl">Extra Large</alpha-option>
+    <alpha-option value="s">Small</alpha-option>
+    <alpha-option value="m">Medium</alpha-option>
+    <alpha-option value="l">Large</alpha-option>
+    <alpha-option value="xl">Extra Large</alpha-option>
 </alpha-select>
 ```
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/09_select.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/09_select.md
@@ -4,9 +4,9 @@ sidebar_label: 'Select'
 id: select
 keywords: [web, web components, select]
 tags:
-  - web
-  - web components
-  - select
+    - web
+    - web components
+    - select
 ---
 
 <div class="select-examples">
@@ -28,7 +28,7 @@ provideDesignSystem().register(alphaSelect(), alphaOption());
 
 ## Attributes
 
-This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`:
+This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`: 
 
 | Name     | Type      | Description                                                                                                                              |
 |----------|-----------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -57,7 +57,7 @@ In order to use the select component, you need to create a list of options for t
 
 :::note
 - If you specify a `selected` or `value` to more than one `option` while `multiple = false`, then the component selects only the first in the `alpha-option` list
-  :::
+:::
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
@@ -134,9 +134,9 @@ To do this, follow the steps below:
 import {... , observable} from '@microsoft/fast-element';
 ...
 export class TEMPLATE extends FASTElement {
-...
-@observable options: Array<{value: string, label: string}> = []
-...
+    ...
+    @observable options: Array<{value: string, label: string}> = []
+    ...
 }
 ```
 
@@ -155,11 +155,11 @@ With this variable created, you can generate any array you wish using a loop. He
 ```html {1,5}
 import {... , repeat} from '@microsoft/fast-element';
 ...
-...
-<alpha-select>
-    ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
-</alpha-select>
-...
+    ...
+        <alpha-select>
+            ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
+        </alpha-select>
+    ...
 ...    
 ```
 
@@ -174,10 +174,10 @@ If you are not familiar with the `repeat` directive, take a look at the [Microso
 
 ```html title="try yourself" live
 <alpha-select>
-    <alpha-option value="s">Small</alpha-option>
-    <alpha-option value="m">Medium</alpha-option>
-    <alpha-option value="l">Large</alpha-option>
-    <alpha-option value="xl">Extra Large</alpha-option>
+  <alpha-option value="s">Small</alpha-option>
+  <alpha-option value="m">Medium</alpha-option>
+  <alpha-option value="l">Large</alpha-option>
+  <alpha-option value="xl">Extra Large</alpha-option>
 </alpha-select>
 ```
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/01_form/09_select.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/01_form/09_select.md
@@ -38,12 +38,11 @@ This component needs to be used in combination with `<alpha-option>`. You can de
 | name     | `string`  | Gives this component a name                                                                                                              |
 | open     | `boolean` | Defines whether the list starts opened or not. **Default:** `false`                                                                      |
 | position | `string`  | Places the list **above** or **below** the component; can be `above` or `below`. **Default:** it will try to fit with the page           | 
-| size     | `number`  | Defines the maximum number of options to be displayed. **Default:** it will try to fit with the page                                     | 
+| size     | `number`  | Defines the display size of the list. For example, if you set `size="2"`, then the list displays two items at a time for the user to scroll through; **Default:** it will try to fit with the page | 
 | value    | `string`  | Sets a value for this component                                                                                                          | 
 
 :::note
-Setting the `size` attribute will cause the component to display the number of options you defined in this attribute whether you
-click on it or not.
+If you set the `size`, the list is displayed by default (the user does not need to click to view it). This overrides any setting you make for `open`.
 :::
 
 ### Option attributes

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/09_select.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/09_select.md
@@ -4,9 +4,9 @@ sidebar_label: 'Select'
 id: select
 keywords: [web, web components, select]
 tags:
-    - web
-    - web components
-    - select
+  - web
+  - web components
+  - select
 ---
 
 <div class="select-examples">
@@ -28,7 +28,7 @@ provideDesignSystem().register(alphaSelect(), alphaOption());
 
 ## Attributes
 
-This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`: 
+This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`:
 
 | Name     | Type      | Description                                                                                                                              |
 |----------|-----------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -41,6 +41,10 @@ This component needs to be used in combination with `<alpha-option>`. You can de
 | size     | `number`  | Defines the maximum number of options to be displayed. **Default:** it will try to fit with the page                                     | 
 | value    | `string`  | Sets a value for this component                                                                                                          | 
 
+:::note
+Setting the `size` attribute will cause the component to display the number of options you defined in this attribute whether you
+click on it or not.
+:::
 
 ### Option attributes
 
@@ -53,7 +57,7 @@ In order to use the select component, you need to create a list of options for t
 
 :::note
 - If you specify a `selected` or `value` to more than one `option` while `multiple = false`, then the component selects only the first in the `alpha-option` list
-:::
+  :::
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
@@ -130,9 +134,9 @@ To do this, follow the steps below:
 import {... , observable} from '@microsoft/fast-element';
 ...
 export class TEMPLATE extends FASTElement {
-    ...
-    @observable options: Array<{value: string, label: string}> = []
-    ...
+...
+@observable options: Array<{value: string, label: string}> = []
+...
 }
 ```
 
@@ -151,11 +155,11 @@ With this variable created, you can generate any array you wish using a loop. He
 ```html {1,5}
 import {... , repeat} from '@microsoft/fast-element';
 ...
-    ...
-        <alpha-select>
-            ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
-        </alpha-select>
-    ...
+...
+<alpha-select>
+    ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
+</alpha-select>
+...
 ...    
 ```
 
@@ -170,10 +174,10 @@ If you are not familiar with the `repeat` directive, take a look at the [Microso
 
 ```html title="try yourself" live
 <alpha-select>
-  <alpha-option value="s">Small</alpha-option>
-  <alpha-option value="m">Medium</alpha-option>
-  <alpha-option value="l">Large</alpha-option>
-  <alpha-option value="xl">Extra Large</alpha-option>
+    <alpha-option value="s">Small</alpha-option>
+    <alpha-option value="m">Medium</alpha-option>
+    <alpha-option value="l">Large</alpha-option>
+    <alpha-option value="xl">Extra Large</alpha-option>
 </alpha-select>
 ```
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/09_select.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/09_select.md
@@ -4,9 +4,9 @@ sidebar_label: 'Select'
 id: select
 keywords: [web, web components, select]
 tags:
-  - web
-  - web components
-  - select
+    - web
+    - web components
+    - select
 ---
 
 <div class="select-examples">
@@ -28,7 +28,7 @@ provideDesignSystem().register(alphaSelect(), alphaOption());
 
 ## Attributes
 
-This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`:
+This component needs to be used in combination with `<alpha-option>`. You can define the following attributes when you declare an `<alpha-select>`: 
 
 | Name     | Type      | Description                                                                                                                              |
 |----------|-----------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -57,7 +57,7 @@ In order to use the select component, you need to create a list of options for t
 
 :::note
 - If you specify a `selected` or `value` to more than one `option` while `multiple = false`, then the component selects only the first in the `alpha-option` list
-  :::
+:::
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
@@ -134,9 +134,9 @@ To do this, follow the steps below:
 import {... , observable} from '@microsoft/fast-element';
 ...
 export class TEMPLATE extends FASTElement {
-...
-@observable options: Array<{value: string, label: string}> = []
-...
+    ...
+    @observable options: Array<{value: string, label: string}> = []
+    ...
 }
 ```
 
@@ -155,11 +155,11 @@ With this variable created, you can generate any array you wish using a loop. He
 ```html {1,5}
 import {... , repeat} from '@microsoft/fast-element';
 ...
-...
-<alpha-select>
-    ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
-</alpha-select>
-...
+    ...
+        <alpha-select>
+            ${repeat(x => x.options, html` <alpha-option value=${x => x.value}>${x => x.label}</alpha-option>`)}
+        </alpha-select>
+    ...
 ...    
 ```
 
@@ -174,10 +174,10 @@ If you are not familiar with the `repeat` directive, take a look at the [Microso
 
 ```html title="try yourself" live
 <alpha-select>
-    <alpha-option value="s">Small</alpha-option>
-    <alpha-option value="m">Medium</alpha-option>
-    <alpha-option value="l">Large</alpha-option>
-    <alpha-option value="xl">Extra Large</alpha-option>
+  <alpha-option value="s">Small</alpha-option>
+  <alpha-option value="m">Medium</alpha-option>
+  <alpha-option value="l">Large</alpha-option>
+  <alpha-option value="xl">Extra Large</alpha-option>
 </alpha-select>
 ```
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/09_select.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/09_select.md
@@ -38,12 +38,11 @@ This component needs to be used in combination with `<alpha-option>`. You can de
 | name     | `string`  | Gives this component a name                                                                                                              |
 | open     | `boolean` | Defines whether the list starts opened or not. **Default:** `false`                                                                      |
 | position | `string`  | Places the list **above** or **below** the component; can be `above` or `below`. **Default:** it will try to fit with the page           | 
-| size     | `number`  | Defines the maximum number of options to be displayed. **Default:** it will try to fit with the page                                     | 
+| size     | `number`  | Defines the display size of the list. For example, if you set `size="2"`, then the list displays two items at a time for the user to scroll through; **Default:** it will try to fit with the page | 
 | value    | `string`  | Sets a value for this component                                                                                                          | 
 
 :::note
-Setting the `size` attribute will cause the component to display the number of options you defined in this attribute whether you
-click on it or not.
+If you set the `size`, the list is displayed by default (the user does not need to click to view it). This overrides any setting you make for `open`.
 :::
 
 ### Option attributes


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:


Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

