### PR TITLE
PTL-1305 formatting issue in new page - gpal script resolution

### DIFF
--- a/docs/01_getting-started/05_advanced-learning/server-runtime-environment/script-resolution.mdx
+++ b/docs/01_getting-started/05_advanced-learning/server-runtime-environment/script-resolution.mdx
@@ -9,10 +9,12 @@ sidebar_position: 2
 Your application's **processes.xml** file enables you to specify the script file for each process. Genesis looks for these files in three locations:
 
 ### Installed modules
-The primary lookup location for GPAL scripts is in the **/scripts** directory in each installed module on the target server. So, for every directory under **$GENESIS_HOME**, the process bootstrap will attempt to resolve a script file in `$GENESIS_HOME/<module>/scripts`.
+The primary lookup location for GPAL scripts is in the **/scripts** directory in each installed module on the target server. So, for every directory under **$GENESIS_HOME**, the process bootstrap will attempt to resolve a script file in the directory **$GENESIS_HOME/*module*/scripts**.
 
 ### Site Specific scripts
-It is possible to override GPAL scripts that are installed as part of either the core platform or additional platform components. To do this, create a script file with the same name (or copy the file from the installed module) to the **site-specific/scripts** directory. Script files in the **site-specific/scripts** directory take precedence over files with the same name in the directory of an installed module.
+It is possible to override GPAL scripts that are installed as part of either the core platform or additional platform components. To do this, create a script file with the same name (or copy the file from the installed module) to the **site-specific/scripts** directory. 
+
+Script files in the **site-specific/scripts** directory take precedence over files with the same name in the directory of an installed module.
 
 ### Runtime classpath
 GPAL script files can also be bundled inside jar archives. A script file can be resolved by name, provided the file is in the root directory of a jar archive that has been added to the process classpath. This is useful if you do not want to allow overrides of specific script files for security reasons.


### PR DESCRIPTION
needs to be bold,not code ticks
chevrons causing html error on build

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
YES

Have you checked all new or changed links?
Builds correctly

Is there anything else you would like us to know?
No

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
