### PR TITLE
Gg/PTL-937: Improve menu documentation

### DIFF
--- a/docs/04_web/02_web-components/03_interaction/07_menu.md
+++ b/docs/04_web/02_web-components/03_interaction/07_menu.md
@@ -4,9 +4,9 @@ sidebar_label: 'Menu'
 id: menu
 keywords: [web, web components, menu]
 tags:
-    - web
-    - web components
-    - menu
+  - web
+  - web components
+  - menu
 ---
 
 As defined by the W3C:
@@ -14,8 +14,6 @@ As defined by the W3C:
 > A menu is a widget that offers a list of choices to the user, such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button, choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu. When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
 While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` will receive keyboard support.
-
-`alpha-menu` applies `alpha-menu-item`'s `startColumnCount` property based on an evaluation of all the `alpha-menu-item`s, so the content text vertically aligns across all `alpha-menu-item`s. If any `alpha-menu-item` does not have a role of `checkbox` or `radio` or the `start` slot is not passed, `startColumnCount` is set to 0 which applies an `indent-0` class to all the `alpha-menu-item`s. If any `alpha-menu-item` has a roll of `checkbox` or `radio` or the `start` slot exists, `startColumnCount` is set to 1, which applies an `indent-1` class to all the `alpha-menu-item`s. Or if any `alpha-menu-item` has a role of `checkbox` or `radio` and the `start` slot exists, `startColumnCount` is set to 2, which applies an `indent-2` class to all the `alpha-menu-item`s.
 
 ## Set-up
 
@@ -25,22 +23,126 @@ import { provideDesignSystem, alphaMenu, alphaMenuItem } from '@genesislcap/alph
 provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 ```
 
+## Parameters
+
+### Methods
+
+You can use the following methods when you declare an `<alpha-menu>`:
+
+| Name                   | Description                     |
+|------------------------|---------------------------------|
+| collapseExpandedItem() | It collapses all expended menus |
+
+### Menu-item attributes
+
+In order to use the menu component, you need to create its items so the user can interact with. You create this using `<alpha-menu-item>`.
+You can define the following attributes for an `<alpha-menu-item>`:
+
+| Name     | Type      | Description                                                                                                                                                  |
+|----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| disabled | `boolean` | Disabled the menu-item                                                                                                                                       |
+| expanded | `boolean` | In case this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
+| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values cen be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
+| checked  | `boolean` | **used with** `role`. Checks the item. **Default:** `false`                                                                                                  |
+
+### Events
+
+In order to interact with this component, we need to use events. These events can trigger specific functions in your application:
+
+| Name            | Description                                                                                             |
+|-----------------|---------------------------------------------------------------------------------------------------------|
+| change          | Fires the `@change` event when a menu or sub-menu is clicked or invoked via keyboard                    |
+| click           | Fires the `@click` event when a menu or sub-menu is clicked. **Use `@change` to enable keyboard event** |
+| expanded-change | Fires the `@expanded-change` event when an item is expanded or collapsed                                |
+
 ## Usage
 
-### Basic usage
+Below you have some examples on how to use the `<alpha-menu>` component.
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
-```html live
+- **Example 1**: a menu with three items
+```html title="Example 1"
 <alpha-menu>
