### PR TITLE
Add example for password reset configuration in docs

### DIFF
--- a/docs/03_server/05_access-control/03_password_authentication.md
+++ b/docs/03_server/05_access-control/03_password_authentication.md
@@ -165,6 +165,19 @@ Both the subject and the body support templating. Values surrounded by double cu
 * `USER` the user record, properties on this record should be accessed using lowerCamelCase, e.g. `{{ USER.firstName }}`
 * any system definition or environment variable available
 
+example: 
+```kotlin
+authentication {
+    genesisPassword {
+        selfServiceReset {
+            timeoutInMinutes = 20
+            notifyTopic = "smtpEmail"
+            redirectUrl = "https://genesis.global/login/password-reset"
+        }
+    }
+}
+```
+
 ### mfa
 The `mfa` function enables you to configure [Multi-factor Authentication (MFA)](https://en.wikipedia.org/wiki/Multi-factor_authentication). From within the `mfa` function, you can choose between different implementations of MFA providers.
 


### PR DESCRIPTION
An example configuration for self-service password reset has been added under the password authentication section of the access-control server documentation. This gives users a clearer idea on setting timeout, notifyTopic and redirectUrl.

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
