### PR TITLE
Update IntelliJ plugin installation instructions

### DIFF
--- a/docs/03_server/12_tooling/02_intellij-plugin.mdx
+++ b/docs/03_server/12_tooling/02_intellij-plugin.mdx
@@ -18,11 +18,29 @@ The Genesis Intellij Plugin enables you to run the full stack of a Genesis appli
 1. To install, click on the button below:
 <iframe width="245px" height="48px" src="https://plugins.jetbrains.com/embeddable/install/21131"></iframe>
 
-![Installing the plugin](/img/plugin-marketplace.png)
-
-2. After installing the plugin, make sure you add it so that it is visible on the [Tool window bars and buttons](https://www.jetbrains.com/help/idea/tool-windows.html#bars_and_buttons).
+2. After installing the plugin, The [Tool window bars and buttons](https://www.jetbrains.com/help/idea/tool-windows.html#bars_and_buttons) will be visible once you open a Genesis Project.
 
 ![Genesis Tool Window](/img/intellij-plugin/genesis-tool-window.png)
+
+:::tip
+If the tool window does not show in a Genesis project, please make sure that you have opened the correct folder.
+The plugin will expect your project to have a folder called "server", and will check the "settings.gradle.kts" file in
+that folder for Genesis dependencies:
+```
+my project/
+├─ client/
+├─ server/
+│  ├─ setting.gradle.kts
+```
+Sometimes, especially when opening a project extracted from a zip file, there might be a nested project folder:
+```
+my project/     <-- don't open this folder
+├─ my project/  <-- open this folder
+│  ├─ client/
+│  ├─ server/
+│  │  ├─ setting.gradle.kts
+```
+:::
 
 3. For MacOs specifically, you need to install LMDB locally to start a Genesis data server.
 

--- a/docs/03_server/12_tooling/02_intellij-plugin.mdx
+++ b/docs/03_server/12_tooling/02_intellij-plugin.mdx
@@ -23,8 +23,8 @@ The Genesis Intellij Plugin enables you to run the full stack of a Genesis appli
 ![Genesis Tool Window](/img/intellij-plugin/genesis-tool-window.png)
 
 :::tip
-If the tool window does not show in a Genesis project, please make sure that you have opened the correct folder.
-The plugin will expect your project to have a folder called "server", and will check the "settings.gradle.kts" file in
+If the tool window does not appear in a Genesis project, please make sure that you have opened the correct folder.
+The plugin will expect your project to have a folder called **server**; it checks the **settings.gradle.kts** file in
 that folder for Genesis dependencies:
 ```
 my project/


### PR DESCRIPTION
The documentation for installing the IntelliJ plugin has been expanded for clarity. It now includes instructions on how to correctly open a Genesis project to view the tool window bars and buttons, as well as additional information on the folder structure the plugin expects to find. This should aid users in successful project setup.

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