-  <alpha-menu-item>Menu item 1</alpha-menu-item>
-  <alpha-menu-item>Menu item 2</alpha-menu-item>
-  <alpha-menu-item>Menu item 3</alpha-menu-item>
-  <alpha-divider></alpha-divider>
-  <alpha-menu-item role="menuitemradio">Menu item 4</alpha-menu-item>
-  <alpha-menu-item role="menuitemradio">Menu item 5</alpha-menu-item>
+    <alpha-menu-item>Menu item 1</alpha-menu-item>
+    <alpha-menu-item>Menu item 2</alpha-menu-item>
+    <alpha-menu-item>Menu item 3</alpha-menu-item>
+</alpha-menu>
+```
+- **Example 2**: a menu with 4 items with the 4th item having more 3 items
+```html title="Example 2"
+<alpha-menu>
+    <alpha-menu-item>Menu item 1</alpha-menu-item>
+    <alpha-menu-item>Menu item 2</alpha-menu-item>
+    <alpha-menu-item>Menu item 3</alpha-menu-item>
+    <alpha-menu-item>
+        Menu item 4
+        <alpha-menu>
+            <alpha-menu-item>Menu item 4.1</alpha-menu-item>
+            <alpha-menu-item>Menu item 4.2</alpha-menu-item>
+            <alpha-menu-item>Menu item 4.3</alpha-menu-item>
+        </alpha-menu>
+    </alpha-menu-item>
+</alpha-menu>
+```
+- **Example 3**: a menu with three items, first as a checkbox, second as a radio and third with a checked checkbox
+```html title="Example 3"
+<alpha-menu>
+    <alpha-menu-item role="menuitemcheckbox">Menu item 1</alpha-menu-item>
+    <alpha-menu-item role="menuitemradio">Menu item 2</alpha-menu-item>
+    <alpha-menu-item role="menuitemcheckbox" checked>Menu item 3</alpha-menu-item>
 </alpha-menu>
 ```
 
-### Nested menus
+### Trigger an action
+The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events to be used.
+
+1. Create a function `functionName1()`, `functionName2()` and `functionName3()` into the class of the component:
+
+```js {3,6,9}
+export class TEMPLATE extends FASTElement {
+    ...
+    functionName1(){
+        // Write an action here
+    }
+    functionName2(){
+        // Write an action here
+    }
+    functionName3(){
+        // Write an action here
+    }
+    ...
+}
+```
+
+2. Use the event `@click`, `@change` or `@expanded-change` to call your function:
+
+```js {2-5}
+    ...
+    <alpha-menu @change=${() => console.log("You changed me")>
+        <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
+        <alpha-menu-item @click=${x => x.functionName2()}>Menu item 3</alpha-menu-item>
+        <alpha-menu-item @expanded-change=${x => x.functionName3()}>
+            Menu item 4
+            <alpha-menu>
+                <alpha-menu-item>Menu item 4.1</alpha-menu-item>
+            </alpha-menu>
+        </alpha-menu-item>
+    </alpha-menu>
+    ...
+```
+
+Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside of it.
+So in case you have something like this:
+
+```html
+<alpha-menu  @click=${x => x.functionName1()}>
+    <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
+</alpha-menu>
+```
+
+Then `funtionName1()` will be called twice.
+
+### Try yourself
 
 ```html live
 <alpha-menu>
@@ -73,8 +175,10 @@ provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 
 ## Use cases
 
-* Dropdown menu control triggered by a button click e.g. settings menu
-* A contextual menu triggered by a right-click
+- Dropdown menu control triggered by a button click e.g. settings menu
+- A contextual menu triggered by a right-click
+- Filtering and Sorting
+- Navigation
 
 ## Additional resources
 

--- a/docs/04_web/02_web-components/03_interaction/07_menu.md
+++ b/docs/04_web/02_web-components/03_interaction/07_menu.md
@@ -13,7 +13,7 @@ As defined by the W3C:
 
 > A menu is a widget that offers a list of choices to the user, such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button, choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu. When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
-While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` will receive keyboard support.
+While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` can receive keyboard support.
 
 ## Set-up
 
@@ -27,27 +27,27 @@ provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 
 ### Methods
 
-You can use the following methods when you declare an `<alpha-menu>`:
+You can use the following method when you declare an `<alpha-menu>`:
 
 | Name                   | Description                     |
 |------------------------|---------------------------------|
-| collapseExpandedItem() | It collapses all expended menus |
+| collapseExpandedItem() | Collapses all expended menus |
 
 ### Menu-item attributes
 
-In order to use the menu component, you need to create its items so the user can interact with. You create this using `<alpha-menu-item>`.
+In order to use the menu component, you need to create the menu items for the user to interact with. You create this using `<alpha-menu-item>`.
 You can define the following attributes for an `<alpha-menu-item>`:
 
 | Name     | Type      | Description                                                                                                                                                  |
 |----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| disabled | `boolean` | Disabled the menu-item                                                                                                                                       |
-| expanded | `boolean` | In case this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
-| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values cen be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
+| disabled | `boolean` | Disables the menu-item                                                                                                                                       |
+| expanded | `boolean` | If this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
+| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values can be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
 | checked  | `boolean` | **used with** `role`. Checks the item. **Default:** `false`                                                                                                  |
 
 ### Events
 
-In order to interact with this component, we need to use events. These events can trigger specific functions in your application:
+In order to interact with this component, you need to use events. These events can trigger specific functions in your application:
 
 | Name            | Description                                                                                             |
 |-----------------|---------------------------------------------------------------------------------------------------------|
@@ -57,8 +57,8 @@ In order to interact with this component, we need to use events. These events ca
 
 ## Usage
 
-Below you have some examples on how to use the `<alpha-menu>` component.
-All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
+Below are some examples of how to use the `<alpha-menu>` component.
+All the examples use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
 - **Example 1**: a menu with three items
 ```html title="Example 1"
@@ -68,7 +68,7 @@ All examples below use the `alpha-design-system`. If you are using any other des
     <alpha-menu-item>Menu item 3</alpha-menu-item>
 </alpha-menu>
 ```
-- **Example 2**: a menu with 4 items with the 4th item having more 3 items
+- **Example 2**: a menu with 4 items, with the 4th item having more 3 items
 ```html title="Example 2"
 <alpha-menu>
     <alpha-menu-item>Menu item 1</alpha-menu-item>
@@ -94,9 +94,9 @@ All examples below use the `alpha-design-system`. If you are using any other des
 ```
 
 ### Trigger an action
-The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events to be used.
+The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events that can be used.
 
-1. Create a function `functionName1()`, `functionName2()` and `functionName3()` into the class of the component:
+1. Create a function `functionName1()`, `functionName2()` and `functionName3()` in the class of the component:
 
 ```js {3,6,9}
 export class TEMPLATE extends FASTElement {
@@ -131,16 +131,14 @@ export class TEMPLATE extends FASTElement {
     ...
 ```
 
-Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside of it.
-So in case you have something like this:
+Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside it.
+In this example, `funtionName1()` will be called twice:
 
 ```html
 <alpha-menu  @click=${x => x.functionName1()}>
     <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
 </alpha-menu>
 ```
-
-Then `funtionName1()` will be called twice.
 
 ### Try yourself
 

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -9,7 +9,7 @@ tags:
   - modal
 ---
 
-A modal is a type of `dialog` that prevents the user from interacting with other content on the page. Usually, when an active modal is displayed, all other content on the screen is dimmed. The user is unable to move focus to other windows or dialogs. The user is forced to deal with the modal before moving to other work with the application.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. Usually, when an active modal is displayed, all other content on the screen is dimmed. The user is unable to move focus to other windows or dialogs. This forces the user to deal with the modal before moving to other work on the application.
 
 If you do not want this exclusive focus, use the [dialog](../../../../web/web-components/interaction/dialog/) component.
 

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -30,12 +30,12 @@ When you declare an `<alpha-modal>`, you can use the following attribute:
 
 | Name     | Type   | Description                                                                     |
 |----------|--------|---------------------------------------------------------------------------------|
-| position | string | It places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
+| position | string | Places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
 
-These attributes must be defined alongside the declaration of the component.
+When you declare a modal, you can provide the following attribute:
 
 :::note
-If you set `position` to be `left` or `right`, the modal will assume `heigh: 100%` by default. To change it, make the appropriate css modifications.
+If you set `position` to be `left` or `right`, the modal will assume `height: 100%` by default. To change it, make the appropriate css modifications.
 :::
 
 
@@ -45,8 +45,8 @@ The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
-| show()  | It shows the referred modal  |
-| close() | It closes the referred modal |
+| show()  | Shows the referred modal  |
+| close() | Closes the referred modal |
 
 By default, the `modal-component` starts closed.
 

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -9,9 +9,11 @@ tags:
   - modal
 ---
 
-A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. Usually, when an active modal is displayed, all other content on the screen is dimmed. The user is unable to move focus to other windows or dialogs. The user is forced to deal with the modal before moving to other work with the application.
 
-As defined by the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
+If you do not want this exclusive focus, use the [dialog](../../../../web/web-components/interaction/dialog/) component.
+
+Here is the definition of a modal from the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
 
 > A dialog is a window overlaid on either the primary window or another dialog window. Windows under a modal dialog are inert. That is, users cannot interact with content outside an active dialog window. Inert content outside an active dialog is typically visually obscured or dimmed so it is difficult to discern; in some implementations, attempts to interact with the inert content cause the dialog to close.
 >
@@ -26,16 +28,14 @@ provideDesignSystem().register(alphaModal());
 ```
 ## Attributes
 
-When you declare an `<alpha-modal>`, you can use the following attribute:
+When you declare an `<alpha-modal>`, you can provide the following attribute:
 
 | Name     | Type   | Description                                                                     |
 |----------|--------|---------------------------------------------------------------------------------|
-| position | string | Places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
-
-When you declare a modal, you can provide the following attribute:
+| position | string | Places the modal to the `right`, `centre` or `left` of the screen. **Default:** `centre` |
 
 :::note
-If you set `position` to be `left` or `right`, the modal will assume `height: 100%` by default. To change it, make the appropriate css modifications.
+If you set `position` to be `left` or `right`, the modal will assume `height: 100%` by default. To change this, make the appropriate css modifications.
 :::
 
 

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -9,7 +9,7 @@ tags:
     - modal
 ---
 
-A modal component will prevent the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
 
 As defined by the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
 
@@ -24,23 +24,104 @@ import { provideDesignSystem, alphaModal } from '@genesislcap/alpha-design-syste
 
 provideDesignSystem().register(alphaModal());
 ```
+## Methods
+
+When you declare an `<alpha-modal>`, you can duse the following methods:
+
+| Name    | Description                  |
+|---------|------------------------------|
+| show()  | It shows the referred modal  |
+| close() | It closes the referred modal |
 
 ## Usage
 
+Below you see the standard declaration of the modal:
+
 ```html
-<alpha-card id="alpha-modal">
-  <alpha-button id="js-alpha-show-modal" appearance="accent">Show Rapid Modal</alpha-button>
-  <alpha-modal>
-    <h5 slot="top">Modal title</h5>
-    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit/</p> 
-    <alpha-button slot="bottom" id="js-alpha-close-modal">Close this modal</alpha-button>
-  </alpha-modal>
-</alpha-card>
+<alpha-modal>
+    This is a modal
+</alpha-modal>
+```
+
+### Interaction
+
+In order to interact with the modal component, you need to use the available methods. To do that, import modal from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { Modal as alphaModal } from '@genesislcap/alpha-design-system';
+```
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+After that, you need to define the local variable to be referred to, in this case `localModal`:
+
+```js {3}
+export class TEMPLATE extends FASTElement {
+    ...
+    localModal: alphaModal;
+    ...
+}
+```
+
+Now that you have your local variable, you can use the directive `ref` to link your component to this variable:
+
+```html {1,5-7}
+import {... , ref} from '@microsoft/fast-element';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-modal ${ref('localModal')}>
+        This is a modal
+    </alpha-modal>
+}
+```
+
+If you are not familiar with the `ref` directive, take a look at the [Microsoft Fast documentation](https://www.fast.design/docs/fast-element/using-directives/#the-repeat-directive).
+
+From this point, you can use both `show()` and `close()` as methods of `localModal`.
+
+### Examples
+
+Below we have two examples of how to use both methods:
+
+- Create a button to open a modal:
+
+```html {6}
+import {... , ref} from '@microsoft/fast-element';
+import {sync} from '@genesislcap/foundation-utils';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-button @click=${x => x.localModal.show()}></alpha-button>
+    <alpha-modal ${ref('localModal')}>
+       This is a modal
+    </alpha-modal>
+}
+```
+
+- Create a button inside the modal to close it:
+
+```html {9}
+import {... , ref} from '@microsoft/fast-element';
+import {sync} from '@genesislcap/foundation-utils';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-button @click=${x => x.localModal.show()}>Open modal</alpha-button>
+    <alpha-modal ${ref('localModal')}>
+       This is a modal
+       <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
+    </alpha-modal>
+}
 ```
 
 ## Use cases
 
-* Confirmation pop-ups
+- Confirmation pop-ups
+- Alerts
+- Forms submissions
+- Contextual information
 
 ## Additional resources
 

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -100,7 +100,7 @@ From this point, you can use both `show()` and `close()` as methods of `localMod
 
 ### Examples
 
