### PR TITLE
PTL-939: improved Tabs documentation

### DIFF
--- a/docs/04_web/02_web-components/03_interaction/09_tab.md
+++ b/docs/04_web/02_web-components/03_interaction/09_tab.md
@@ -1,7 +1,7 @@
 ---
-title: 'Web Components - Tabs'
-sidebar_label: 'Tabs'
-id: tabs
+title: 'Web Components - Tab'
+sidebar_label: 'Tab'
+id: tab
 keywords: [web, web components, tab]
 tags:
     - web

--- a/docs/04_web/02_web-components/03_interaction/09_tab.md
+++ b/docs/04_web/02_web-components/03_interaction/09_tab.md
@@ -1,7 +1,7 @@
 ---
-title: 'Web Components - Tab'
-sidebar_label: 'Tab'
-id: tab
+title: 'Web Components - Tabs'
+sidebar_label: 'Tabs'
+id: tabs
 keywords: [web, web components, tab]
 tags:
     - web
@@ -18,39 +18,125 @@ import { provideDesignSystem, alphaTabs, alphaTab, alphaTabPanel } from '@genesi
 
 provideDesignSystem().register(alphaTabs(), alphaTab(), alphaTabPanel());
 ```
+## Attributes
 
-## Usage
+When you declare an `<alpha-tabs>`, you can define the following attributes:
+
+| Name            | Type      | Description                                                                                           |
+|-----------------|-----------|-------------------------------------------------------------------------------------------------------|
+| activeid        | `string`  | Sets the corresponding `<alpha-tab>` to active                                                        | 
+| activeindicator | `boolean` | Activates or deactivates the selected tab indicator                                                   | 
+| orientation     | `string`  | Defines the orientation of the tabs. It can be: `horizontal` or `vertical`. **Default:** `horizontal` | 
+
+These attributes must be defined alongside the declaration of the component.
+
+### alpha-tab
+
+In order to use the tabs, you need to create `<alpha-tab>`, you can define the following attributes:
+
+| Name        | Type      | Description                                                                                           |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------|
+| disabled    | `boolean` | Disables the tab, so the user cannot interact with                                                    | 
+| id          | `string`  | Sets the id for the tab                                                                               | 
+
+These attributes must be defined alongside the declaration of the component.
+
+### alpha-tab-panel
+
+In order to use tab, you need to create `alpha-tab-panel`. This is the component that will host all the content available in each tab.
+
+| Name | Type     | Description                              |
+|------|----------|------------------------------------------|
+| id   | `string` | Links the panel to its corresponding tab |
+
+### Event
+
+These are the available events you can use:
+
+| Name   | component                        | Description                           |
+|--------|----------------------------------|---------------------------------------|
+| change | `<alpha-tabs>`                   | Fires an event when changing tabs     |
+| click  | `<alpha-tabs>` and `<alpha-tab>` | Fires an event when clicking on a tab |
+
+:::warning
+If you use the event `@click` with `<alpha-tabs>` it will fire this event everytime this component is clicked, whether 
+it is clicking in a tab or in its content.
+:::
+
+## Examples
+
+Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
+
+- Create three tabs, with the first one disabled:
+```html
+<alpha-tabs activeid="tab1">
+    <alpha-tab disabled id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+        This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+    This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+        This is tab number 3
+    </alpha-tab-panel>
+</alpha-tabs>
+```
+- Create three tabs, vertically orientated:
+```html
+<alpha-tabs orientation="vertical">
+    <alpha-tab id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+      This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+      This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+      This is tab number 3
+    </alpha-tab-panel>
+</alpha-tabs>
+```
+- Create three tabs, with a `@change` event calling a function called `function()`. This function needs to be defined in
+the main class of your application
+
+```html
+<alpha-tabs @change=${(x) => x.function()}>
+  <alpha-tab id="tab1">Tab 1</alpha-tab>
+  <alpha-tab id="tab2">Tab 2</alpha-tab>
+  <alpha-tab id="tab3">Tab 3</alpha-tab>
+  <alpha-tab-panel id="tab1">
+      This is tab number 1
+  </alpha-tab-panel>
+  <alpha-tab-panel id="tab2">
+      This is tab number 2
+  </alpha-tab-panel>
+  <alpha-tab-panel id="tab3">
+      This is tab number 3
+  </alpha-tab-panel>
+</alpha-tabs>
+```
+
+## Try yourself
 
 ```html live
