### PR TITLE
PTL-928: Add fixed attributes to number-field

### DIFF
--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -27,7 +27,7 @@ You can define the following attributes when you declare an `<alpha-number-field
 | appearance     | `string`  | Controls the general appearance of the element. It can be **filled** or **outline**                                                     |
 | autofocus      | `boolean` | When true, the component will be in focus when the page has finished loading                                                            |
 | disabled       | `boolean` | Disables this component; users will not be able to change its value                                                                     |
-| locale         | `string`  | Defines a number format based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting`                    |
+| locale         | `string`  | Defines a number format based on language and location. **Default: "en-US"**. Must be used with `withFormatting`                    |
 | form           | `string`  | Associates this component with a form. Form `id` needs to be passed. If no Id is provided, then it will be associated with the ancestor form |
 | hideStep       | `boolean` | Hides the step control (up and down arrows) for the element                                                                             |
 | max            | `number`  | Defines the maximum value allowed                                                                                                       |
@@ -38,19 +38,18 @@ You can define the following attributes when you declare an `<alpha-number-field
 | size           | `number`  | Defines the width of the component                                                                                                      |
 | step           | `number`  | Defines the step rate for each user click on the arrows (steps) in the element. **Default: `1`**                                        |
 | value          | `string`  | Defines a value for the component when it is created                                                                                    |
-| withFormatting | `boolean` | Allows number formatting                                                                                                                |
+| withFormatting | `boolean` | Enables you to format the number                                                                                                               |
 
 
-### Custom options
+### Setting the number of decimal places
 
-The `number-field` has 2 custom options:
+To set the number of decimal places, use the `withFormatting` attribute `maximumFractionDigits`.
+
 
 | Variable              | Type     | Default | Description                               |
 |-----------------------|----------|---------|-------------------------------------------|
-| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted |
-| minimumFractionDigits | `number` | 0       | This field needs to be set `0`            |
+| maximumFractionDigits | `number` | 3       | Maximum number of decimal digits accepted (up to 11 digits)|
 
-These options need to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -66,9 +65,9 @@ of this component accordingly.
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
 ```
 
-- **Example 3**: a number-field with a maximum digit number of 2 and minimum of 0
+- **Example 3**: a number-field with a maximum of 2 digits 
 ```html title="Example 3"
-<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 0})}>Number-field</alpha-number-field>
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -9,7 +9,7 @@ tags:
   - number field
 ---
 
-A text field for numeric entry.
+A text field for numeric entry. By default, this includes steps - up and down arrows where the user can click to increase or decrease the number in the field.
 
 ## Set-up
 
@@ -20,27 +20,26 @@ provideDesignSystem().register(alphaNumberField());
 ```
 ## Attributes
 
-You can define the following attributes in an `<alpha-number-field>`.
+You can define the following attributes when you declare an `<alpha-number-field>`.
 
 | Name           | Type      | Description                                                                                                                             |
 |----------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                                           |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                                     |
-| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting`                |
-| form           | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
-| hideStep       | `boolean` | Hides the step control of the element                                                                                                   |
-| max            | `number`  | Defines maximum number allowed                                                                                                          |
+| appearance     | `string`  | Controls the general appearance of the element. It can be **filled** or **outline**                                                     |
+| autofocus      | `boolean` | When true, the component will be in focus when the page has finished loading                                                            |
+| disabled       | `boolean` | Disables this component; users will not be able to change its value                                                                     |
+| locale         | `string`  | Defines a number format based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting`                    |
+| form           | `string`  | Associates this component with a form. Form `id` needs to be passed. If no Id is provided, then it will be associated with the ancestor form |
+| hideStep       | `boolean` | Hides the step control (up and down arrows) for the element                                                                             |
+| max            | `number`  | Defines the maximum value allowed                                                                                                       |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                                |
-| min            | `number`  | Defines minimum number allowed                                                                                                          |
-| minlength      | `number`  | The minimum number of characters allowed                                                                                                |
+| min            | `number`  | Defines minimum value allowed                                                                                                           |
+| minlength      | `number`  | The minimum number of characters required                                                                                               |
 | placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                                    |
 | size           | `number`  | Defines the width of the component                                                                                                      |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                                            |
+| step           | `number`  | Defines the step rate for each user click on the arrows (steps) in the element. **Default: `1`**                                        |
 | value          | `string`  | Defines a value for the component when it is created                                                                                    |
 | withFormatting | `boolean` | Allows number formatting                                                                                                                |
 
