### PR TITLE
Restored LINK in Server Commands

### DIFF
--- a/docs/05_operations/03_commands/01_server-commands.mdx
+++ b/docs/05_operations/03_commands/01_server-commands.mdx
@@ -830,6 +830,7 @@ If you want to commit the changes to the database, you must use the **--commit**
 ```bash
 remap [-c | --commit]
 ```
+For full details, see our page on the [remap](../remap) command. 
 
 ## RenameFields
 This command is used to rename a field name in a database without changing the dictionary or config files.

--- a/docs/05_operations/03_commands/03_remap.mdx
+++ b/docs/05_operations/03_commands/03_remap.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Operations - Remap'
 sidebar_label: 'Remap'
-id: Remap
+id: remap
 keywords: [operations, server, commands, Remap, schema]
 tags:
     - database

--- a/versioned_docs/version-previous/05_operations/02_commands/01_server-commands.md
+++ b/versioned_docs/version-previous/05_operations/02_commands/01_server-commands.md
@@ -829,6 +829,7 @@ If you want to commit the changes to the database, you must use the **--commit**
 ```bash
 remap [-c | --commit]
 ```
+For full details, see our page on the [remap](../remap) command. 
 
 ## RenameFields 
 This command is used to rename a field name in a database without changing the dictionary or config files.

--- a/versioned_docs/version-previous/05_operations/02_commands/03_remap.md
+++ b/versioned_docs/version-previous/05_operations/02_commands/03_remap.md
@@ -1,7 +1,7 @@
 ---
 title: 'Operations - Remap'
 sidebar_label: 'Remap'
-id: Remap
+id: remap
 keywords: [operations, server, commands, Remap, schema]
 tags:
     - database


### PR DESCRIPTION
NO ticket for this. Just the outcome of a short chat with Guilerme, where he has fixed the problem of the link

The page identifier had a cap, which was causing the issue

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
YES

Have you checked all new or changed links?
YES

Is there anything else you would like us to know?
NO

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
