### PR TITLE
feat: Update docs to reflect the fact that generated repositories are not generated by default since version 7.0.0 (PDOC-492)

### DIFF
--- a/docs/02_database/05_database-interface/02_generated-repositories.md
+++ b/docs/02_database/05_database-interface/02_generated-repositories.md
@@ -10,7 +10,15 @@ tags:
     - repositories
 ---
 
+:::warning
+IMPORTANT! Code generation for database repositories is now disabled by default since GSF version 7.0.0. To re-enable code generation the **generateRepositories** setting needs to be enabled inside the *build.gradle.kts* files pertaining to the *genesis-generated-dao* and *genesis-generated-view* modules as show below:
 
+```{kotlin}
+codeGen {
+    generateRepositories = true
+}
+```
+:::
 
 During the code generation phase, repository classes are generated for every table and view in the system. These repositories provide a type-safe way of accessing the database.
 

--- a/docs/02_database/05_database-interface/02_generated-repositories.md
+++ b/docs/02_database/05_database-interface/02_generated-repositories.md
@@ -11,7 +11,7 @@ tags:
 ---
 
 :::warning
-IMPORTANT! Code generation for database repositories is now disabled by default since GSF version 7.0.0. To re-enable code generation the **generateRepositories** setting needs to be enabled inside the *build.gradle.kts* files pertaining to the *genesis-generated-dao* and *genesis-generated-view* modules as show below:
+IMPORTANT! From GSF version 7.0.0 onwards, code generation for database repositories is disabled by default. To re-enable code generation, change the **generateRepositories** setting inside the **build.gradle.kts** files for the **genesis-generated-dao** and **genesis-generated-view** modules, as shown below:
 
 ```{kotlin}
 codeGen {


### PR DESCRIPTION
Thank you for contributing to the documentation.

Your Jira ticket is:
PDOC-492

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
No, we don't do this anymore.

Have you checked all new or changed links?
There are no new links.

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

