### PR TITLE
update Genesis dao docs to include more information about JVM version

### DIFF
--- a/docs/02_database/01_fields-tables-views/04_genesisdao.mdx
+++ b/docs/02_database/01_fields-tables-views/04_genesisdao.mdx
@@ -63,8 +63,8 @@ bundleGeneratedClasses=true
 
 ### Gradle build errors in project and no gradle commands listed in IntelliJ 
 
-If you don't see any menu options per the guide above, and see gradle errors when you try to build or open a project, a common cause is gradle jvm settings.
+If you don't see any menu options per the guide above, and see gradle errors when you try to build or open a project, a common cause is gradle JVM settings.
 
-In IntelliJ. go to **File** -> **Settings** and search for the Build Gradle page. Make sure Gradle JVM is set to **11**, as shown below:
+In IntelliJ. go to **File** -> **Settings** and search for the Build Gradle page. Make sure Gradle JVM is set to the correct JDK version used by Genesis. If you are using Genesis Server version 7+, it will be **17**, otherwise **11**. See example for setting version **11** below:
 
 ![](/img/gradle-jvm-version.png)


### PR DESCRIPTION
The genesis server framework uses different Java version versions depending on what genesis server framework version you are on. It is misleading to point users to always select Java 11, so I have amended the text.

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
No

Have you checked all new or changed links?
Yes

Is there anything else you would like us to know?
No

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
