### PR TITLE
feat: update dataserver docs to explain new settings available in 7.0.0: Fury serializer, off heap buffer support and direct buffer size settings. (PDOC-502)

### DIFF
--- a/docs/03_server/02_data-server/02_basics.md
+++ b/docs/03_server/02_data-server/02_basics.md
@@ -168,10 +168,10 @@ lmdbAllocateSize = 512.MEGA_BYTE()
 
 `serializationType` (available from GSF version 7.0.0)
 
-This sets the serialization approach used to convert query rows into bytes and viceversa. There are two options available: SerializationType.KRYO and SerializationType.FURY
+This sets the serialization approach used to convert query rows into bytes and vice versa. There are two options available: SerializationType.KRYO and SerializationType.FURY
 
 * The KRYO option is the default setting if `serializationType` is left undefined. It uses the [Kryo library](https://github.com/EsotericSoftware/kryo).
-* The FURY option uses the [Fury library](https://github.com/alipay/fury) instead. Internal tests show that Fury can serialize and deserialize row objects 13-15x quicker than Kryo in our current dataserver implementation, which leads to faster LMDB read/write operations (i.e. up to 2x in some cases). This performance improvement has a great impact on the latency incurred when requesting rows from a dataserver query, whether this happens as part of the first subscription message (i.e. DATA_LOGON messages) or subsequent row request messages (i.e. MORE_ROWS messages). Unfortunately, the serialized byte array size of a Fury object can be 10-15% larger than a Kryo object, so there is a small penalty to pay for using this option.
+* The FURY option uses the [Fury library](https://github.com/alipay/fury) instead. Internal tests show that Fury can serialize and deserialize row objects 13-15 times more quickly  than Kryo in our current Data Server implementation; this leads to faster LMDB read/write operations (up to twice as quick in some cases). This performance improvement has a great impact on the latency incurred when requesting rows from a Data Server query, whether this happens as part of the first subscription message (DATA_LOGON messages) or subsequent row request messages (MORE_ROWS messages). However, the serialized byte array size of a Fury object can be between 10 to 15% larger than a Kryo object, so there is a small penalty to pay for using this option.
 
 `serializationBufferMode` (available from GSF version 7.0.0)
 

--- a/docs/03_server/02_data-server/02_basics.md
+++ b/docs/03_server/02_data-server/02_basics.md
@@ -178,7 +178,7 @@ This sets the serialization approach used to convert query rows into bytes and v
 This option changes the buffer type used to read/write information from/to LMDB. There are two options available: SerializationBufferMode.ON_HEAP and SerializationBufferMode.OFF_HEAP.
 
 * The ON_HEAP option is the default setting if `serializationBufferMode` is left undefined. It uses a custom cache of Java HeapByteBuffer objects that exist within the JVM addressable space.
-* The OFF_HEAP option uses DirectByteBuffer objects instead, so memory can be addressed directly to access LMDB buffers natively in order to write and read data. OFF_HEAP buffers permit zero-copy serialization/deserialization to LMDB, and these type of buffers are generally more efficient as they allow Java to exchange bytes directly with the operating system for I/O operations. OFF_HEAP buffer support in its current implementation requires the buffer size to be specified ahead of time (i.e. see `directBufferSize` setting), which could be problematic problems if the serialized query row object size is not known ahead of time.
+* The OFF_HEAP option uses DirectByteBuffer objects instead, so memory can be addressed directly to access LMDB buffers natively in order to write and read data. OFF_HEAP buffers permit zero-copy serialization/deserialization to LMDB; buffers of this type are generally more efficient as they allow Java to exchange bytes directly with the operating system for I/O operations. To use OFF_HEAP, you **must** specify the buffer size in advance (see `directBufferSize` setting); consider this carefully if you do not know the size of the serialized query row object in advance.
 
 `directBufferSize`
 

--- a/docs/03_server/02_data-server/02_basics.md
+++ b/docs/03_server/02_data-server/02_basics.md
@@ -168,14 +168,14 @@ lmdbAllocateSize = 512.MEGA_BYTE()
 
 `serializationType` (available from GSF version 7.0.0)
 
-This sets the serialization approach used to convert query rows into bytes and vice versa. There are two options available: SerializationType.KRYO and SerializationType.FURY
+This sets the serialization approach used to convert query rows into bytes and vice versa. There are two options: SerializationType.KRYO and SerializationType.FURY
 
 * The KRYO option is the default setting if `serializationType` is left undefined. It uses the [Kryo library](https://github.com/EsotericSoftware/kryo).
-* The FURY option uses the [Fury library](https://github.com/alipay/fury) instead. Internal tests show that Fury can serialize and deserialize row objects 13-15 times more quickly  than Kryo in our current Data Server implementation; this leads to faster LMDB read/write operations (up to twice as quick in some cases). This performance improvement has a great impact on the latency incurred when requesting rows from a Data Server query, whether this happens as part of the first subscription message (DATA_LOGON messages) or subsequent row request messages (MORE_ROWS messages). However, the serialized byte array size of a Fury object can be between 10 to 15% larger than a Kryo object, so there is a small penalty to pay for using this option.
+* The FURY option uses the [Fury library](https://github.com/alipay/fury) instead. Internal tests show that Fury can serialize and deserialize row objects 13-15 times more quickly than Kryo in our current Data Server implementation; this leads to faster LMDB read/write operations (up to twice as quick in some cases). This performance improvement has a great impact on the latency incurred when requesting rows from a Data Server query, whether it happens as part of the first subscription message (DATA_LOGON messages) or subsequent row request messages (MORE_ROWS messages). However, the serialized byte array size of a Fury object can be between 10 and 15 per cent larger than a Kryo object, so there is a small penalty to pay for using this option.
 
 `serializationBufferMode` (available from GSF version 7.0.0)
 
-This option changes the buffer type used to read/write information from/to LMDB. There are two options available: SerializationBufferMode.ON_HEAP and SerializationBufferMode.OFF_HEAP.
+This option changes the buffer type used to read/write information from/to LMDB. There are two options: SerializationBufferMode.ON_HEAP and SerializationBufferMode.OFF_HEAP.
 
 * The ON_HEAP option is the default setting if `serializationBufferMode` is left undefined. It uses a custom cache of Java HeapByteBuffer objects that exist within the JVM addressable space.
 * The OFF_HEAP option uses DirectByteBuffer objects instead, so memory can be addressed directly to access LMDB buffers natively in order to write and read data. OFF_HEAP buffers permit zero-copy serialization/deserialization to LMDB; buffers of this type are generally more efficient as they allow Java to exchange bytes directly with the operating system for I/O operations. To use OFF_HEAP, you **must** specify the buffer size in advance (see `directBufferSize` setting); consider this carefully if you do not know the size of the serialized query row object in advance.


### PR DESCRIPTION

Thank you for contributing to the documentation.

Your Jira ticket is:
PDOC-502

Have you provided changes for all the relevant versions: next, 2022.4, 2023.1, etc?
Not in use anymore.

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

- if you are an internal contributor:
  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 
- If you are an external contributor:
  - We have an [external contribution guide](../Type-of-contribution)

**This week's exciting excerpt from the style guide**
LISTS. Only use numbered lists when the sequence is important. Usually, that is a set of instructions.
For example:
1. Change the dictionary files.
2. Run genesisInstall.
3. Run remap.
In all other cases, use an **unnumbered** list. OK?  