-Below we have two examples of how to use both methods:
+Below we have three examples of how to use both methods:
 
 - Create a modal positioned to the left:
 ```html

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -45,8 +45,8 @@ The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
-| show()  | Shows the referred modal  |
-| close() | Closes the referred modal |
+| show()  | Shows the modal  |
+| close() | Closes the modal |
 
 By default, the `modal-component` starts closed.
 

--- a/docs/04_web/02_web-components/03_interaction/08_modal.md
+++ b/docs/04_web/02_web-components/03_interaction/08_modal.md
@@ -4,9 +4,9 @@ sidebar_label: 'Modal'
 id: modal
 keywords: [web, web components, modal]
 tags:
-    - web
-    - web components
-    - modal
+  - web
+  - web components
+  - modal
 ---
 
 A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
@@ -24,14 +24,31 @@ import { provideDesignSystem, alphaModal } from '@genesislcap/alpha-design-syste
 
 provideDesignSystem().register(alphaModal());
 ```
+## Attributes
+
+When you declare an `<alpha-modal>`, you can use the following attribute:
+
+| Name     | Type   | Description                                                                     |
+|----------|--------|---------------------------------------------------------------------------------|
+| position | string | It places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
+
+These attributes must be defined alongside the declaration of the component.
+
+:::note
+If you set `position` to be `left` or `right`, the modal will assume `heigh: 100%` by default. To change it, make the appropriate css modifications.
+:::
+
+
 ## Methods
 
-When you declare an `<alpha-modal>`, you can duse the following methods:
+The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
 | show()  | It shows the referred modal  |
 | close() | It closes the referred modal |
+
+By default, the `modal-component` starts closed.
 
 ## Usage
 