-<alpha-tabs activeid="entrees">
-  <alpha-tab id="apps">Appetizers</alpha-tab>
-  <alpha-tab id="entrees">Entrees</alpha-tab>
-  <alpha-tab id="desserts">Desserts</alpha-tab>
-  <alpha-tab-panel id="appsPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Stuffed artichokes</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Bruschetta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Oven-baked polenta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Salami and Fig Crostini with Ricotta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Rosemary-Potato Focaccia with Goat Cheese</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
-  <alpha-tab-panel id="entreesPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Mushroom-Sausage Ragù</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Tomato Bread Soup with Steamed Mussels</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Grilled Fish with Artichoke Caponata</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Celery Root and Mushroom Lasagna</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Osso Buco with Citrus Gremolata</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
-  <alpha-tab-panel id="dessertsPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Tiramisu</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Spumoni</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Limoncello and Ice Cream with Biscotti</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
+<alpha-tabs>
+    <alpha-tab id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+        This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+        This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+        This is tab number 3
+    </alpha-tab-panel>
 </alpha-tabs>
 ```
 

--- a/docs/04_web/02_web-components/03_interaction/09_tab.md
+++ b/docs/04_web/02_web-components/03_interaction/09_tab.md
@@ -9,7 +9,7 @@ tags:
     - tab
 ---
 
-_Tabs_ are a set of layered sections of content that display one panel of content at a time. Each tab panel has an associated tab element that, when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
+_Tabs_ are displayed as a set of layered sections of content, where one selected panel of content is displayed above all the other sections. Each tab panel has an associated tab element that, when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
 
 ## Set-up
 
@@ -28,22 +28,20 @@ When you declare an `<alpha-tabs>`, you can define the following attributes:
 | activeindicator | `boolean` | Activates or deactivates the selected tab indicator                                                   | 
 | orientation     | `string`  | Defines the orientation of the tabs. It can be: `horizontal` or `vertical`. **Default:** `horizontal` | 
 
-These attributes must be defined alongside the declaration of the component.
-
 ### alpha-tab
 
-In order to use the tabs, you need to create `<alpha-tab>`, you can define the following attributes:
+For each tab, you need to declare an `<alpha-tab>`, where you can define the following attributes:
 
 | Name        | Type      | Description                                                                                           |
 |-------------|-----------|-------------------------------------------------------------------------------------------------------|
-| disabled    | `boolean` | Disables the tab, so the user cannot interact with                                                    | 
+| disabled    | `boolean` | Disables the tab, so the user cannot interact with it                                                 | 
 | id          | `string`  | Sets the id for the tab                                                                               | 
 
-These attributes must be defined alongside the declaration of the component.
+
 
 ### alpha-tab-panel
 
-In order to use tab, you need to create `alpha-tab-panel`. This is the component that will host all the content available in each tab.
+For each tab, you must also declare an `alpha-tab-panel`. This is the component that hosts the content of the tab.
 
 | Name | Type     | Description                              |
 |------|----------|------------------------------------------|
@@ -59,15 +57,14 @@ These are the available events you can use:
 | click  | `<alpha-tabs>` and `<alpha-tab>` | Fires an event when clicking on a tab |
 
 :::warning
-If you use the event `@click` with `<alpha-tabs>` it will fire this event everytime this component is clicked, whether 
-it is clicking in a tab or in its content.
+If you use the event `@click` with `<alpha-tabs>` it will fire this event every time this component is clicked, regardless of whether the click is in the tab or in its content.
 :::
 
 ## Examples
 
-Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
+Below are three examples of how to use `tabs`, `tab` and `tab-panel`
 
-- Create three tabs, with the first one disabled:
+- Create three tabs, with the first one disabled (it is displayed, but once another tab is clicked, you cannot go back to it):
 ```html
 <alpha-tabs activeid="tab1">
     <alpha-tab disabled id="tab1">Tab 1</alpha-tab>
