### PR TITLE
PTL-1183 - remove markdown issues causing warning on the build

### DIFF
--- a/docs/04_web/05_micro-front-ends/05_foundation-login/05_foundation-login.mdx
+++ b/docs/04_web/05_micro-front-ends/05_foundation-login/05_foundation-login.mdx
@@ -95,7 +95,7 @@ You may need to set up a `NavigationContributor` in your application's router co
 }
 ```
 
-:::warning
+:::caution
 By default, a route that isn't marked public is not. However, a non-public route isn't automatically going to block non-authenticated users from viewing them. This must be implemented in a `NavigationContributor`; see [example](./docs/api/foundation-login.login.md#example).
 :::
 
@@ -107,18 +107,22 @@ For authentication, most configuration is set in the back end. You should famili
 
 The standard authentication method is the user supplying their username and password. Even when SSO is enabled as an authentication method, the user will still have the option to sign in with their normal credentials.
 
-:::note
-Setting the `DEFAULT_USER` and `DEFAULT_PASSWORD` environment variables automatically populates the credentials in the login form, which can be useful during development so developers don't need to write out their credentials continuously. However, the browser may also offer auto-filling if you have previously chosen to save your credentials, which can make setting these unnecessary.
+:::info
+Setting the `DEFAULT_USER` and `DEFAULT_PASSWORD` environment variables automatically populates the credentials in the login form, which can be useful during development so developers don't need to write out their credentials continuously. 
+
+However, the browser could also offer auto-filling if you have previously chosen to save your credentials, which can make setting these unnecessary.
 :::
 
 ### SSO
 
-SSO functionality allows the `Login` micro front-end to work with your company's existing authentication system, enabling them to have a single set of credentials - including those built on the Genesis low-code platform. Genesis supports SSO with both JWT and SAML.
+SSO enables the `Login` micro front-end to work with your company's existing authentication system, so users can have a single set of credentials - including those built on the Genesis low-code platform. Genesis supports SSO with both JWT and SAML.
 
 Setting up SSO is primarily [a back-end task](docs/03_server/05_access-control/04_sso_jwt.mdx); however, there is a small amount of front-end [sso configuration](docs/api/foundation-login.loginconfig.sso.md) required.
 
-:::note
-The standard process of SSO is that the SSO authentication provider flow is opened via a redirect in the current page. However, many authentication providers block their system when running in an iframe to prevent [clickjacking attacks](https://owasp.org/www-community/attacks/Clickjacking). Because of this, if the `Login` micro front-end detects that it is running in an iframe, it opens up the authentication provider in a popup instead.
+:::info
+In the standard SSO process, the SSO authentication provider flow is opened via a redirect in the current page. However, many authentication providers block their system when running in an iframe to prevent [clickjacking attacks](https://owasp.org/www-community/attacks/Clickjacking). 
+
+To avoid this, if the Login micro front-end detects that it is running in an iframe, it opens up the authentication provider in a popup.
 :::
 
 ## Customising login


### PR DESCRIPTION
Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
No

Have you checked all new or changed links?
Build works

Is there anything else you would like us to know?
This improves text in the boxes and enables me to build without markup warnings

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
