### PR TITLE
fix: material UI palette cleanup FUI-1934

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,9 +6,6 @@
 
 require("dotenv").config();
 
-import { dark } from "@mui/material/styles/createPalette";
-import { themes as prismThemes } from "prism-react-renderer";
-
 const baseUrl = process.env.BASE_URL || "/";
 const routeBasePath = "/";
 const GTM_ID = process.env.GTM_ID || "GTM-5GTR43J"; // default to uat GTM_ID, prod one should be set on CI (master)


### PR DESCRIPTION
Cleanup to remove this:
<img width="1008" alt="image" src="https://github.com/genesiscommunitysuccess/docs/assets/82830570/b6011bdf-5199-4a76-b043-510cd94681ab">