@@ -84,24 +81,28 @@ Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
     </alpha-tab-panel>
 </alpha-tabs>
 ```
-- Create three tabs, vertically orientated:
+- Create four tabs, vertically orientated:
 ```html
 <alpha-tabs orientation="vertical">
     <alpha-tab id="tab1">Tab 1</alpha-tab>
     <alpha-tab id="tab2">Tab 2</alpha-tab>
     <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab id="tab4">Tab 4</alpha-tab>
     <alpha-tab-panel id="tab1">
-      This is tab number 1
+      One for sorrow
     </alpha-tab-panel>
     <alpha-tab-panel id="tab2">
-      This is tab number 2
+     Two for joy
     </alpha-tab-panel>
     <alpha-tab-panel id="tab3">
-      This is tab number 3
+      Three for a girl
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab4">
+      Four for a boy
     </alpha-tab-panel>
 </alpha-tabs>
 ```
-- Create three tabs, with a `@change` event calling a function called `function()`. This function needs to be defined in
+- Create three tabs, with an `@change` event calling a function called `function()`. This function needs to be defined in
 the main class of your application
 
 ```html

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/09_tab.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/09_tab.md
@@ -1,7 +1,7 @@
 ---
-title: 'Web Components - Tabs'
-sidebar_label: 'Tabs'
-id: tabs
+title: 'Web Components - Tab'
+sidebar_label: 'Tab'
+id: tab
 keywords: [web, web components, tab]
 tags:
     - web

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/09_tab.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/09_tab.md
@@ -1,7 +1,7 @@
 ---
-title: 'Web Components - Tab'
-sidebar_label: 'Tab'
-id: tab
+title: 'Web Components - Tabs'
+sidebar_label: 'Tabs'
+id: tabs
 keywords: [web, web components, tab]
 tags:
     - web
@@ -18,39 +18,125 @@ import { provideDesignSystem, alphaTabs, alphaTab, alphaTabPanel } from '@genesi
 
 provideDesignSystem().register(alphaTabs(), alphaTab(), alphaTabPanel());
 ```
+## Attributes
 
-## Usage
+When you declare an `<alpha-tabs>`, you can define the following attributes:
+
+| Name            | Type      | Description                                                                                           |
+|-----------------|-----------|-------------------------------------------------------------------------------------------------------|
+| activeid        | `string`  | Sets the corresponding `<alpha-tab>` to active                                                        | 
+| activeindicator | `boolean` | Activates or deactivates the selected tab indicator                                                   | 
+| orientation     | `string`  | Defines the orientation of the tabs. It can be: `horizontal` or `vertical`. **Default:** `horizontal` | 
+
+These attributes must be defined alongside the declaration of the component.
+
+### alpha-tab
+
+In order to use the tabs, you need to create `<alpha-tab>`, you can define the following attributes:
+
+| Name        | Type      | Description                                                                                           |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------|
+| disabled    | `boolean` | Disables the tab, so the user cannot interact with                                                    | 
+| id          | `string`  | Sets the id for the tab                                                                               | 
+
+These attributes must be defined alongside the declaration of the component.
+
+### alpha-tab-panel
+
+In order to use tab, you need to create `alpha-tab-panel`. This is the component that will host all the content available in each tab.
+
+| Name | Type     | Description                              |
+|------|----------|------------------------------------------|
+| id   | `string` | Links the panel to its corresponding tab |
+
+### Event
+
+These are the available events you can use:
+
+| Name   | component                        | Description                           |
+|--------|----------------------------------|---------------------------------------|
+| change | `<alpha-tabs>`                   | Fires an event when changing tabs     |
+| click  | `<alpha-tabs>` and `<alpha-tab>` | Fires an event when clicking on a tab |
+
+:::warning
+If you use the event `@click` with `<alpha-tabs>` it will fire this event everytime this component is clicked, whether
+it is clicking in a tab or in its content.
+:::
+
+## Examples
+
+Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
+
+- Create three tabs, with the first one disabled:
+```html
+<alpha-tabs activeid="tab1">
+    <alpha-tab disabled id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+        This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+    This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+        This is tab number 3
+    </alpha-tab-panel>
+</alpha-tabs>
+```
+- Create three tabs, vertically orientated:
+```html
+<alpha-tabs orientation="vertical">
+    <alpha-tab id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+      This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+      This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+      This is tab number 3
+    </alpha-tab-panel>
+</alpha-tabs>
+```
+- Create three tabs, with a `@change` event calling a function called `function()`. This function needs to be defined in
+  the main class of your application
+
+```html
+<alpha-tabs @change=${(x) => x.function()}>
+  <alpha-tab id="tab1">Tab 1</alpha-tab>
+  <alpha-tab id="tab2">Tab 2</alpha-tab>
+  <alpha-tab id="tab3">Tab 3</alpha-tab>
+  <alpha-tab-panel id="tab1">
+      This is tab number 1
+  </alpha-tab-panel>
+  <alpha-tab-panel id="tab2">
+      This is tab number 2
+  </alpha-tab-panel>
+  <alpha-tab-panel id="tab3">
+      This is tab number 3
+  </alpha-tab-panel>
+</alpha-tabs>
+```
+
+## Try yourself
 
 ```html live
