### PR TITLE
Gg/ptl-942: Improve banner documentation

### DIFF
--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -11,7 +11,7 @@ tags:
 
 `foundation-banner` extends `foundation-element`.
 
-The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is disimssed by the user.
+The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is dismissed by the user.
 
 Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, so the user can either ignore the banner or interact with it at any time.
 

--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -4,16 +4,16 @@ sidebar_label: 'Banner'
 id: banner
 keywords: [web, web components, banner]
 tags:
-    - web
-    - web components
-    - banner
+  - web
+  - web components
+  - banner
 ---
 
 `foundation-banner` extends `foundation-element`.
 
 The `banner` displays an important, succinct message, such as actions for users to address. It requires a user action to be dismissed.
 
-Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, allowing the user to ignore them or to interact with them at any time. Only one banner should be shown at a time.
+Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, allowing the user to ignore them or to interact with them at any time.
 
 ## Set-up
 
@@ -34,44 +34,55 @@ When you use an `<alpha-banner>`, you can use the following method:
 
 ## Slots
 
-When you use an `<alpha-banner` you can use the following slots
+When you use an `<alpha-banner>` you can use the following slots
 
 | Name    | Description                                                                   |
 |---------|-------------------------------------------------------------------------------|
 | content | The content to be displayed on the left side of the component                 |
 | action  | Defined the action components to be placed on the right side of the component |
 
+:::note
+Multiple content/action slots will be placed side by side.
+:::
+
 ## Usage
 
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
 - **Example 1**: A banner with no action buttons with a content slot
+
 ```html title="Example 1"
 <alpha-banner>
     <div slot="content">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+        This is a banner
     </div>
 </alpha-banner>
 ```
+
 - **Example 2**: a banner with two action buttons and a content slot
+
 ```html title="Example 2"
 <alpha-banner>
     <div slot="content">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+        This is a banner
     </div>
-    <alpha-button slot="action" appearance="lightweight">Ignore</alpha-button>
-    <alpha-button slot="action" appearance="lightweight">Diagnose</alpha-button>
+    <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
+    <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>
 </alpha-banner>
 ```
 
 ### Interaction
-When you place a banner, you can use the method `dismiss` to remove the banner. Bellow you see how to use this method
+
+#### Dismiss a banner
+
+When you place a banner, you can use the method `dismiss()` to remove the banner. Below you see how to use this method:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
 ``` typescript
 import { alphaBanner } from '@genesislcap/alpha-design-system';
 ```
+
 :::note
 If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
 :::
@@ -85,6 +96,7 @@ export class TEMPLATE extends FASTElement {
     ...
 }
 ```
+
 2. Create a function `dismissBanner()` into the class of the component:
 
 ```js {1,5}