@@ -72,9 +89,9 @@ import {... , ref} from '@microsoft/fast-element';
 export const yourTemplate = html<Template>`
     ...
     <alpha-modal ${ref('localModal')}>
-        This is a modal
+    This is a modal
     </alpha-modal>
-}
+    }
 ```
 
 If you are not familiar with the `ref` directive, take a look at the [Microsoft Fast documentation](https://www.fast.design/docs/fast-element/using-directives/#the-repeat-directive).
@@ -85,6 +102,12 @@ From this point, you can use both `show()` and `close()` as methods of `localMod
 
 Below we have two examples of how to use both methods:
 
+- Create a modal positioned to the left:
+```html
+<alpha-modal position="left">
+    This is a modal
+</alpha-modal>
+```
 - Create a button to open a modal:
 
 ```html {6}
@@ -95,9 +118,9 @@ export const yourTemplate = html<Template>`
     ...
     <alpha-button @click=${x => x.localModal.show()}></alpha-button>
     <alpha-modal ${ref('localModal')}>
-       This is a modal
+    This is a modal
     </alpha-modal>
-}
+    }
 ```
 
 - Create a button inside the modal to close it:
@@ -110,10 +133,10 @@ export const yourTemplate = html<Template>`
     ...
     <alpha-button @click=${x => x.localModal.show()}>Open modal</alpha-button>
     <alpha-modal ${ref('localModal')}>
-       This is a modal
-       <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
+    This is a modal
+    <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
     </alpha-modal>
-}
+    }
 ```
 
 ## Use cases
@@ -125,4 +148,4 @@ export const yourTemplate = html<Template>`
 
 ## Additional resources
 
-- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#dialog_modal)
+- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#dialog_modal)~~

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/07_menu.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/07_menu.md
@@ -4,9 +4,9 @@ sidebar_label: 'Menu'
 id: menu
 keywords: [web, web components, menu]
 tags:
-    - web
-    - web components
-    - menu
+  - web
+  - web components
+  - menu
 ---
 
 As defined by the W3C:
@@ -14,8 +14,6 @@ As defined by the W3C:
 > A menu is a widget that offers a list of choices to the user, such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button, choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu. When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
 While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` will receive keyboard support.
-
-`alpha-menu` applies `alpha-menu-item`'s `startColumnCount` property based on an evaluation of all the `alpha-menu-item`s, so the content text vertically aligns across all `alpha-menu-item`s. If any `alpha-menu-item` does not have a role of `checkbox` or `radio` or the `start` slot is not passed, `startColumnCount` is set to 0 which applies an `indent-0` class to all the `alpha-menu-item`s. If any `alpha-menu-item` has a roll of `checkbox` or `radio` or the `start` slot exists, `startColumnCount` is set to 1, which applies an `indent-1` class to all the `alpha-menu-item`s. Or if any `alpha-menu-item` has a role of `checkbox` or `radio` and the `start` slot exists, `startColumnCount` is set to 2, which applies an `indent-2` class to all the `alpha-menu-item`s.
 
 ## Set-up
 
@@ -25,22 +23,126 @@ import { provideDesignSystem, alphaMenu, alphaMenuItem } from '@genesislcap/alph
 provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 ```
 
+## Parameters
+
+### Methods
+
+You can use the following methods when you declare an `<alpha-menu>`:
+
+| Name                   | Description                     |
+|------------------------|---------------------------------|
+| collapseExpandedItem() | It collapses all expended menus |
+
+### Menu-item attributes
+
+In order to use the menu component, you need to create its items so the user can interact with. You create this using `<alpha-menu-item>`.
+You can define the following attributes for an `<alpha-menu-item>`:
+
+| Name     | Type      | Description                                                                                                                                                  |
+|----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| disabled | `boolean` | Disabled the menu-item                                                                                                                                       |
+| expanded | `boolean` | In case this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
+| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values cen be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
+| checked  | `boolean` | **used with** `role`. Checks the item. **Default:** `false`                                                                                                  |
+
+### Events
+
+In order to interact with this component, we need to use events. These events can trigger specific functions in your application:
+
+| Name            | Description                                                                                             |
+|-----------------|---------------------------------------------------------------------------------------------------------|
+| change          | Fires the `@change` event when a menu or sub-menu is clicked or invoked via keyboard                    |
+| click           | Fires the `@click` event when a menu or sub-menu is clicked. **Use `@change` to enable keyboard event** |
+| expanded-change | Fires the `@expanded-change` event when an item is expanded or collapsed                                |
+
 ## Usage
 
-### Basic usage
+Below you have some examples on how to use the `<alpha-menu>` component.
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
-```html live
+- **Example 1**: a menu with three items
+```html title="Example 1"
 <alpha-menu>
-  <alpha-menu-item>Menu item 1</alpha-menu-item>
-  <alpha-menu-item>Menu item 2</alpha-menu-item>
-  <alpha-menu-item>Menu item 3</alpha-menu-item>
-  <alpha-divider></alpha-divider>
-  <alpha-menu-item role="menuitemradio">Menu item 4</alpha-menu-item>
-  <alpha-menu-item role="menuitemradio">Menu item 5</alpha-menu-item>
+    <alpha-menu-item>Menu item 1</alpha-menu-item>
+    <alpha-menu-item>Menu item 2</alpha-menu-item>
+    <alpha-menu-item>Menu item 3</alpha-menu-item>
+</alpha-menu>
+```
+- **Example 2**: a menu with 4 items with the 4th item having more 3 items
+```html title="Example 2"
+<alpha-menu>
+    <alpha-menu-item>Menu item 1</alpha-menu-item>
+    <alpha-menu-item>Menu item 2</alpha-menu-item>
+    <alpha-menu-item>Menu item 3</alpha-menu-item>
+    <alpha-menu-item>
+        Menu item 4
+        <alpha-menu>
+            <alpha-menu-item>Menu item 4.1</alpha-menu-item>
+            <alpha-menu-item>Menu item 4.2</alpha-menu-item>
+            <alpha-menu-item>Menu item 4.3</alpha-menu-item>
+        </alpha-menu>
+    </alpha-menu-item>
+</alpha-menu>
+```
+- **Example 3**: a menu with three items, first as a checkbox, second as a radio and third with a checked checkbox
+```html title="Example 3"
+<alpha-menu>
+    <alpha-menu-item role="menuitemcheckbox">Menu item 1</alpha-menu-item>
+    <alpha-menu-item role="menuitemradio">Menu item 2</alpha-menu-item>
+    <alpha-menu-item role="menuitemcheckbox" checked>Menu item 3</alpha-menu-item>
 </alpha-menu>
 ```
 
-### Nested menus
+### Trigger an action
+The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events to be used.
+
+1. Create a function `functionName1()`, `functionName2()` and `functionName3()` into the class of the component:
+
+```js {3,6,9}
+export class TEMPLATE extends FASTElement {
+    ...
+    functionName1(){
+        // Write an action here
+    }
+    functionName2(){
+        // Write an action here
+    }
+    functionName3(){
+        // Write an action here
+    }
+    ...
+}
+```
+
+2. Use the event `@click`, `@change` or `@expanded-change` to call your function:
+
+```js {2-5}
+    ...
+    <alpha-menu @change=${() => console.log("You changed me")>
+        <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
+        <alpha-menu-item @click=${x => x.functionName2()}>Menu item 3</alpha-menu-item>
+        <alpha-menu-item @expanded-change=${x => x.functionName3()}>
+            Menu item 4
+            <alpha-menu>
+                <alpha-menu-item>Menu item 4.1</alpha-menu-item>
+            </alpha-menu>
+        </alpha-menu-item>
+    </alpha-menu>
+    ...
+```
+
+Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside of it.
+So in case you have something like this:
+
+```html
+<alpha-menu  @click=${x => x.functionName1()}>
+    <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
+</alpha-menu>
+```
+
+Then `funtionName1()` will be called twice.
+
+### Try yourself
 
 ```html live
 <alpha-menu>
@@ -73,8 +175,10 @@ provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 
 ## Use cases
 
-* Dropdown menu control triggered by a button click e.g. settings menu
-* A contextual menu triggered by a right-click
+- Dropdown menu control triggered by a button click e.g. settings menu
+- A contextual menu triggered by a right-click
+- Filtering and Sorting
+- Navigation
 
 ## Additional resources
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/07_menu.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/07_menu.md
@@ -13,7 +13,7 @@ As defined by the W3C:
 
 > A menu is a widget that offers a list of choices to the user, such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button, choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu. When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
-While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` will receive keyboard support.
+While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` can receive keyboard support.
 
 ## Set-up
 
@@ -27,27 +27,27 @@ provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 
 ### Methods
 
-You can use the following methods when you declare an `<alpha-menu>`:
+You can use the following method when you declare an `<alpha-menu>`:
 
 | Name                   | Description                     |
 |------------------------|---------------------------------|
-| collapseExpandedItem() | It collapses all expended menus |
+| collapseExpandedItem() | Collapses all expended menus |
 
 ### Menu-item attributes
 
-In order to use the menu component, you need to create its items so the user can interact with. You create this using `<alpha-menu-item>`.
+In order to use the menu component, you need to create the menu items for the user to interact with. You create this using `<alpha-menu-item>`.
 You can define the following attributes for an `<alpha-menu-item>`:
 
 | Name     | Type      | Description                                                                                                                                                  |
 |----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| disabled | `boolean` | Disabled the menu-item                                                                                                                                       |
-| expanded | `boolean` | In case this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
-| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values cen be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
+| disabled | `boolean` | Disables the menu-item                                                                                                                                       |
+| expanded | `boolean` | If this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
+| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values can be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
 | checked  | `boolean` | **used with** `role`. Checks the item. **Default:** `false`                                                                                                  |
 
 ### Events
 
-In order to interact with this component, we need to use events. These events can trigger specific functions in your application:
+In order to interact with this component, you need to use events. These events can trigger specific functions in your application:
 
 | Name            | Description                                                                                             |
 |-----------------|---------------------------------------------------------------------------------------------------------|
@@ -57,8 +57,8 @@ In order to interact with this component, we need to use events. These events ca
 
 ## Usage
 
-Below you have some examples on how to use the `<alpha-menu>` component.
-All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
+Below are some examples of how to use the `<alpha-menu>` component.
+All the examples use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
 - **Example 1**: a menu with three items
 ```html title="Example 1"
@@ -68,7 +68,7 @@ All examples below use the `alpha-design-system`. If you are using any other des
     <alpha-menu-item>Menu item 3</alpha-menu-item>
 </alpha-menu>
 ```
-- **Example 2**: a menu with 4 items with the 4th item having more 3 items
+- **Example 2**: a menu with 4 items, with the 4th item having more 3 items
 ```html title="Example 2"
 <alpha-menu>
     <alpha-menu-item>Menu item 1</alpha-menu-item>
@@ -94,9 +94,9 @@ All examples below use the `alpha-design-system`. If you are using any other des
 ```
 
 ### Trigger an action
-The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events to be used.
+The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events that can be used.
 
-1. Create a function `functionName1()`, `functionName2()` and `functionName3()` into the class of the component:
+1. Create a function `functionName1()`, `functionName2()` and `functionName3()` in the class of the component:
 
 ```js {3,6,9}
 export class TEMPLATE extends FASTElement {
@@ -131,16 +131,14 @@ export class TEMPLATE extends FASTElement {
     ...
 ```
 
-Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside of it.
-So in case you have something like this:
+Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside it.
+In this example, `funtionName1()` will be called twice:
 
 ```html
 <alpha-menu  @click=${x => x.functionName1()}>
     <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
 </alpha-menu>
 ```
-
-Then `funtionName1()` will be called twice.
 
 ### Try yourself
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
@@ -9,9 +9,11 @@ tags:
   - modal
 ---
 
-A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. Usually, when an active modal is displayed, all other content on the screen is dimmed. The user is unable to move focus to other windows or dialogs. This forces the user to deal with the modal before moving to other work on the application.
 
-As defined by the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
+If you do not want this exclusive focus, use the [dialog](../../../../web/web-components/interaction/dialog/) component.
+
+Here is the definition of a modal from the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
 
 > A dialog is a window overlaid on either the primary window or another dialog window. Windows under a modal dialog are inert. That is, users cannot interact with content outside an active dialog window. Inert content outside an active dialog is typically visually obscured or dimmed so it is difficult to discern; in some implementations, attempts to interact with the inert content cause the dialog to close.
 >
@@ -26,16 +28,14 @@ provideDesignSystem().register(alphaModal());
 ```
 ## Attributes
 
-When you declare an `<alpha-modal>`, you can use the following attribute:
+When you declare an `<alpha-modal>`, you can provide the following attribute:
 
 | Name     | Type   | Description                                                                     |
 |----------|--------|---------------------------------------------------------------------------------|
-| position | string | It places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
-
-These attributes must be defined alongside the declaration of the component.
+| position | string | Places the modal to the `right`, `centre` or `left` of the screen. **Default:** `centre` |
 
 :::note
-If you set `position` to be `left` or `right`, the modal will assume `heigh: 100%` by default. To change it, make the appropriate css modifications.
+If you set `position` to be `left` or `right`, the modal will assume `height: 100%` by default. To change this, make the appropriate css modifications.
 :::
 
 
@@ -45,8 +45,8 @@ The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
-| show()  | It shows the referred modal  |
-| close() | It closes the referred modal |
+| show()  | Shows the referred modal  |
+| close() | Closes the referred modal |
 
 By default, the `modal-component` starts closed.
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
@@ -4,12 +4,12 @@ sidebar_label: 'Modal'
 id: modal
 keywords: [web, web components, modal]
 tags:
-    - web
-    - web components
-    - modal
+  - web
+  - web components
+  - modal
 ---
 
-A modal component will prevent the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
 
 As defined by the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
 
@@ -24,23 +24,104 @@ import { provideDesignSystem, alphaModal } from '@genesislcap/alpha-design-syste
 
 provideDesignSystem().register(alphaModal());
 ```
+## Methods
+
+When you declare an `<alpha-modal>`, you can duse the following methods:
+
+| Name    | Description                  |
+|---------|------------------------------|
+| show()  | It shows the referred modal  |
+| close() | It closes the referred modal |
 
 ## Usage
 
+Below you see the standard declaration of the modal:
+
 ```html
-<alpha-card id="alpha-modal">
-  <alpha-button id="js-alpha-show-modal" appearance="accent">Show Rapid Modal</alpha-button>
-  <alpha-modal>
-    <h5 slot="top">Modal title</h5>
-    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit/</p> 
-    <alpha-button slot="bottom" id="js-alpha-close-modal">Close this modal</alpha-button>
-  </alpha-modal>
-</alpha-card>
+<alpha-modal>
+    This is a modal
+</alpha-modal>
+```
+
+### Interaction
+
+In order to interact with the modal component, you need to use the available methods. To do that, import modal from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { Modal as alphaModal } from '@genesislcap/alpha-design-system';
+```
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+After that, you need to define the local variable to be referred to, in this case `localModal`:
+
+```js {3}
+export class TEMPLATE extends FASTElement {
+    ...
+    localModal: alphaModal;
+    ...
+}
+```
+
+Now that you have your local variable, you can use the directive `ref` to link your component to this variable:
+
+```html {1,5-7}
+import {... , ref} from '@microsoft/fast-element';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-modal ${ref('localModal')}>
+        This is a modal
+    </alpha-modal>
+}
+```
+
+If you are not familiar with the `ref` directive, take a look at the [Microsoft Fast documentation](https://www.fast.design/docs/fast-element/using-directives/#the-repeat-directive).
+
+From this point, you can use both `show()` and `close()` as methods of `localModal`.
+
+### Examples
+
+Below we have two examples of how to use both methods:
+
+- Create a button to open a modal:
+
+```html {6}
+import {... , ref} from '@microsoft/fast-element';
+import {sync} from '@genesislcap/foundation-utils';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-button @click=${x => x.localModal.show()}></alpha-button>
+    <alpha-modal ${ref('localModal')}>
+       This is a modal
+    </alpha-modal>
+}
+```
+
+- Create a button inside the modal to close it:
+
+```html {9}
+import {... , ref} from '@microsoft/fast-element';
+import {sync} from '@genesislcap/foundation-utils';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-button @click=${x => x.localModal.show()}>Open modal</alpha-button>
+    <alpha-modal ${ref('localModal')}>
+       This is a modal
+       <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
+    </alpha-modal>
+}
 ```
 
 ## Use cases
 
-* Confirmation pop-ups
+- Confirmation pop-ups
+- Alerts
+- Forms submissions
+- Contextual information
 
 ## Additional resources
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
@@ -24,14 +24,31 @@ import { provideDesignSystem, alphaModal } from '@genesislcap/alpha-design-syste
 
 provideDesignSystem().register(alphaModal());
 ```
+## Attributes
+
+When you declare an `<alpha-modal>`, you can use the following attribute:
+
+| Name     | Type   | Description                                                                     |
+|----------|--------|---------------------------------------------------------------------------------|
+| position | string | It places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
+
+These attributes must be defined alongside the declaration of the component.
+
+:::note
+If you set `position` to be `left` or `right`, the modal will assume `heigh: 100%` by default. To change it, make the appropriate css modifications.
+:::
+
+
 ## Methods
 
-When you declare an `<alpha-modal>`, you can duse the following methods:
+The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
 | show()  | It shows the referred modal  |
 | close() | It closes the referred modal |
+
+By default, the `modal-component` starts closed.
 
 ## Usage
 
@@ -72,9 +89,9 @@ import {... , ref} from '@microsoft/fast-element';
 export const yourTemplate = html<Template>`
     ...
     <alpha-modal ${ref('localModal')}>
-        This is a modal
+    This is a modal
     </alpha-modal>
-}
+    }
 ```
 
 If you are not familiar with the `ref` directive, take a look at the [Microsoft Fast documentation](https://www.fast.design/docs/fast-element/using-directives/#the-repeat-directive).
@@ -85,6 +102,12 @@ From this point, you can use both `show()` and `close()` as methods of `localMod
 
 Below we have two examples of how to use both methods:
 
+- Create a modal positioned to the left:
+```html
+<alpha-modal position="left">
+    This is a modal
+</alpha-modal>
+```
 - Create a button to open a modal:
 
 ```html {6}
@@ -95,9 +118,9 @@ export const yourTemplate = html<Template>`
     ...
     <alpha-button @click=${x => x.localModal.show()}></alpha-button>
     <alpha-modal ${ref('localModal')}>
-       This is a modal
+    This is a modal
     </alpha-modal>
-}
+    }
 ```
 
 - Create a button inside the modal to close it:
@@ -110,10 +133,10 @@ export const yourTemplate = html<Template>`
     ...
     <alpha-button @click=${x => x.localModal.show()}>Open modal</alpha-button>
     <alpha-modal ${ref('localModal')}>