-<alpha-tabs activeid="entrees">
-  <alpha-tab id="apps">Appetizers</alpha-tab>
-  <alpha-tab id="entrees">Entrees</alpha-tab>
-  <alpha-tab id="desserts">Desserts</alpha-tab>
-  <alpha-tab-panel id="appsPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Stuffed artichokes</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Bruschetta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Oven-baked polenta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Salami and Fig Crostini with Ricotta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Rosemary-Potato Focaccia with Goat Cheese</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
-  <alpha-tab-panel id="entreesPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Mushroom-Sausage Ragù</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Tomato Bread Soup with Steamed Mussels</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Grilled Fish with Artichoke Caponata</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Celery Root and Mushroom Lasagna</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Osso Buco with Citrus Gremolata</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
-  <alpha-tab-panel id="dessertsPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Tiramisu</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Spumoni</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Limoncello and Ice Cream with Biscotti</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
+<alpha-tabs>
+    <alpha-tab id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+        This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+        This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+        This is tab number 3
+    </alpha-tab-panel>
 </alpha-tabs>
 ```
 

--- a/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/09_tab.md
+++ b/versioned_docs/version-2022.4/04_web/02_web-components/03_interaction/09_tab.md
@@ -9,7 +9,7 @@ tags:
     - tab
 ---
 
-_Tabs_ are a set of layered sections of content that display one panel of content at a time. Each tab panel has an associated tab element that, when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
+_Tabs_ are displayed as a set of layered sections of content, where one selected panel of content is displayed above all the other sections. Each tab panel has an associated tab element that, when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
 
 ## Set-up
 
@@ -28,22 +28,20 @@ When you declare an `<alpha-tabs>`, you can define the following attributes:
 | activeindicator | `boolean` | Activates or deactivates the selected tab indicator                                                   | 
 | orientation     | `string`  | Defines the orientation of the tabs. It can be: `horizontal` or `vertical`. **Default:** `horizontal` | 
 
-These attributes must be defined alongside the declaration of the component.
-
 ### alpha-tab
 
-In order to use the tabs, you need to create `<alpha-tab>`, you can define the following attributes:
+For each tab, you need to declare an `<alpha-tab>`, where you can define the following attributes:
 
 | Name        | Type      | Description                                                                                           |
 |-------------|-----------|-------------------------------------------------------------------------------------------------------|
-| disabled    | `boolean` | Disables the tab, so the user cannot interact with                                                    | 
+| disabled    | `boolean` | Disables the tab, so the user cannot interact with it                                                 | 
 | id          | `string`  | Sets the id for the tab                                                                               | 
 
-These attributes must be defined alongside the declaration of the component.
+
 
 ### alpha-tab-panel
 
-In order to use tab, you need to create `alpha-tab-panel`. This is the component that will host all the content available in each tab.
+For each tab, you must also declare an `alpha-tab-panel`. This is the component that hosts the content of the tab.
 
 | Name | Type     | Description                              |
 |------|----------|------------------------------------------|
@@ -59,15 +57,14 @@ These are the available events you can use:
 | click  | `<alpha-tabs>` and `<alpha-tab>` | Fires an event when clicking on a tab |
 
 :::warning
-If you use the event `@click` with `<alpha-tabs>` it will fire this event everytime this component is clicked, whether
-it is clicking in a tab or in its content.
+If you use the event `@click` with `<alpha-tabs>` it will fire this event every time this component is clicked, regardless of whether the click is in the tab or in its content.
 :::
 
 ## Examples
 
-Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
+Below are three examples of how to use `tabs`, `tab` and `tab-panel`
 
-- Create three tabs, with the first one disabled:
+- Create three tabs, with the first one disabled (it is displayed, but once another tab is clicked, you cannot go back to it):
 ```html
 <alpha-tabs activeid="tab1">
     <alpha-tab disabled id="tab1">Tab 1</alpha-tab>
