### PR TITLE
Add MacOS instructions for LMDB installation in IntelliJ plugin

### DIFF
--- a/docs/03_server/12_tooling/02_intellij-plugin.mdx
+++ b/docs/03_server/12_tooling/02_intellij-plugin.mdx
@@ -21,6 +21,26 @@ The Genesis Intellij Plugin enables you to run the full stack of a Genesis appli
 
 2. After installing the plugin, make sure you add it so that it is visible on the [Tool window bars and buttons](https://www.jetbrains.com/help/idea/tool-windows.html#bars_and_buttons).
 
+3. For Macos specifically, you will need to install LMDB locally to start a Genesis data server.
+
+### Installing LMDB for Macos
+
+:::info
+This is not required for developers that use Windows locally
+:::
+
+First you will need to install lmdb using `brew`:
+
+```shell
+brew install lmdb
+```
+
+Next, you will need to create a symlink to make LMDB accessible through Java:
+
+```shell
+ln -s /opt/homebrew/opt/lmdb/lib/liblmdb.dylib /Users/<your.username>/Library/Java/Extensions/liblmdb.dylib
+```
+
 :::info
 That's the end of the installation process.
 If you have come here from the Quick Start guide, [you can **go back now**](../../../getting-started/quick-start/hardware-and-software/).


### PR DESCRIPTION
This commit introduces steps specifically for MacOS users to install LMDB locally for starting a Genesis data server. It includes directions for brew installation and creating a symlink to make LMDB accessible through Java. No changes for Windows users are involved.

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