-       This is a modal
-       <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
+    This is a modal
+    <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
     </alpha-modal>
-}
+    }
 ```
 
 ## Use cases
@@ -125,4 +148,4 @@ export const yourTemplate = html<Template>`
 
 ## Additional resources
 
-- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#dialog_modal)
+- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#dialog_modal)~~

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
@@ -100,7 +100,7 @@ From this point, you can use both `show()` and `close()` as methods of `localMod
 
 ### Examples
 
-Below we have two examples of how to use both methods:
+Below we have three examples of how to use both methods:
 
 - Create a modal positioned to the left:
 ```html

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/08_modal.md
@@ -45,8 +45,8 @@ The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
-| show()  | Shows the referred modal  |
-| close() | Closes the referred modal |
+| show()  | Shows the modal  |
+| close() | Closes the modal |
 
 By default, the `modal-component` starts closed.
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/08_menu.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/08_menu.md
@@ -4,9 +4,9 @@ sidebar_label: 'Menu'
 id: menu
 keywords: [web, web components, menu]
 tags:
-    - web
-    - web components
-    - menu
+  - web
+  - web components
+  - menu
 ---
 
 As defined by the W3C:
@@ -14,8 +14,6 @@ As defined by the W3C:
 > A menu is a widget that offers a list of choices to the user, such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button, choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu. When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
 While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` will receive keyboard support.
-
-`alpha-menu` applies `alpha-menu-item`'s `startColumnCount` property based on an evaluation of all the `alpha-menu-item`s, so the content text vertically aligns across all `alpha-menu-item`s. If any `alpha-menu-item` does not have a role of `checkbox` or `radio` or the `start` slot is not passed, `startColumnCount` is set to 0 which applies an `indent-0` class to all the `alpha-menu-item`s. If any `alpha-menu-item` has a roll of `checkbox` or `radio` or the `start` slot exists, `startColumnCount` is set to 1, which applies an `indent-1` class to all the `alpha-menu-item`s. Or if any `alpha-menu-item` has a role of `checkbox` or `radio` and the `start` slot exists, `startColumnCount` is set to 2, which applies an `indent-2` class to all the `alpha-menu-item`s.
 
 ## Set-up
 
@@ -25,22 +23,126 @@ import { provideDesignSystem, alphaMenu, alphaMenuItem } from '@genesislcap/alph
 provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 ```
 