@@ -84,25 +81,29 @@ Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
     </alpha-tab-panel>
 </alpha-tabs>
 ```
-- Create three tabs, vertically orientated:
+- Create four tabs, vertically orientated:
 ```html
 <alpha-tabs orientation="vertical">
     <alpha-tab id="tab1">Tab 1</alpha-tab>
     <alpha-tab id="tab2">Tab 2</alpha-tab>
     <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab id="tab4">Tab 4</alpha-tab>
     <alpha-tab-panel id="tab1">
-      This is tab number 1
+      One for sorrow
     </alpha-tab-panel>
     <alpha-tab-panel id="tab2">
-      This is tab number 2
+     Two for joy
     </alpha-tab-panel>
     <alpha-tab-panel id="tab3">
-      This is tab number 3
+      Three for a girl
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab4">
+      Four for a boy
     </alpha-tab-panel>
 </alpha-tabs>
 ```
-- Create three tabs, with a `@change` event calling a function called `function()`. This function needs to be defined in
-  the main class of your application
+- Create three tabs, with an `@change` event calling a function called `function()`. This function needs to be defined in
+the main class of your application
 
 ```html
 <alpha-tabs @change=${(x) => x.function()}>

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
@@ -1,7 +1,7 @@
 ---
-title: 'Web Components - Tabs'
-sidebar_label: 'Tabs'
-id: tabs
+title: 'Web Components - Tab'
+sidebar_label: 'Tab'
+id: tab
 keywords: [web, web components, tab]
 tags:
     - web

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
@@ -1,7 +1,7 @@
 ---
-title: 'Web Components - Tab'
-sidebar_label: 'Tab'
-id: tab
+title: 'Web Components - Tabs'
+sidebar_label: 'Tabs'
+id: tabs
 keywords: [web, web components, tab]
 tags:
     - web