-These attributes must be defined alongside the declaration of the component.
 
 ### Custom options
 
@@ -51,13 +50,13 @@ The `number-field` has 2 custom options:
 | maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted |
 | minimumFractionDigits | `number` | 0       | This field needs to be set `0`            |
 
-All these options needs to be used with `withFormatting` attribute.
+These options need to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
-- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control
+- **Example 1**: a number-field with maximum number 50 and minimum 10; the step control is hidden
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```

--- a/docs/04_web/02_web-components/01_form/05_number-field.md
+++ b/docs/04_web/02_web-components/01_form/05_number-field.md
@@ -27,6 +27,7 @@ You can define the following attributes in an `<alpha-number-field>`.
 | appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                                           |
 | autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
 | disabled       | `boolean` | Disables this component, users will not be able to change its value                                                                     |
+| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting`                |
 | form           | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
 | hideStep       | `boolean` | Hides the step control of the element                                                                                                   |
 | max            | `number`  | Defines maximum number allowed                                                                                                          |
@@ -41,6 +42,17 @@ You can define the following attributes in an `<alpha-number-field>`.
 
 These attributes must be defined alongside the declaration of the component.
 
+### Custom options
+
+The `number-field` has 2 custom options:
+
+| Variable              | Type     | Default | Description                               |
+|-----------------------|----------|---------|-------------------------------------------|
+| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted |
+| minimumFractionDigits | `number` | 0       | This field needs to be set `0`            |
+
+All these options needs to be used with `withFormatting` attribute.
+
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
@@ -53,6 +65,11 @@ of this component accordingly.
 - **Example 2**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 2"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+
+- **Example 3**: a number-field with a maximum digit number of 2 and minimum of 0
+```html title="Example 3"
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 0})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -9,7 +9,7 @@ tags:
   - number field
 ---
 
-A text field for numeric entry.
+A text field for numeric entry. By default, this includes steps - up and down arrows where the user can click to increase or decrease the number in the field.
 
 ## Set-up
 
@@ -20,44 +20,42 @@ provideDesignSystem().register(alphaNumberField());
 ```
 ## Attributes
 
-You can define the following attributes in an `<alpha-number-field>`.
+You can define the following attributes when you declare an `<alpha-number-field>`.
 
 | Name           | Type      | Description                                                                                                                             |
 |----------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                                           |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                                     |
-| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting`                |
-| form           | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
-| hideStep       | `boolean` | Hides the step control of the element                                                                                                   |
-| max            | `number`  | Defines maximum number allowed                                                                                                          |
+| appearance     | `string`  | Controls the general appearance of the element. It can be **filled** or **outline**                                                     |
+| autofocus      | `boolean` | When true, the component will be in focus when the page has finished loading                                                            |
+| disabled       | `boolean` | Disables this component; users will not be able to change its value                                                                     |
+| locale         | `string`  | Defines a number format based on language and location. **Default: "en-US"**. Must be used with `withFormatting`                    |
+| form           | `string`  | Associates this component with a form. Form `id` needs to be passed. If no Id is provided, then it will be associated with the ancestor form |
+| hideStep       | `boolean` | Hides the step control (up and down arrows) for the element                                                                             |
+| max            | `number`  | Defines the maximum value allowed                                                                                                       |
 | maxlength      | `number`  | The maximum number of characters allowed                                                                                                |
-| min            | `number`  | Defines minimum number allowed                                                                                                          |
-| minlength      | `number`  | The minimum number of characters allowed                                                                                                |
+| min            | `number`  | Defines minimum value allowed                                                                                                           |
+| minlength      | `number`  | The minimum number of characters required                                                                                               |
 | placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                                    |
 | size           | `number`  | Defines the width of the component                                                                                                      |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                                            |
+| step           | `number`  | Defines the step rate for each user click on the arrows (steps) in the element. **Default: `1`**                                        |
 | value          | `string`  | Defines a value for the component when it is created                                                                                    |
-| withFormatting | `boolean` | Allows number formatting                                                                                                                |
+| withFormatting | `boolean` | Enables you to format the number                                                                                                               |
 
-These attributes must be defined alongside the declaration of the component.
 
-### Custom options
+### Setting the number of decimal places
 
-The `number-field` has 2 custom options:
+To set the number of decimal places, use the `withFormatting` attribute `maximumFractionDigits`.
+
 
 | Variable              | Type     | Default | Description                               |
 |-----------------------|----------|---------|-------------------------------------------|
-| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted |
-| minimumFractionDigits | `number` | 0       | This field needs to be set `0`            |
+| maximumFractionDigits | `number` | 3       | Maximum number of decimal digits accepted (up to 11 digits)|
 
-All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
 of this component accordingly.
 
-- **Example 1**: a number-field with maximum number 50 and minimum 10 hiding the step control
+- **Example 1**: a number-field with maximum number 50 and minimum 10; the step control is hidden
 ```html title="Example 1"
 <alpha-number-field min="10" max="50" hidestep>number-field</alpha-number-field>
 ```
@@ -67,9 +65,9 @@ of this component accordingly.
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
 ```
 