+## Parameters
+
+### Methods
+
+You can use the following methods when you declare an `<alpha-menu>`:
+
+| Name                   | Description                     |
+|------------------------|---------------------------------|
+| collapseExpandedItem() | It collapses all expended menus |
+
+### Menu-item attributes
+
+In order to use the menu component, you need to create its items so the user can interact with. You create this using `<alpha-menu-item>`.
+You can define the following attributes for an `<alpha-menu-item>`:
+
+| Name     | Type      | Description                                                                                                                                                  |
+|----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| disabled | `boolean` | Disabled the menu-item                                                                                                                                       |
+| expanded | `boolean` | In case this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
+| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values cen be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
+| checked  | `boolean` | **used with** `role`. Checks the item. **Default:** `false`                                                                                                  |
+
+### Events
+
+In order to interact with this component, we need to use events. These events can trigger specific functions in your application:
+
+| Name            | Description                                                                                             |
+|-----------------|---------------------------------------------------------------------------------------------------------|
+| change          | Fires the `@change` event when a menu or sub-menu is clicked or invoked via keyboard                    |
+| click           | Fires the `@click` event when a menu or sub-menu is clicked. **Use `@change` to enable keyboard event** |
+| expanded-change | Fires the `@expanded-change` event when an item is expanded or collapsed                                |
+
 ## Usage
 
-### Basic usage
+Below you have some examples on how to use the `<alpha-menu>` component.
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
-```html live
+- **Example 1**: a menu with three items
+```html title="Example 1"
 <alpha-menu>