@@ -97,7 +109,7 @@ export class TEMPLATE extends FASTElement {
 }
 ```
 
-3. Create an action slot to dismiss the banner:
+3. Create an action slot to dismiss the banner with a button:
 
 ```html tile="Example 4" {1,4}
 <alpha-banner ${ref('localBanner)}>
@@ -108,22 +120,92 @@ export class TEMPLATE extends FASTElement {
 </alpha-banner>
 ```
 
-From this point, your application can run the action after the button has been clicked.
+From this point, when you click on the **Close banner** button, the banner will be smoothly removed with a transition.
+
+#### Create a banner dynamically
+
+Normally you would prefer to choose when your banner appears to your user. But if you create the banner in your file, it will automatically
+show up in your application. In that case, here is an example of how to create this component dynamically so it appears whenever you set to:
+
+1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { alphaBanner } from '@genesislcap/alpha-design-system';
+```
+
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+2. In your template file, create a `<div>` placeholder where you want the banner to appear:
+
+``` typescript
+<div id="BannerPlaceholder"></div>
+```
+
+3. Create the function to create your banner dynamically:
+
+``` typescript
+createBanner(){
+
+    // Creates the banner element
+    const bannerElement = document.createElement('alpha-banner');
+    bannerElement.id = 'bannerId';
+
+    // Sets the HTML content of the banner element
+    bannerElement.innerHTML = `
+        <div slot="content">
+            This is a banner
+        </div>
+        <alpha-button id="button ${bannerElement.id}" slot="action" appearance="lightweight">Close Banner</alpha-button>
+    `;
+
+    // Gets the placeholder div where you want to append the banner
+    const placeholderDiv = this.shadowRoot.getElementById('BannerPlaceholder');
+
+    // Appends the banner element to the div
+    placeholderDiv.appendChild(bannerElement)
+
+    // Adds dismiss event to the button action
+    const actionButton = this.shadowRoot.getElementById("button " + bannerElement.id);
+    const tempBanner = this.shadowRoot.getElementById(bannerElement.id) as alphaBanner
+    
+    actionButton.addEventListener('click', function() {
+        tempBanner.dismiss();
+    });
+}
+```
+
+In this example, the following commands used are:
+
+- `document.createElement('alpha-banner')`: Creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
+- `bannerElement.id`: Sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
+- `bannerElement.innerHTML`: Sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
+- `this.shadowRoot.getElementById('BannerPlaceholder')`: Retrieves the placeholder `<div>` for the banner. We use `shadowRoot` instead of `document` because the web component utilizes shadow DOM.
+- `placeholderDiv.appendChild(bannerElement)`: Appends the newly created banner to the placeholder `<div>`.
+- `as Banner`: You must specify the type as `Banner`, or else you won't be able to access the banner's methods.
+- `actionButton.addEventListener('click', function() {tempBanner.dismiss()});`: Adds a `@click` event to the button inside the banner.
+
+Now, you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder we defined.
+
+:::warning
+Creating components dynamically is a valuable technique, but it's crucial to exercise caution when defining the `id`. Failing to do so may result in multiple components sharing the same `id`, potentially leading to a malfunctioning application.
+:::
 
 ## Try yourself
 
 ```jsx live
-<alpha-banner id="js-banner">
+<alpha-banner>
   <div slot="content">
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+    This is a banner
   </div>
-  <alpha-button slot="action" appearance="lightweight" style={{marginRight: '5px'}}>Ignore</alpha-button>
-  <alpha-button slot="action" appearance="lightweight">Diagnose</alpha-button>
+  <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
+  <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>
 </alpha-banner>
 ```
 
 ## Use cases
 
-* warning notifications
-* advertisement
-* displaying a logo
+- warning notifications
+- advertisement
+- displaying a logo

--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -11,9 +11,9 @@ tags:
 
 `foundation-banner` extends `foundation-element`.
 
-The `banner` displays an important, succinct message, such as actions for users to address. It requires a user action to be dismissed.
+The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is disimssed by the user
 
-Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, allowing the user to ignore them or to interact with them at any time.
+Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, so the user can either ignore the banner or to interact with it at any time.
 
 ## Set-up
 

--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -11,7 +11,7 @@ tags:
 
 `foundation-banner` extends `foundation-element`.
 
-The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is disimssed by the user
+The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is disimssed by the user.
 
 Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, so the user can either ignore the banner or interact with it at any time.
 

--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -24,7 +24,93 @@ provideDesignSystem().register(alphaBanner());
 provideDesignSystem().register(alphaButton());
 ```
 
+## Methods
+
+When you use an `<alpha-banner>`, you can use the following method:
+
+| Name    | Description          |
+|---------|----------------------|
+| dismiss | Dismisses the banner |
+
+## Slots
+
+When you use an `<alpha-banner` you can use the following slots
+
+| Name    | Description                                                                   |
+|---------|-------------------------------------------------------------------------------|
+| content | The content to be displayed on the left side of the component                 |
+| action  | Defined the action components to be placed on the right side of the component |
+
 ## Usage
+
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
+
+- **Example 1**: A banner with no action buttons with a content slot
+```html title="Example 1"
+<alpha-banner>
+    <div slot="content">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+    </div>
+</alpha-banner>
+```
+- **Example 2**: a banner with two action buttons and a content slot
+```html title="Example 2"
+<alpha-banner>
+    <div slot="content">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+    </div>
+    <alpha-button slot="action" appearance="lightweight">Ignore</alpha-button>
+    <alpha-button slot="action" appearance="lightweight">Diagnose</alpha-button>
+</alpha-banner>
+```
+
+### Interaction
+When you place a banner, you can use the method `dismiss` to remove the banner. Bellow you see how to use this method
+
+1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { alphaBanner } from '@genesislcap/alpha-design-system';
+```
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+After that, you need to define the local variable to be referred to, in this case `localBanner`:
+
+```js {3}
+export class TEMPLATE extends FASTElement {
+    ...
+    localBanner: alphaBanner;
+    ...
+}
+```
+2. Create a function `dismissBanner()` into the class of the component:
+
+```js {1,5}
+export class TEMPLATE extends FASTElement {
+    ...
+    dismissBanner(){
+        this.localBanner.dismiss();
+    }
+    ...
+}
+```
+
+3. Create an action slot to dismiss the banner:
+
+```html tile="Example 4" {1,4}
+<alpha-banner ${ref('localBanner)}>
+    <div slot="content">
+        This is a banner
+    </div>
+    <alpha-button slot="action" appearance="lightweight" @click=${(x) => x.dismissBanner()}>Close banner</alpha-button>
+</alpha-banner>
+```
+
+From this point, your application can run the action after the button has been clicked.
+
+## Try yourself
 
 ```jsx live
 <alpha-banner id="js-banner">

--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -13,7 +13,7 @@ tags:
 
 The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is disimssed by the user
 
-Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, so the user can either ignore the banner or to interact with it at any time.
+Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, so the user can either ignore the banner or interact with it at any time.
 
 ## Set-up
 
@@ -34,48 +34,46 @@ When you use an `<alpha-banner>`, you can use the following method:
 
 ## Slots
 
-When you use an `<alpha-banner>` you can use the following slots
+When you use an `<alpha-banner>` you can use the following slots to define content and actions:
 
 | Name    | Description                                                                   |
 |---------|-------------------------------------------------------------------------------|
 | content | The content to be displayed on the left side of the component                 |
-| action  | Defined the action components to be placed on the right side of the component |
+| action  | Defines the action components to be placed on the right side of the component |
 
 :::note
-Multiple content/action slots will be placed side by side.
+If you create multiple slots of content or actions, the slots will be placed side by side.
 :::
 
 ## Usage
 
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
-- **Example 1**: A banner with no action buttons with a content slot
+- **Example 1**: A banner with a content slot and no action buttons 
 
 ```html title="Example 1"
 <alpha-banner>
     <div slot="content">
-        This is a banner
+        This is a banner that the user cannot remove
     </div>
 </alpha-banner>
 ```
 
-- **Example 2**: a banner with two action buttons and a content slot
+- **Example 2**: a banner with two action buttons and a message
 
 ```html title="Example 2"
 <alpha-banner>
     <div slot="content">
-        This is a banner
+        Båten min er ikke lenger sjødyktig
     </div>
     <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
     <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>
 </alpha-banner>
 ```
 
-### Interaction
+### Interaction: dismiss a banner
 
-#### Dismiss a banner
-
-When you place a banner, you can use the method `dismiss()` to remove the banner. Below you see how to use this method:
+When you place a banner, you can use the method `dismiss()` to remove the banner. here is an example of how to use this method:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
@@ -97,7 +95,7 @@ export class TEMPLATE extends FASTElement {
 }
 ```
 
-2. Create a function `dismissBanner()` into the class of the component:
+2. Create a function `dismissBanner()` in the class of the component:
 
 ```js {1,5}
 export class TEMPLATE extends FASTElement {
@@ -120,12 +118,12 @@ export class TEMPLATE extends FASTElement {
 </alpha-banner>
 ```
 
-From this point, when you click on the **Close banner** button, the banner will be smoothly removed with a transition.
+From this point, when you click on the **Close banner** button, the banner will be removed with a smooth transition.
 
-#### Create a banner dynamically
+### Interaction: create a banner dynamically
 
-Normally you would prefer to choose when your banner appears to your user. But if you create the banner in your file, it will automatically
-show up in your application. In that case, here is an example of how to create this component dynamically so it appears whenever you set to:
+If you create the banner in your file, it will be displayed automatically. However, Normally, you often need to display a banner subject to certain conditions. 
+Here is an example of how to create this component dynamically so that it is only displayed in specific circumstances:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
@@ -155,7 +153,7 @@ createBanner(){
     // Sets the HTML content of the banner element
     bannerElement.innerHTML = `
         <div slot="content">
-            This is a banner
+            Vær tålmodig mens vi oppdaterer maskinen
         </div>
         <alpha-button id="button ${bannerElement.id}" slot="action" appearance="lightweight">Close Banner</alpha-button>
     `;
@@ -178,15 +176,15 @@ createBanner(){
 
 In this example, the following commands used are:
 
-- `document.createElement('alpha-banner')`: Creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
-- `bannerElement.id`: Sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
-- `bannerElement.innerHTML`: Sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
-- `this.shadowRoot.getElementById('BannerPlaceholder')`: Retrieves the placeholder `<div>` for the banner. We use `shadowRoot` instead of `document` because the web component utilizes shadow DOM.
-- `placeholderDiv.appendChild(bannerElement)`: Appends the newly created banner to the placeholder `<div>`.
-- `as Banner`: You must specify the type as `Banner`, or else you won't be able to access the banner's methods.
+- `document.createElement('alpha-banner')` creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
+- `bannerElement.id` sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
+- `bannerElement.innerHTML` sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
+- `this.shadowRoot.getElementById('BannerPlaceholder')` retrieves the placeholder `<div>` for the banner; we use `shadowRoot` instead of `document` because the web component uses shadow DOM.
+- `placeholderDiv.appendChild(bannerElement)` appends the newly created banner to the placeholder `<div>`.
+- `as Banner` specifies the type as `Banner`, if you don't do this, you won't be able to access the banner's methods.
 - `actionButton.addEventListener('click', function() {tempBanner.dismiss()});`: Adds a `@click` event to the button inside the banner.
 
-Now, you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder we defined.
+Now you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder that you defined.
 
 :::warning
 Creating components dynamically is a valuable technique, but it's crucial to exercise caution when defining the `id`. Failing to do so may result in multiple components sharing the same `id`, potentially leading to a malfunctioning application.
@@ -197,7 +195,7 @@ Creating components dynamically is a valuable technique, but it's crucial to exe
 ```jsx live
 <alpha-banner>
   <div slot="content">
-    This is a banner
+    Dette er et banner
   </div>
   <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
   <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>

--- a/docs/04_web/02_web-components/04_presentation/03_banner.md
+++ b/docs/04_web/02_web-components/04_presentation/03_banner.md
@@ -122,8 +122,9 @@ From this point, when you click on the **Close banner** button, the banner will 
 
 ### Interaction: create a banner dynamically
 
-If you create the banner in your file, it will be displayed automatically. However, Normally, you often need to display a banner subject to certain conditions. 
-Here is an example of how to create this component dynamically so that it is only displayed in specific circumstances:
+If you simply create the banner in your file, it will be displayed automatically in the application. However, you often need to display a banner only when certain conditions apply. 
+
+Here is an example of a banner that is not displayed automatically; it is created dynamically and displayed only when you call the function `createBanner()`:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
@@ -178,16 +179,16 @@ In this example, the following commands used are:
 
 - `document.createElement('alpha-banner')` creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
 - `bannerElement.id` sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
-- `bannerElement.innerHTML` sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
+- `bannerElement.innerHTML` sets the HTML content and actions of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
 - `this.shadowRoot.getElementById('BannerPlaceholder')` retrieves the placeholder `<div>` for the banner; we use `shadowRoot` instead of `document` because the web component uses shadow DOM.
 - `placeholderDiv.appendChild(bannerElement)` appends the newly created banner to the placeholder `<div>`.
 - `as Banner` specifies the type as `Banner`, if you don't do this, you won't be able to access the banner's methods.
-- `actionButton.addEventListener('click', function() {tempBanner.dismiss()});`: Adds a `@click` event to the button inside the banner.
+- `actionButton.addEventListener('click', function() {tempBanner.dismiss()});` adds a `@click` event to the button inside the banner.
 
 Now you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder that you defined.
 
 :::warning
-Creating components dynamically is a valuable technique, but it's crucial to exercise caution when defining the `id`. Failing to do so may result in multiple components sharing the same `id`, potentially leading to a malfunctioning application.
+When creating a banner dynamically, make sure that your 'id's are unique. If they are not, you will be unable to dismiss one or more of your banners.
 :::
 
 ## Try yourself

--- a/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
@@ -4,9 +4,9 @@ sidebar_label: 'Banner'
 id: banner
 keywords: [web, web components, banner]
 tags:
-    - web
-    - web components
-    - banner
+  - web
+  - web components
+  - banner
 ---
 
 `foundation-banner` extends `foundation-element`.
@@ -24,7 +24,121 @@ provideDesignSystem().register(alphaBanner());
 provideDesignSystem().register(alphaButton());
 ```
 
+## Methods
+
+When you use an `<alpha-banner>`, you can use the following method:
+
+| Name    | Description          |
+|---------|----------------------|
+| dismiss | Dismisses the banner |
+
+## Slots
+
+When you use an `<alpha-banner` you can use the following slots
+
+| Name    | Description                                                                   |
+|---------|-------------------------------------------------------------------------------|
+| content | The content to be displayed on the left side of the component                 |
+| action  | Defined the action components to be placed on the right side of the component |
+
 ## Usage
+
+All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
+
+- **Example 1**: A banner with no action buttons with a content slot
+```html title="Example 1"
+<alpha-banner>
+    <div slot="content">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+    </div>
+</alpha-banner>
+```
+- **Example 2**: a banner with two action buttons and a content slot
+```html title="Example 2"
+<alpha-banner>
+    <div slot="content">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+    </div>
+    <alpha-button slot="action" appearance="lightweight">Ignore</alpha-button>
+    <alpha-button slot="action" appearance="lightweight">Diagnose</alpha-button>
+</alpha-banner>
+```
+
+### Interaction
+
+#### Dismiss a banner
+When you place a banner, you can use the method `dismiss` to remove the banner. Bellow you see how to use this method
+
+1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { alphaBanner } from '@genesislcap/alpha-design-system';
+```
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+After that, you need to define the local variable to be referred to, in this case `localBanner`:
+
+```js {3}
+export class TEMPLATE extends FASTElement {
+    ...
+    localBanner: alphaBanner;
+    ...
+}
+```
+2. Create a function `dismissBanner()` into the class of the component:
+
+```js {1,5}
+export class TEMPLATE extends FASTElement {
+    ...
+    dismissBanner(){
+        this.localBanner.dismiss();
+    }
+    ...
+}
+```
+
+3. Create an action slot to dismiss the banner with a button:
+
+```html tile="Example 4" {1,4}
+<alpha-banner ${ref('localBanner)}>
+    <div slot="content">
+        This is a banner
+    </div>
+    <alpha-button slot="action" appearance="lightweight" @click=${(x) => x.dismissBanner()}>Close banner</alpha-button>
+</alpha-banner>
+```
+
+From this point, if you click no the button **Close banner**, the banner will be removed with a transition.
+
+#### Create a banner
+Normally you would prefer to choose when your banner appears to your user. But if you create the Banner, it will automatically
+show up in your application. In that case, here is an example of how to create this component to appear whenever you wish:
+
+
+1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
+
+``` typescript
+import { alphaBanner } from '@genesislcap/alpha-design-system';
+```
+:::note
+If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
+:::
+
+After that, you need to define the local variable to be referred to, in this case `localBanner`:
+
+```js {3}
+export class TEMPLATE extends FASTElement {
+    ...
+    localBanner: alphaBanner;
+    ...
+}
+```
+
+3. Create a ``
+
+## Try yourself
 
 ```jsx live
 <alpha-banner id="js-banner">

--- a/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
@@ -13,7 +13,7 @@ tags:
 
 The `banner` displays an important, succinct message, such as actions for users to address. It requires a user action to be dismissed.
 
-Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, allowing the user to ignore them or to interact with them at any time. Only one banner should be shown at a time.
+Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, allowing the user to ignore them or to interact with them at any time.
 
 ## Set-up
 
@@ -34,46 +34,55 @@ When you use an `<alpha-banner>`, you can use the following method:
 
 ## Slots
 
-When you use an `<alpha-banner` you can use the following slots
+When you use an `<alpha-banner>` you can use the following slots
 
 | Name    | Description                                                                   |
 |---------|-------------------------------------------------------------------------------|
 | content | The content to be displayed on the left side of the component                 |
 | action  | Defined the action components to be placed on the right side of the component |
 
+:::note
+Multiple content/action slots will be placed side by side.
+:::
+
 ## Usage
 
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
 - **Example 1**: A banner with no action buttons with a content slot
+
 ```html title="Example 1"
 <alpha-banner>
     <div slot="content">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+        This is a banner
     </div>
 </alpha-banner>
 ```
+
 - **Example 2**: a banner with two action buttons and a content slot
+
 ```html title="Example 2"
 <alpha-banner>
     <div slot="content">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+        This is a banner
     </div>
-    <alpha-button slot="action" appearance="lightweight">Ignore</alpha-button>
-    <alpha-button slot="action" appearance="lightweight">Diagnose</alpha-button>
+    <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
+    <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>
 </alpha-banner>
 ```
 
 ### Interaction
 
 #### Dismiss a banner
-When you place a banner, you can use the method `dismiss` to remove the banner. Bellow you see how to use this method
+
+When you place a banner, you can use the method `dismiss()` to remove the banner. Below you see how to use this method:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
 ``` typescript
 import { alphaBanner } from '@genesislcap/alpha-design-system';
 ```
+
 :::note
 If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
 :::
@@ -87,6 +96,7 @@ export class TEMPLATE extends FASTElement {
     ...
 }
 ```
+
 2. Create a function `dismissBanner()` into the class of the component:
 
 ```js {1,5}
@@ -110,48 +120,92 @@ export class TEMPLATE extends FASTElement {
 </alpha-banner>
 ```
 
-From this point, if you click no the button **Close banner**, the banner will be removed with a transition.
+From this point, when you click on the **Close banner** button, the banner will be smoothly removed with a transition.
 
-#### Create a banner
-Normally you would prefer to choose when your banner appears to your user. But if you create the Banner, it will automatically
-show up in your application. In that case, here is an example of how to create this component to appear whenever you wish:
+#### Create a banner dynamically
 
+Normally you would prefer to choose when your banner appears to your user. But if you create the banner in your file, it will automatically
+show up in your application. In that case, here is an example of how to create this component dynamically so it appears whenever you set to:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
 ``` typescript
 import { alphaBanner } from '@genesislcap/alpha-design-system';
 ```
+
 :::note
 If you are using `foundation-zero`, then you need to import using `@genesislcap/foundation-zero`
 :::
 
-After that, you need to define the local variable to be referred to, in this case `localBanner`:
+2. In your template file, create a `<div>` placeholder where you want the banner to appear:
 
-```js {3}
-export class TEMPLATE extends FASTElement {
-    ...
-    localBanner: alphaBanner;
-    ...
+``` typescript
+<div id="BannerPlaceholder"></div>
+```
+
+3. Create the function to create your banner dynamically:
+
+``` typescript
+createBanner(){
+
+    // Creates the banner element
+    const bannerElement = document.createElement('alpha-banner');
+    bannerElement.id = 'bannerId';
+
+    // Sets the HTML content of the banner element
+    bannerElement.innerHTML = `
+        <div slot="content">
+            This is a banner
+        </div>
+        <alpha-button id="button ${bannerElement.id}" slot="action" appearance="lightweight">Close Banner</alpha-button>
+    `;
+
+    // Gets the placeholder div where you want to append the banner
+    const placeholderDiv = this.shadowRoot.getElementById('BannerPlaceholder');
+
+    // Appends the banner element to the div
+    placeholderDiv.appendChild(bannerElement)
+
+    // Adds dismiss event to the button action
+    const actionButton = this.shadowRoot.getElementById("button " + bannerElement.id);
+    const tempBanner = this.shadowRoot.getElementById(bannerElement.id) as alphaBanner
+    
+    actionButton.addEventListener('click', function() {
+        tempBanner.dismiss();
+    });
 }
 ```
 
-3. Create a ``
+In this example, the following commands used are:
+
+- `document.createElement('alpha-banner')`: Creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
+- `bannerElement.id`: Sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
+- `bannerElement.innerHTML`: Sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
+- `this.shadowRoot.getElementById('BannerPlaceholder')`: Retrieves the placeholder `<div>` for the banner. We use `shadowRoot` instead of `document` because the web component utilizes shadow DOM.
+- `placeholderDiv.appendChild(bannerElement)`: Appends the newly created banner to the placeholder `<div>`.
+- `as Banner`: You must specify the type as `Banner`, or else you won't be able to access the banner's methods.
+- `actionButton.addEventListener('click', function() {tempBanner.dismiss()});`: Adds a `@click` event to the button inside the banner.
+
+Now, you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder we defined.
+
+:::warning
+Creating components dynamically is a valuable technique, but it's crucial to exercise caution when defining the `id`. Failing to do so may result in multiple components sharing the same `id`, potentially leading to a malfunctioning application.
+:::
 
 ## Try yourself
 
 ```jsx live
-<alpha-banner id="js-banner">
+<alpha-banner>
   <div slot="content">
-    Lorem ipsum dolor sit amet consectetur adipisicing elit. Lorem ipsum dolor sit amet. Lorem, ipsum dolor.
+    This is a banner
   </div>
-  <alpha-button slot="action" appearance="lightweight" style={{marginRight: '5px'}}>Ignore</alpha-button>
-  <alpha-button slot="action" appearance="lightweight">Diagnose</alpha-button>
+  <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
+  <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>
 </alpha-banner>
 ```
 
 ## Use cases
 
-* warning notifications
-* advertisement
-* displaying a logo
+- warning notifications
+- advertisement
+- displaying a logo

--- a/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
@@ -11,9 +11,9 @@ tags:
 
 `foundation-banner` extends `foundation-element`.
 
-The `banner` displays an important, succinct message, such as actions for users to address. It requires a user action to be dismissed.
+The `banner` displays an important, succinct message, such as actions for users to address. It remains displayed until it is dismissed by the user.
 
-Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, allowing the user to ignore them or to interact with them at any time.
+Banners should be displayed at the top of the screen, below a top app bar. They’re persistent and nonmodal, so the user can either ignore the banner or interact with it at any time.
 
 ## Set-up
 
@@ -34,48 +34,46 @@ When you use an `<alpha-banner>`, you can use the following method:
 
 ## Slots
 
-When you use an `<alpha-banner>` you can use the following slots
+When you use an `<alpha-banner>` you can use the following slots to define content and actions:
 
 | Name    | Description                                                                   |
 |---------|-------------------------------------------------------------------------------|
 | content | The content to be displayed on the left side of the component                 |
-| action  | Defined the action components to be placed on the right side of the component |
+| action  | Defines the action components to be placed on the right side of the component |
 
 :::note
-Multiple content/action slots will be placed side by side.
+If you create multiple slots of content or actions, the slots will be placed side by side.
 :::
 
 ## Usage
 
 All examples below use the `alpha-design-system`. If you are using any other design system, change the declaration of this component accordingly.
 
-- **Example 1**: A banner with no action buttons with a content slot
+- **Example 1**: A banner with a content slot and no action buttons 
 
 ```html title="Example 1"
 <alpha-banner>
     <div slot="content">
-        This is a banner
+        This is a banner that the user cannot remove
     </div>
 </alpha-banner>
 ```
 
-- **Example 2**: a banner with two action buttons and a content slot
+- **Example 2**: a banner with two action buttons and a message
 
 ```html title="Example 2"
 <alpha-banner>
     <div slot="content">
-        This is a banner
+        Båten min er ikke lenger sjødyktig
     </div>
     <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
     <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>
 </alpha-banner>
 ```
 
-### Interaction
+### Interaction: dismiss a banner
 
-#### Dismiss a banner
-
-When you place a banner, you can use the method `dismiss()` to remove the banner. Below you see how to use this method:
+When you place a banner, you can use the method `dismiss()` to remove the banner. here is an example of how to use this method:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
@@ -97,7 +95,7 @@ export class TEMPLATE extends FASTElement {
 }
 ```
 
-2. Create a function `dismissBanner()` into the class of the component:
+2. Create a function `dismissBanner()` in the class of the component:
 
 ```js {1,5}
 export class TEMPLATE extends FASTElement {
@@ -120,12 +118,12 @@ export class TEMPLATE extends FASTElement {
 </alpha-banner>
 ```
 
-From this point, when you click on the **Close banner** button, the banner will be smoothly removed with a transition.
+From this point, when you click on the **Close banner** button, the banner will be removed with a smooth transition.
 
-#### Create a banner dynamically
+### Interaction: create a banner dynamically
 
-Normally you would prefer to choose when your banner appears to your user. But if you create the banner in your file, it will automatically
-show up in your application. In that case, here is an example of how to create this component dynamically so it appears whenever you set to:
+If you create the banner in your file, it will be displayed automatically. However, Normally, you often need to display a banner subject to certain conditions. 
+Here is an example of how to create this component dynamically so that it is only displayed in specific circumstances:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
@@ -155,7 +153,7 @@ createBanner(){
     // Sets the HTML content of the banner element
     bannerElement.innerHTML = `
         <div slot="content">
-            This is a banner
+            Vær tålmodig mens vi oppdaterer maskinen
         </div>
         <alpha-button id="button ${bannerElement.id}" slot="action" appearance="lightweight">Close Banner</alpha-button>
     `;
@@ -178,15 +176,15 @@ createBanner(){
 
 In this example, the following commands used are:
 
-- `document.createElement('alpha-banner')`: Creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
-- `bannerElement.id`: Sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
-- `bannerElement.innerHTML`: Sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
-- `this.shadowRoot.getElementById('BannerPlaceholder')`: Retrieves the placeholder `<div>` for the banner. We use `shadowRoot` instead of `document` because the web component utilizes shadow DOM.
-- `placeholderDiv.appendChild(bannerElement)`: Appends the newly created banner to the placeholder `<div>`.
-- `as Banner`: You must specify the type as `Banner`, or else you won't be able to access the banner's methods.
+- `document.createElement('alpha-banner')` creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
+- `bannerElement.id` sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
+- `bannerElement.innerHTML` sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
+- `this.shadowRoot.getElementById('BannerPlaceholder')` retrieves the placeholder `<div>` for the banner; we use `shadowRoot` instead of `document` because the web component uses shadow DOM.
+- `placeholderDiv.appendChild(bannerElement)` appends the newly created banner to the placeholder `<div>`.
+- `as Banner` specifies the type as `Banner`, if you don't do this, you won't be able to access the banner's methods.
 - `actionButton.addEventListener('click', function() {tempBanner.dismiss()});`: Adds a `@click` event to the button inside the banner.
 
-Now, you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder we defined.
+Now you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder that you defined.
 
 :::warning
 Creating components dynamically is a valuable technique, but it's crucial to exercise caution when defining the `id`. Failing to do so may result in multiple components sharing the same `id`, potentially leading to a malfunctioning application.
@@ -197,7 +195,7 @@ Creating components dynamically is a valuable technique, but it's crucial to exe
 ```jsx live
 <alpha-banner>
   <div slot="content">
-    This is a banner
+    Dette er et banner
   </div>
   <alpha-button slot="action" appearance="lightweight">Button 1</alpha-button>
   <alpha-button slot="action" appearance="lightweight">Button 2</alpha-button>

--- a/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/04_presentation/03_banner.md
@@ -122,8 +122,9 @@ From this point, when you click on the **Close banner** button, the banner will 
 
 ### Interaction: create a banner dynamically
 
-If you create the banner in your file, it will be displayed automatically. However, Normally, you often need to display a banner subject to certain conditions. 
-Here is an example of how to create this component dynamically so that it is only displayed in specific circumstances:
+If you simply create the banner in your file, it will be displayed automatically in the application. However, you often need to display a banner only when certain conditions apply. 
+
+Here is an example of a banner that is not displayed automatically; it is created dynamically and displayed only when you call the function `createBanner()`:
 
 1. Import the `alphaBanner` from `@genesislcap/alpha-design-system`:
 
@@ -178,16 +179,16 @@ In this example, the following commands used are:
 
 - `document.createElement('alpha-banner')` creates an `alpha-banner` HTMLElement and stores it in the bannerElement variable.
 - `bannerElement.id` sets the ID for the component. Note that if you intend to create multiple banners, you should change their IDs dynamically.
-- `bannerElement.innerHTML` sets the HTML content of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
+- `bannerElement.innerHTML` sets the HTML content and actions of the component, defining what is wrapped within `<alpha-banner></alpha-banner>`.
 - `this.shadowRoot.getElementById('BannerPlaceholder')` retrieves the placeholder `<div>` for the banner; we use `shadowRoot` instead of `document` because the web component uses shadow DOM.
 - `placeholderDiv.appendChild(bannerElement)` appends the newly created banner to the placeholder `<div>`.
 - `as Banner` specifies the type as `Banner`, if you don't do this, you won't be able to access the banner's methods.
-- `actionButton.addEventListener('click', function() {tempBanner.dismiss()});`: Adds a `@click` event to the button inside the banner.
+- `actionButton.addEventListener('click', function() {tempBanner.dismiss()});` adds a `@click` event to the button inside the banner.
 
 Now you can use the `createBanner()` function whenever you need to create a new banner in the `<div>` placeholder that you defined.
 
 :::warning
-Creating components dynamically is a valuable technique, but it's crucial to exercise caution when defining the `id`. Failing to do so may result in multiple components sharing the same `id`, potentially leading to a malfunctioning application.
+When creating a banner dynamically, make sure that your 'id's are unique. If they are not, you will be unable to dismiss one or more of your banners.
 :::
 
 ## Try yourself


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PTL-942

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Docs and 2023.1

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
I added section on how to create a banner dynamically. It is not actually part of the Banner documentation itself, but I think it is extremely important considering why people use banner. Happy to discuss if it is considered too much. 

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

