### PR TITLE
enable mermaid charts PTL-1280

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,7 @@ const config = {
   trailingSlash: true,
   markdown: {
     format: "detect",
+    mermaid: true,
   },
   onBrokenLinks: "throw", // please do NOT change this to 'warn', fix or remove your broken links instead
   onBrokenMarkdownLinks: "throw", // please do NOT change this to 'warn', fix or remove your broken links instead
@@ -143,7 +144,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     colorMode: {
       disableSwitch: true,
-      defaultMode: 'light',
+      defaultMode: "light",
       respectPrefersColorScheme: false,
     },
     navbar: {


### PR DESCRIPTION
This PR enables mermaid charts again.

<img width="831" alt="image" src="https://github.com/genesiscommunitysuccess/docs/assets/82830570/eb56af33-dbe7-4b11-8d21-0b124a691a23">