-  <alpha-menu-item>Menu item 1</alpha-menu-item>
-  <alpha-menu-item>Menu item 2</alpha-menu-item>
-  <alpha-menu-item>Menu item 3</alpha-menu-item>
-  <alpha-divider></alpha-divider>
-  <alpha-menu-item role="menuitemradio">Menu item 4</alpha-menu-item>
-  <alpha-menu-item role="menuitemradio">Menu item 5</alpha-menu-item>
+    <alpha-menu-item>Menu item 1</alpha-menu-item>
+    <alpha-menu-item>Menu item 2</alpha-menu-item>
+    <alpha-menu-item>Menu item 3</alpha-menu-item>
+</alpha-menu>
+```
+- **Example 2**: a menu with 4 items with the 4th item having more 3 items
+```html title="Example 2"
+<alpha-menu>
+    <alpha-menu-item>Menu item 1</alpha-menu-item>
+    <alpha-menu-item>Menu item 2</alpha-menu-item>
+    <alpha-menu-item>Menu item 3</alpha-menu-item>
+    <alpha-menu-item>
+        Menu item 4
+        <alpha-menu>
+            <alpha-menu-item>Menu item 4.1</alpha-menu-item>
+            <alpha-menu-item>Menu item 4.2</alpha-menu-item>
+            <alpha-menu-item>Menu item 4.3</alpha-menu-item>
+        </alpha-menu>
+    </alpha-menu-item>
+</alpha-menu>
+```
+- **Example 3**: a menu with three items, first as a checkbox, second as a radio and third with a checked checkbox
+```html title="Example 3"
+<alpha-menu>
+    <alpha-menu-item role="menuitemcheckbox">Menu item 1</alpha-menu-item>
+    <alpha-menu-item role="menuitemradio">Menu item 2</alpha-menu-item>
+    <alpha-menu-item role="menuitemcheckbox" checked>Menu item 3</alpha-menu-item>
 </alpha-menu>
 ```
 
-### Nested menus
+### Trigger an action
+The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events to be used.
+
+1. Create a function `functionName1()`, `functionName2()` and `functionName3()` into the class of the component:
+
+```js {3,6,9}
+export class TEMPLATE extends FASTElement {
+    ...
+    functionName1(){
+        // Write an action here
+    }
+    functionName2(){
+        // Write an action here
+    }
+    functionName3(){
+        // Write an action here
+    }
+    ...
+}
+```
+
+2. Use the event `@click`, `@change` or `@expanded-change` to call your function:
+
+```js {2-5}
+    ...
+    <alpha-menu @change=${() => console.log("You changed me")>
+        <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
+        <alpha-menu-item @click=${x => x.functionName2()}>Menu item 3</alpha-menu-item>
+        <alpha-menu-item @expanded-change=${x => x.functionName3()}>
+            Menu item 4
+            <alpha-menu>
+                <alpha-menu-item>Menu item 4.1</alpha-menu-item>
+            </alpha-menu>
+        </alpha-menu-item>
+    </alpha-menu>
+    ...
+```
+
+Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside of it.
+So in case you have something like this:
+
+```html
+<alpha-menu  @click=${x => x.functionName1()}>
+    <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
+</alpha-menu>
+```
+
+Then `funtionName1()` will be called twice.
+
+### Try yourself
 
 ```html live
 <alpha-menu>
@@ -73,8 +175,10 @@ provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 
 ## Use cases
 
-* Dropdown menu control triggered by a button click e.g. settings menu
-* A contextual menu triggered by a right-click
+- Dropdown menu control triggered by a button click e.g. settings menu
+- A contextual menu triggered by a right-click
+- Filtering and Sorting
+- Navigation
 
 ## Additional resources
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/08_menu.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/08_menu.md
@@ -13,7 +13,7 @@ As defined by the W3C:
 
 > A menu is a widget that offers a list of choices to the user, such as a set of actions or functions. Menu widgets behave like native operating system menus, such as the menus that pull down from the menubars commonly found at the top of many desktop application windows. A menu is usually opened, or made visible, by activating a menu button, choosing an item in a menu that opens a sub menu, or by invoking a command, such as Shift + F10 in Windows, that opens a context specific menu. When a user activates a choice in a menu, the menu usually closes unless the choice opened a submenu.
 
-While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` will receive keyboard support.
+While any DOM content is permissible as a child of the menu, only `alpha-menu-item`s and slotted content with a role of `menuitem`, `menuitemcheckbox`, or `menuitemradio` can receive keyboard support.
 
 ## Set-up
 
@@ -27,27 +27,27 @@ provideDesignSystem().register(alphaMenu(), alphaMenuItem());
 
 ### Methods
 
-You can use the following methods when you declare an `<alpha-menu>`:
+You can use the following method when you declare an `<alpha-menu>`:
 
 | Name                   | Description                     |
 |------------------------|---------------------------------|
-| collapseExpandedItem() | It collapses all expended menus |
+| collapseExpandedItem() | Collapses all expended menus |
 
 ### Menu-item attributes
 
-In order to use the menu component, you need to create its items so the user can interact with. You create this using `<alpha-menu-item>`.
+In order to use the menu component, you need to create the menu items for the user to interact with. You create this using `<alpha-menu-item>`.
 You can define the following attributes for an `<alpha-menu-item>`:
 
 | Name     | Type      | Description                                                                                                                                                  |
 |----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| disabled | `boolean` | Disabled the menu-item                                                                                                                                       |
-| expanded | `boolean` | In case this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
-| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values cen be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
+| disabled | `boolean` | Disables the menu-item                                                                                                                                       |
+| expanded | `boolean` | If this menu-item has sub-menus, it starts expanded. **Default:** `false`                                                                               |
+| role     | `string`  | Changes the displayed item into a menu item, a radio or a checkbox. Values can be:  `menuitem`, `menuitemcheckbox`, `menuitemradio`. **Default:** `menuitem` |
 | checked  | `boolean` | **used with** `role`. Checks the item. **Default:** `false`                                                                                                  |
 
 ### Events
 
-In order to interact with this component, we need to use events. These events can trigger specific functions in your application:
+In order to interact with this component, you need to use events. These events can trigger specific functions in your application:
 
 | Name            | Description                                                                                             |
 |-----------------|---------------------------------------------------------------------------------------------------------|
@@ -57,8 +57,8 @@ In order to interact with this component, we need to use events. These events ca
 
 ## Usage
 
-Below you have some examples on how to use the `<alpha-menu>` component.
-All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
+Below are some examples of how to use the `<alpha-menu>` component.
+All the examples use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
 - **Example 1**: a menu with three items
 ```html title="Example 1"
@@ -68,7 +68,7 @@ All examples below use the `alpha-design-system`. If you are using any other des
     <alpha-menu-item>Menu item 3</alpha-menu-item>
 </alpha-menu>
 ```
-- **Example 2**: a menu with 4 items with the 4th item having more 3 items
+- **Example 2**: a menu with 4 items, with the 4th item having more 3 items
 ```html title="Example 2"
 <alpha-menu>
     <alpha-menu-item>Menu item 1</alpha-menu-item>
@@ -94,9 +94,9 @@ All examples below use the `alpha-design-system`. If you are using any other des
 ```
 
 ### Trigger an action
-The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events to be used.
+The `<alpha-menu>` and `<alpha-menu-item>`components have 3 custom events that can be used.
 
-1. Create a function `functionName1()`, `functionName2()` and `functionName3()` into the class of the component:
+1. Create a function `functionName1()`, `functionName2()` and `functionName3()` in the class of the component:
 
 ```js {3,6,9}
 export class TEMPLATE extends FASTElement {
@@ -131,16 +131,14 @@ export class TEMPLATE extends FASTElement {
     ...
 ```
 
-Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside of it.
-So in case you have something like this:
+Remember that if your main `<alpha-menu>` has an event attached, then it will replicate to all components inside it.
+In this example, `funtionName1()` will be called twice:
 
 ```html
 <alpha-menu  @click=${x => x.functionName1()}>
     <alpha-menu-item @click=${x => x.functionName1()}>Menu item 1</alpha-menu-item>
 </alpha-menu>
 ```
-
-Then `funtionName1()` will be called twice.
 
 ### Try yourself
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
@@ -9,9 +9,11 @@ tags:
   - modal
 ---
 
-A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. Usually, when an active modal is displayed, all other content on the screen is dimmed. The user is unable to move focus to other windows or dialogs. This forces the user to deal with the modal before moving to other work on the application.
 
-As defined by the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
+If you do not want this exclusive focus, use the [dialog](../../../../web/web-components/interaction/dialog/) component.
+
+Here is the definition of a modal from the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
 
 > A dialog is a window overlaid on either the primary window or another dialog window. Windows under a modal dialog are inert. That is, users cannot interact with content outside an active dialog window. Inert content outside an active dialog is typically visually obscured or dimmed so it is difficult to discern; in some implementations, attempts to interact with the inert content cause the dialog to close.
 >
@@ -26,16 +28,14 @@ provideDesignSystem().register(alphaModal());
 ```
 ## Attributes
 
-When you declare an `<alpha-modal>`, you can use the following attribute:
+When you declare an `<alpha-modal>`, you can provide the following attribute:
 
 | Name     | Type   | Description                                                                     |
 |----------|--------|---------------------------------------------------------------------------------|
-| position | string | It places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
-
-These attributes must be defined alongside the declaration of the component.
+| position | string | Places the modal to the `right`, `centre` or `left` of the screen. **Default:** `centre` |
 
 :::note
-If you set `position` to be `left` or `right`, the modal will assume `heigh: 100%` by default. To change it, make the appropriate css modifications.
+If you set `position` to be `left` or `right`, the modal will assume `height: 100%` by default. To change this, make the appropriate css modifications.
 :::
 
 
@@ -45,8 +45,8 @@ The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
-| show()  | It shows the referred modal  |
-| close() | It closes the referred modal |
+| show()  | Shows the referred modal  |
+| close() | Closes the referred modal |
 
 By default, the `modal-component` starts closed.
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
@@ -4,12 +4,12 @@ sidebar_label: 'Modal'
 id: modal
 keywords: [web, web components, modal]
 tags:
-    - web
-    - web components
-    - modal
+  - web
+  - web components
+  - modal
 ---
 
-A modal component will prevent the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
+A modal is a type of `dialog` that prevents the user from interacting with other content on the page. An alternative is the [dialog](../../../../web/web-components/interaction/dialog/) component.
 
 As defined by the [W3C](https://w3c.github.io/aria-practices/#dialog_modal):
 
@@ -24,23 +24,104 @@ import { provideDesignSystem, alphaModal } from '@genesislcap/alpha-design-syste
 
 provideDesignSystem().register(alphaModal());
 ```
+## Methods
+
+When you declare an `<alpha-modal>`, you can duse the following methods:
+
+| Name    | Description                  |
+|---------|------------------------------|
+| show()  | It shows the referred modal  |
+| close() | It closes the referred modal |
 
 ## Usage
 
+Below you see the standard declaration of the modal:
+
 ```html
-<alpha-card id="alpha-modal">
-  <alpha-button id="js-alpha-show-modal" appearance="accent">Show Rapid Modal</alpha-button>
-  <alpha-modal>
-    <h5 slot="top">Modal title</h5>
-    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit/</p> 
-    <alpha-button slot="bottom" id="js-alpha-close-modal">Close this modal</alpha-button>
-  </alpha-modal>
-</alpha-card>
+<alpha-modal>
+    This is a modal
+</alpha-modal>
+```
+
+### Interaction
+
+In order to interact with the modal component, you need to use the available methods. To do that, import modal from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { Modal as alphaModal } from '@genesislcap/alpha-design-system';
+```
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+After that, you need to define the local variable to be referred to, in this case `localModal`:
+
+```js {3}
+export class TEMPLATE extends FASTElement {
+    ...
+    localModal: alphaModal;
+    ...
+}
+```
+
+Now that you have your local variable, you can use the directive `ref` to link your component to this variable:
+
+```html {1,5-7}
+import {... , ref} from '@microsoft/fast-element';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-modal ${ref('localModal')}>
+        This is a modal
+    </alpha-modal>
+}
+```
+
+If you are not familiar with the `ref` directive, take a look at the [Microsoft Fast documentation](https://www.fast.design/docs/fast-element/using-directives/#the-repeat-directive).
+
+From this point, you can use both `show()` and `close()` as methods of `localModal`.
+
+### Examples
+
+Below we have two examples of how to use both methods:
+
+- Create a button to open a modal:
+
+```html {6}
+import {... , ref} from '@microsoft/fast-element';
+import {sync} from '@genesislcap/foundation-utils';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-button @click=${x => x.localModal.show()}></alpha-button>
+    <alpha-modal ${ref('localModal')}>
+       This is a modal
+    </alpha-modal>
+}
+```
+
+- Create a button inside the modal to close it:
+
+```html {9}
+import {... , ref} from '@microsoft/fast-element';
+import {sync} from '@genesislcap/foundation-utils';
+...
+export const yourTemplate = html<Template>`
+    ...
+    <alpha-button @click=${x => x.localModal.show()}>Open modal</alpha-button>
+    <alpha-modal ${ref('localModal')}>
+       This is a modal
+       <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
+    </alpha-modal>
+}
 ```
 
 ## Use cases
 
-* Confirmation pop-ups
+- Confirmation pop-ups
+- Alerts
+- Forms submissions
+- Contextual information
 
 ## Additional resources
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
@@ -24,14 +24,31 @@ import { provideDesignSystem, alphaModal } from '@genesislcap/alpha-design-syste
 
 provideDesignSystem().register(alphaModal());
 ```
+## Attributes
+
+When you declare an `<alpha-modal>`, you can use the following attribute:
+
+| Name     | Type   | Description                                                                     |
+|----------|--------|---------------------------------------------------------------------------------|
+| position | string | It places the modal to be on `right`, `centre` or `left`. **Default:** `centre` |
+
+These attributes must be defined alongside the declaration of the component.
+
+:::note
+If you set `position` to be `left` or `right`, the modal will assume `heigh: 100%` by default. To change it, make the appropriate css modifications.
+:::
+
+
 ## Methods
 
-When you declare an `<alpha-modal>`, you can duse the following methods:
+The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
 | show()  | It shows the referred modal  |
 | close() | It closes the referred modal |
+
+By default, the `modal-component` starts closed.
 
 ## Usage
 
@@ -72,9 +89,9 @@ import {... , ref} from '@microsoft/fast-element';
 export const yourTemplate = html<Template>`
     ...
     <alpha-modal ${ref('localModal')}>
-        This is a modal
+    This is a modal
     </alpha-modal>
-}
+    }
 ```
 
 If you are not familiar with the `ref` directive, take a look at the [Microsoft Fast documentation](https://www.fast.design/docs/fast-element/using-directives/#the-repeat-directive).
@@ -85,6 +102,12 @@ From this point, you can use both `show()` and `close()` as methods of `localMod
 
 Below we have two examples of how to use both methods:
 
+- Create a modal positioned to the left:
+```html
+<alpha-modal position="left">
+    This is a modal
+</alpha-modal>
+```
 - Create a button to open a modal:
 
 ```html {6}
@@ -95,9 +118,9 @@ export const yourTemplate = html<Template>`
     ...
     <alpha-button @click=${x => x.localModal.show()}></alpha-button>
     <alpha-modal ${ref('localModal')}>
-       This is a modal
+    This is a modal
     </alpha-modal>
-}
+    }
 ```
 
 - Create a button inside the modal to close it:
@@ -110,10 +133,10 @@ export const yourTemplate = html<Template>`
     ...
     <alpha-button @click=${x => x.localModal.show()}>Open modal</alpha-button>
     <alpha-modal ${ref('localModal')}>
-       This is a modal
-       <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
+    This is a modal
+    <alpha-button @click=${x => x.localModal.show()}>Close modal</alpha-button>
     </alpha-modal>
-}
+    }
 ```
 
 ## Use cases
@@ -125,4 +148,4 @@ export const yourTemplate = html<Template>`
 
 ## Additional resources
 
-- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#dialog_modal)
+- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#dialog_modal)~~

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
@@ -100,7 +100,7 @@ From this point, you can use both `show()` and `close()` as methods of `localMod
 
 ### Examples
 
-Below we have two examples of how to use both methods:
+Below we have three examples of how to use both methods:
 
 - Create a modal positioned to the left:
 ```html

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/09_modal.md
@@ -45,8 +45,8 @@ The following methods are available for the `alpha-modal` component:
 
 | Name    | Description                  |
 |---------|------------------------------|
-| show()  | Shows the referred modal  |
-| close() | Closes the referred modal |
+| show()  | Shows the modal  |
+| close() | Closes the modal |
 
 By default, the `modal-component` starts closed.
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-937

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs, 2022.4, and 2023.1

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

