### PR TITLE
using SetSequence command instead of SetAutoincrement

### DIFF
--- a/docs/02_database/01_fields-tables-views/02_tables/02_tables-advanced.mdx
+++ b/docs/02_database/01_fields-tables-views/02_tables/02_tables-advanced.mdx
@@ -64,7 +64,7 @@ To switch off UUID generation and use the default Genesis format for `sequence`:
 
 4. If there are existing fields using sequences, run the server command [CreateMissingSqlSequences](../../../../operations/commands/server-commands/#createmissingsqlsequences).
 
-5. If you need to adjust the initial value of the sequences (for example if you are migrating data), use the server command [SetAutoIncrement](../../../../operations/commands/server-commands/#setautoincrement).
+5. If you need to adjust the initial value of the sequences (for example if you are migrating data), use the server command [SetSequence](../../../../operations/commands/server-commands/#setsequence).
 
 ## Subtables
 


### PR DESCRIPTION
As of 7.1 we have integrated `SetSequence` command, which is more intuitive from user's perspective then SetAutoIncrement, technically they will both achieve the same results under SQL context.