@@ -18,39 +18,125 @@ import { provideDesignSystem, alphaTabs, alphaTab, alphaTabPanel } from '@genesi
 
 provideDesignSystem().register(alphaTabs(), alphaTab(), alphaTabPanel());
 ```
+## Attributes
 
-## Usage
+When you declare an `<alpha-tabs>`, you can define the following attributes:
+
+| Name            | Type      | Description                                                                                           |
+|-----------------|-----------|-------------------------------------------------------------------------------------------------------|
+| activeid        | `string`  | Sets the corresponding `<alpha-tab>` to active                                                        | 
+| activeindicator | `boolean` | Activates or deactivates the selected tab indicator                                                   | 
+| orientation     | `string`  | Defines the orientation of the tabs. It can be: `horizontal` or `vertical`. **Default:** `horizontal` | 
+
+These attributes must be defined alongside the declaration of the component.
+
+### alpha-tab
+
+In order to use the tabs, you need to create `<alpha-tab>`, you can define the following attributes:
+
+| Name        | Type      | Description                                                                                           |
+|-------------|-----------|-------------------------------------------------------------------------------------------------------|
+| disabled    | `boolean` | Disables the tab, so the user cannot interact with                                                    | 
+| id          | `string`  | Sets the id for the tab                                                                               | 
+
+These attributes must be defined alongside the declaration of the component.
+
+### alpha-tab-panel
+
+In order to use tab, you need to create `alpha-tab-panel`. This is the component that will host all the content available in each tab.
+
+| Name | Type     | Description                              |
+|------|----------|------------------------------------------|
+| id   | `string` | Links the panel to its corresponding tab |
+
+### Event
+
+These are the available events you can use:
+
+| Name   | component                        | Description                           |
+|--------|----------------------------------|---------------------------------------|
+| change | `<alpha-tabs>`                   | Fires an event when changing tabs     |
+| click  | `<alpha-tabs>` and `<alpha-tab>` | Fires an event when clicking on a tab |
+
+:::warning
+If you use the event `@click` with `<alpha-tabs>` it will fire this event everytime this component is clicked, whether
+it is clicking in a tab or in its content.
+:::
+
+## Examples
+
+Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
+
+- Create three tabs, with the first one disabled:
+```html
+<alpha-tabs activeid="tab1">
+    <alpha-tab disabled id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+        This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+    This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+        This is tab number 3
+    </alpha-tab-panel>
+</alpha-tabs>
+```
+- Create three tabs, vertically orientated:
+```html
+<alpha-tabs orientation="vertical">
+    <alpha-tab id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+      This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+      This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+      This is tab number 3
+    </alpha-tab-panel>
+</alpha-tabs>
+```
+- Create three tabs, with a `@change` event calling a function called `function()`. This function needs to be defined in
+  the main class of your application
+
+```html
+<alpha-tabs @change=${(x) => x.function()}>
+  <alpha-tab id="tab1">Tab 1</alpha-tab>
+  <alpha-tab id="tab2">Tab 2</alpha-tab>
+  <alpha-tab id="tab3">Tab 3</alpha-tab>
+  <alpha-tab-panel id="tab1">
+      This is tab number 1
+  </alpha-tab-panel>
+  <alpha-tab-panel id="tab2">
+      This is tab number 2
+  </alpha-tab-panel>
+  <alpha-tab-panel id="tab3">
+      This is tab number 3
+  </alpha-tab-panel>
+</alpha-tabs>
+```
+
+## Try yourself
 
 ```html live