-- **Example 3**: a number-field with a maximum digit number of 2 and minimum of 0
+- **Example 3**: a number-field with a maximum of 2 digits 
 ```html title="Example 3"
-<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 0})}>Number-field</alpha-number-field>
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input

--- a/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/01_form/04_number-field.md
@@ -22,24 +22,36 @@ provideDesignSystem().register(alphaNumberField());
 
 You can define the following attributes in an `<alpha-number-field>`.
 
-| Name           | Type      | Description                                                                          |
-|----------------|-----------|--------------------------------------------------------------------------------------|
-| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**        |
-| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading          |
-| form        | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
-| disabled       | `boolean` | Disables this component, users will not be able to change its value                  |
-| hideStep       | `boolean` | Hides the step control of the element                                                |
-| max            | `number`  | Defines maximum number allowed                                                       |
-| maxlength      | `number`  | The maximum number of characters allowed                                             |
-| min            | `number`  | Defines minimum number allowed                                                       |
-| minlength      | `number`  | The minimum number of characters allowed                                             |
-| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting) |
-| size           | `number`  | Defines the width of the component                                                   |
-| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**         |
-| value          | `string`  | Defines a value for the component when it is created                                 |
-| withFormatting | `boolean` | Allows number formatting                                                             |
+| Name           | Type      | Description                                                                                                                             |
+|----------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| appearance     | `string`  | Controls the general view of the element. It can be **filled** or **outline**                                                           |
+| autofocus      | `boolean` | When true, the component will be focused when the page has finished loading                                                             |
+| disabled       | `boolean` | Disables this component, users will not be able to change its value                                                                     |
+| locale         | `string`  | Defines a number formatting based on language and location. **Default: "en-US"**. Needs to be used with `withFormatting`                |
+| form           | `string`  | Associates this component to a form. Form `id` needs to be passed. If no Id informed, then it will be associated with the ancestor form |
+| hideStep       | `boolean` | Hides the step control of the element                                                                                                   |
+| max            | `number`  | Defines maximum number allowed                                                                                                          |
+| maxlength      | `number`  | The maximum number of characters allowed                                                                                                |
+| min            | `number`  | Defines minimum number allowed                                                                                                          |
+| minlength      | `number`  | The minimum number of characters allowed                                                                                                |
+| placeholder    | `string`  | Sets a placeholder for the element (which disappears when the user starts inputting)                                                    |
+| size           | `number`  | Defines the width of the component                                                                                                      |
+| step           | `number`  | Defines the step rate when using the arrows in the element. **Default: `1`**                                                            |
+| value          | `string`  | Defines a value for the component when it is created                                                                                    |
+| withFormatting | `boolean` | Allows number formatting                                                                                                                |
 
 These attributes must be defined alongside the declaration of the component.
+
+### Custom options
+
+The `number-field` has 2 custom options:
+
+| Variable              | Type     | Default | Description                               |
+|-----------------------|----------|---------|-------------------------------------------|
+| maximumFractionDigits | `number` | 11      | Maximum number of decimal digits accepted |
+| minimumFractionDigits | `number` | 0       | This field needs to be set `0`            |
+
+All these options needs to be used with `withFormatting` attribute.
 
 ## Usage
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration
@@ -53,6 +65,11 @@ of this component accordingly.
 - **Example 2**: a number-field with step 0.5 - each time the user clicks on a step arrow, the value increases or decreases by 0.5
 ```html title="Example 2"
 <alpha-number-field step="0.5">Number-field</alpha-number-field>
+```
+
+- **Example 3**: a number-field with a maximum digit number of 2 and minimum of 0
+```html title="Example 3"
+<alpha-number-field withFormatting :options=${() => ({maximumFractionDigits: 2, minimumFractionDigits: 0})}>Number-field</alpha-number-field>
 ```
 
 ### Get the user input


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-928

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
docs and 2023.1

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
N/A

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

