### PR TITLE
Add linkage to main intellij plugin docs

### DIFF
--- a/docs/06_operations/02_infrastructure/01_infrastructure.mdx
+++ b/docs/06_operations/02_infrastructure/01_infrastructure.mdx
@@ -13,19 +13,19 @@ This guide is to assist people responsible for the infrastructure that is used t
 
 Where available, we point to maintained documentation areas.
 
-If you have any questions or concerns, or if you any content in this guide or its links to be incorrect or lacking detail, please raise them with your Genesis Account Technical Contact, who will be happy to discuss and source any details they are not able to answer directly.
+If you have any questions or concerns, or if you find any content in this guide or its links to be incorrect or lacking detail, please raise them with your Genesis Account Technical Contact, who will be happy to discuss and source any details they are not able to answer directly.
 
 ## Infrastructure for user development
 
-The Genesis platform includes tools and libraries that enable developers to building applications more quickly.
+The Genesis platform includes tools and libraries that enable developers to build applications more quickly.
 
 The following gives an overview of where they are hosted and how corporate infrastructure is typically set up to access them.
 
 ## Intellij Plugin
 
-Genesis maintains a [plugin](https://plugins.jetbrains.com/plugin/21131-genesis-platform-support) that allows developers to run the full stack of their application locally for early development phases.
+Genesis maintains a [plugin](https://plugins.jetbrains.com/plugin/21131-genesis-platform-support) that allows you to run the full stack of your application locally for early development phases.
 
-Find [full documentation on the plugin here](https://learn.genesis.global/docs/server/tooling/intellij-plugin/)
+The plugin is [fully documented in our Server pages](https://learn.genesis.global/docs/server/tooling/intellij-plugin/).
 
 ### Installing via IntelliJ plugin marketplace
 

--- a/docs/06_operations/02_infrastructure/01_infrastructure.mdx
+++ b/docs/06_operations/02_infrastructure/01_infrastructure.mdx
@@ -23,7 +23,9 @@ The following gives an overview of where they are hosted and how corporate infra
 
 ## Intellij Plugin
 
-Genesis maintains a [plugin](https://plugins.jetbrains.com/plugin/21131-genesis-platform-support) that allows developers to run the full stack of their application locally for early development phases. 
+Genesis maintains a [plugin](https://plugins.jetbrains.com/plugin/21131-genesis-platform-support) that allows developers to run the full stack of their application locally for early development phases.
+
+Find [full documentation on the plugin here](https://learn.genesis.global/docs/server/tooling/intellij-plugin/)
 
 ### Installing via IntelliJ plugin marketplace
 

--- a/docs/06_operations/02_infrastructure/01_infrastructure.mdx
+++ b/docs/06_operations/02_infrastructure/01_infrastructure.mdx
@@ -25,7 +25,7 @@ The following gives an overview of where they are hosted and how corporate infra
 
 Genesis maintains a [plugin](https://plugins.jetbrains.com/plugin/21131-genesis-platform-support) that allows you to run the full stack of your application locally for early development phases.
 
-The plugin is [fully documented in our Server pages](https://learn.genesis.global/docs/server/tooling/intellij-plugin/).
+The plugin is [fully documented in our Server pages](../../../server/tooling/intellij-plugin/).
 
 ### Installing via IntelliJ plugin marketplace
 


### PR DESCRIPTION
Search isn't the best and this is the first page I find, we need to link to the proper docs

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
