### PR TITLE
fix: Correct location for ADMIN_PERMISSION keys so all required DAOs are properly generated in case of running codegen with gradle

### DIFF
--- a/docs/01_getting-started/06_developer-training/05_training-content-day5.md
+++ b/docs/01_getting-started/06_developer-training/05_training-content-day5.md
@@ -243,7 +243,7 @@ Starting with the server, set up the USER and USER_ATTRIBUTES records for the sy
 If you are not sure how to read and write information from the Genesis database, see reference page covering the [`DbMon`](../../../operations/commands/server-commands/#dbmon-script) and [`SendIt`](../../../operations/commands/server-commands/#sendit-script) commands.
 :::
 
-Set two new key values in **site-specific/cfg/genesis-system-definition.kts** file in systemDefinition-global block This enables the COUNTERPARTY table and COUNTERPARTY_ID field to become part of the generic permissions system:
+Set two new key values in **alpha-config/src/main/resources/cfg/alpha-system-definition.kts** file in systemDefinition-global block This enables the COUNTERPARTY table and COUNTERPARTY_ID field to become part of the generic permissions system:
 
 ```kotlin {6,7}
 package genesis.cfg

--- a/docs/03_server/05_access-control/08_authorisation-overview.md
+++ b/docs/03_server/05_access-control/08_authorisation-overview.md
@@ -176,7 +176,7 @@ All `customPermissions` functions give you access to a property called `entityDb
 
 Generic permissions is a term used to name the optional permissions configuration that is available for a Genesis application; this is included as part of the Genesis Auth Module.
 
-To fully activate Generic permissions, you need to add the following values to your [system definition file](../../../server/configuring-runtime/system-definitions/) before you run `genesisInstall`.
+To fully activate Generic permissions, you need to add the following values to your product [system definition file](../../../server/configuring-runtime/system-definitions/) locate under the `config` project (for example `alpha-system-definition.kts`) before you run `genesisInstall`.
 
 These values specify which table column will be used to associate users with entities for fine-grained row permissions.
 


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PLAT-942

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
No - only the latest (current applicable for V6.7+)

Have you checked all new or changed links?
N/A

Is there anything else you would like us to know?
N/A see details in the ticket

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

