### PR TITLE
Improve process sysdef override example

### DIFF
--- a/docs/03_server/01_configuring-runtime/06_cache.md
+++ b/docs/03_server/01_configuring-runtime/06_cache.md
@@ -60,6 +60,9 @@ Choosing the right index definition is paramount to improving view query perform
     	</cacheConfig>
 ```
 ### GPAL example
+The example below shows the GPAL **process-config** being used to override system-definition values on a per microservice basis. Any process that uses this config is given a bigger Db connection pool size.
+
+
 ```kotlin
     import java.util.concurrent.TimeUnit
     
@@ -86,8 +89,6 @@ Choosing the right index definition is paramount to improving view query perform
         }
     }
 ```
-
-As the example above shows, the GPAL **process-config** file can override system definition values on a per microservice basis as well. For example in this example we can give the process(es) using this config a bigger Db connection pool size.
 
 ### GPAL processes.xml example
 ```xml

--- a/docs/03_server/01_configuring-runtime/06_cache.md
+++ b/docs/03_server/01_configuring-runtime/06_cache.md
@@ -66,8 +66,7 @@ Choosing the right index definition is paramount to improving view query perform
     process {
     
         systemDefinition {
-            item(name = "DbHost", value = "localhost")
-            item(name = "ClusterPort", value = "5678")
+            item(name = "DbSqlConnectionPoolSize", value = 50)
         }
     
         cacheConfig {
@@ -88,7 +87,7 @@ Choosing the right index definition is paramount to improving view query perform
     }
 ```
 
-As the example above shows, the GPAL **process-config** file can override system definition values on a per microservice basis as well.
+As the example above shows, the GPAL **process-config** file can override system definition values on a per microservice basis as well. For example in this example we can give the process(es) using this config a bigger Db connection pool size.
 
 ### GPAL processes.xml example
 ```xml

--- a/docs/03_server/01_configuring-runtime/06_cache.md
+++ b/docs/03_server/01_configuring-runtime/06_cache.md
@@ -60,8 +60,7 @@ Choosing the right index definition is paramount to improving view query perform
     	</cacheConfig>
 ```
 ### GPAL example
-The example below shows the GPAL **process-config** being used to override system-definition values on a per microservice basis. Any process that uses this config is given a bigger Db connection pool size.
-
+As well as making specific cache settings, the example below shows the GPAL **process-config** being used to override system-definition values on a per microservice basis. Any process that uses this config is given a bigger Db connection pool size (50).
 
 ```kotlin
     import java.util.concurrent.TimeUnit

--- a/versioned_docs/version-previous/03_server/01_configuring-runtime/06_cache.md
+++ b/versioned_docs/version-previous/03_server/01_configuring-runtime/06_cache.md
@@ -60,14 +60,15 @@ Choosing the right index definition is paramount to improving view query perform
     	</cacheConfig>
 ```
 ### GPAL example
+As well as making specific cache settings, the example below shows the GPAL **process-config** being used to override system-definition values on a per microservice basis. Any process that uses this config is given a bigger Db connection pool size (50).
+
 ```kotlin
     import java.util.concurrent.TimeUnit
     
     process {
     
         systemDefinition {
-            item(name = "DbHost", value = "localhost")
-            item(name = "ClusterPort", value = "5678")
+            item(name = "DbSqlConnectionPoolSize", value = 50)
         }
     
         cacheConfig {
@@ -87,8 +88,6 @@ Choosing the right index definition is paramount to improving view query perform
         }
     }
 ```
-
-As the example above shows, the GPAL **process-config** file can override system definition values on a per microservice basis as well.
 
 ### GPAL processes.xml example
 ```xml


### PR DESCRIPTION
Giving a better example of overriding sysdef items and some clarity. Pre-existing example was fairly nonsensical (overriding a ClusterPort?)

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