-<alpha-tabs activeid="entrees">
-  <alpha-tab id="apps">Appetizers</alpha-tab>
-  <alpha-tab id="entrees">Entrees</alpha-tab>
-  <alpha-tab id="desserts">Desserts</alpha-tab>
-  <alpha-tab-panel id="appsPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Stuffed artichokes</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Bruschetta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Oven-baked polenta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Salami and Fig Crostini with Ricotta</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Rosemary-Potato Focaccia with Goat Cheese</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
-  <alpha-tab-panel id="entreesPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Mushroom-Sausage Ragù</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Tomato Bread Soup with Steamed Mussels</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Grilled Fish with Artichoke Caponata</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Celery Root and Mushroom Lasagna</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Osso Buco with Citrus Gremolata</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
-  <alpha-tab-panel id="dessertsPanel">
-    <ol>
-      <li><alpha-anchor href="#" appearance="hypertext">Tiramisu</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Spumoni</alpha-anchor></li>
-      <li><alpha-anchor href="#" appearance="hypertext">Limoncello and Ice Cream with Biscotti</alpha-anchor></li>
-    </ol>
-  </alpha-tab-panel>
+<alpha-tabs>
+    <alpha-tab id="tab1">Tab 1</alpha-tab>
+    <alpha-tab id="tab2">Tab 2</alpha-tab>
+    <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab-panel id="tab1">
+        This is tab number 1
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab2">
+        This is tab number 2
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab3">
+        This is tab number 3
+    </alpha-tab-panel>
 </alpha-tabs>
 ```
 

--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
@@ -9,7 +9,7 @@ tags:
     - tab
 ---
 
-_Tabs_ are a set of layered sections of content that display one panel of content at a time. Each tab panel has an associated tab element that, when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
+_Tabs_ are displayed as a set of layered sections of content, where one selected panel of content is displayed above all the other sections. Each tab panel has an associated tab element that, when activated, displays the panel. The list of tab elements is arranged along one edge of the currently displayed panel.
 
 ## Set-up
 
@@ -28,22 +28,20 @@ When you declare an `<alpha-tabs>`, you can define the following attributes:
 | activeindicator | `boolean` | Activates or deactivates the selected tab indicator                                                   | 
 | orientation     | `string`  | Defines the orientation of the tabs. It can be: `horizontal` or `vertical`. **Default:** `horizontal` | 
 
-These attributes must be defined alongside the declaration of the component.
-
 ### alpha-tab
 
-In order to use the tabs, you need to create `<alpha-tab>`, you can define the following attributes:
+For each tab, you need to declare an `<alpha-tab>`, where you can define the following attributes:
 
 | Name        | Type      | Description                                                                                           |
 |-------------|-----------|-------------------------------------------------------------------------------------------------------|
-| disabled    | `boolean` | Disables the tab, so the user cannot interact with                                                    | 
+| disabled    | `boolean` | Disables the tab, so the user cannot interact with it                                                 | 
 | id          | `string`  | Sets the id for the tab                                                                               | 
 
-These attributes must be defined alongside the declaration of the component.
+
 
 ### alpha-tab-panel
 
-In order to use tab, you need to create `alpha-tab-panel`. This is the component that will host all the content available in each tab.
+For each tab, you must also declare an `alpha-tab-panel`. This is the component that hosts the content of the tab.
 
 | Name | Type     | Description                              |
 |------|----------|------------------------------------------|
@@ -59,15 +57,14 @@ These are the available events you can use:
 | click  | `<alpha-tabs>` and `<alpha-tab>` | Fires an event when clicking on a tab |
 
 :::warning
-If you use the event `@click` with `<alpha-tabs>` it will fire this event everytime this component is clicked, whether
-it is clicking in a tab or in its content.
+If you use the event `@click` with `<alpha-tabs>` it will fire this event every time this component is clicked, regardless of whether the click is in the tab or in its content.
 :::
 
 ## Examples
 
-Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
+Below are three examples of how to use `tabs`, `tab` and `tab-panel`
 
-- Create three tabs, with the first one disabled:
+- Create three tabs, with the first one disabled (it is displayed, but once another tab is clicked, you cannot go back to it):
 ```html
 <alpha-tabs activeid="tab1">
     <alpha-tab disabled id="tab1">Tab 1</alpha-tab>
@@ -84,25 +81,29 @@ Below you find three examples on how to use `tabs`, `tab` and `tab-panel`
     </alpha-tab-panel>
 </alpha-tabs>
 ```
-- Create three tabs, vertically orientated:
+- Create four tabs, vertically orientated:
 ```html
 <alpha-tabs orientation="vertical">
     <alpha-tab id="tab1">Tab 1</alpha-tab>
     <alpha-tab id="tab2">Tab 2</alpha-tab>
     <alpha-tab id="tab3">Tab 3</alpha-tab>
+    <alpha-tab id="tab4">Tab 4</alpha-tab>
     <alpha-tab-panel id="tab1">
-      This is tab number 1
+      One for sorrow
     </alpha-tab-panel>
     <alpha-tab-panel id="tab2">
-      This is tab number 2
+     Two for joy
     </alpha-tab-panel>
     <alpha-tab-panel id="tab3">
-      This is tab number 3
+      Three for a girl
+    </alpha-tab-panel>
+    <alpha-tab-panel id="tab4">
+      Four for a boy
     </alpha-tab-panel>
 </alpha-tabs>
 ```
-- Create three tabs, with a `@change` event calling a function called `function()`. This function needs to be defined in
-  the main class of your application
+- Create three tabs, with an `@change` event calling a function called `function()`. This function needs to be defined in
+the main class of your application
 
 ```html
 <alpha-tabs @change=${(x) => x.function()}>


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-939

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs, 2023.1 and 2022.4

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

