### PR TITLE
Update 10_tab.md

### DIFF
--- a/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
+++ b/versioned_docs/version-2023.1/04_web/02_web-components/03_interaction/10_tab.md
@@ -47,6 +47,10 @@ For each tab, you must also declare an `alpha-tab-panel`. This is the component 
 |------|----------|------------------------------------------|
 | id   | `string` | Links the panel to its corresponding tab |
 
+:::note
+The `alpha-tab-panel` is linked to its corresponting `alpha-tab` based on the order. So it will be linked the first `alpha-tab` with the first `alpha-tab-panel`, the second `alpha-tab` with the second `alpha-tab-panel` and so on. 
+:::
+
 ### Event
 
 These are the available events you can use:


### PR DESCRIPTION
add a comment about the linking order of tabs and tab-panels

Thank you for contributing to the documentation.

Your Jira ticket is:
P********

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

