### PR TITLE
Add Migration Guide and Notice for Table Syntax Changes

### DIFF
--- a/docs/02_database/01_fields-tables-views/01_tables/01_tables-basics.mdx
+++ b/docs/02_database/01_fields-tables-views/01_tables/01_tables-basics.mdx
@@ -9,6 +9,13 @@ tags:
 - basics
 ---
 
+:::info
+Version 7.2 introduced a simplified table dictionary syntax, where fields are defined inline in the table,
+rather than in a separate file.
+To help migrate to the new syntax, please follow the guide [here](../tables-migration).
+:::
+
+
 Tables are essential to the data model. In your application's **tables-dictionary.kts** file, you need to define every table that your application needs. 
 
 Each table requires:

--- a/docs/02_database/01_fields-tables-views/01_tables/01_tables-basics.mdx
+++ b/docs/02_database/01_fields-tables-views/01_tables/01_tables-basics.mdx
@@ -10,9 +10,9 @@ tags:
 ---
 
 :::info
-Version 7.2 introduced a simplified table dictionary syntax, where fields are defined inline in the table,
+Version 7.2 introduced a simplified table-dictionary syntax, where fields are defined inline in the table,
 rather than in a separate file.
-To help migrate to the new syntax, please follow the guide [here](../tables-migration).
+We have provided a [guide](../tables-migration) to help you migrate from older projects to the new syntax.
 :::
 
 

--- a/docs/02_database/01_fields-tables-views/01_tables/04_tables-migration.mdx
+++ b/docs/02_database/01_fields-tables-views/01_tables/04_tables-migration.mdx
@@ -10,10 +10,10 @@ tags:
 - migration
 ---
 
-Before version 7.2, Genesis required developers to define fields, separate from tables in their own dictionary file.
-Since 7.2, Genesis supports a new syntax where fields are defined inline in the table.
+Before version 7.2, Genesis required you to define fields in their own dictionary file, separately from tables.
+SiFrom version 7.2, Genesis supports a new syntax where fields are defined inline in the table.
 
-We went from this
+We went from this...
 ```kotlin
 table(name = "RIGHT", id = 1004) {
     CODE
@@ -24,7 +24,7 @@ table(name = "RIGHT", id = 1004) {
 }
 ```
 
-to this:
+...to this:
 ```kotlin
 table(name = "RIGHT", id = 1004) {
     field("CODE").primaryKey()
@@ -32,7 +32,8 @@ table(name = "RIGHT", id = 1004) {
 }
 ```
 
-To help users migrate to the new syntax, Genesis provides a gradle plugin.
+To help you migrate to the new syntax, Genesis provides a gradle plugin.
+
 To start, add the following line to the top of the **build.gradle.kts** file in your `-config` module:
 
 ```kotlin
@@ -41,6 +42,5 @@ plugins {
 }
 ```
 
-After doing a Gradle refresh, a new task: `updateTablesDictionary`
-should be available in the Gradle task list, under `genesis`.
-To migrate the table dictionaries in your config module, run the task
+After doing a Gradle refresh, a new task: `updateTablesDictionary` is available in the Gradle task list, under **genesis**.
+To migrate the table dictionaries in your config module, run the task.

--- a/docs/02_database/01_fields-tables-views/01_tables/04_tables-migration.mdx
+++ b/docs/02_database/01_fields-tables-views/01_tables/04_tables-migration.mdx
@@ -10,8 +10,9 @@ tags:
 - migration
 ---
 
-Before version 7.2, Genesis required you to define fields in their own dictionary file, separately from tables.
-SiFrom version 7.2, Genesis supports a new syntax where fields are defined inline in the table.
+Before version 7.2, Genesis you had to define fields in their own dictionary file, separately from tables.
+
+From version 7.2, Genesis supports a new syntax where fields are defined inline in the table.
 
 We went from this...
 ```kotlin
@@ -34,7 +35,7 @@ table(name = "RIGHT", id = 1004) {
 
 To help you migrate to the new syntax, Genesis provides a gradle plugin.
 
-To start, add the following line to the top of the **build.gradle.kts** file in your `-config` module:
+To start, add the following line to the top of the **build.gradle.kts** file in your **-config** module:
 
 ```kotlin
 plugins {

--- a/docs/02_database/01_fields-tables-views/01_tables/04_tables-migration.mdx
+++ b/docs/02_database/01_fields-tables-views/01_tables/04_tables-migration.mdx
@@ -1,0 +1,46 @@
+---
+title: 'Tables - migration'
+sidebar_label: 'Tables - migration'
+id: tables-migration
+keywords: [database, tables, fields, migration]
+tags:
+- database
+- tables
+- fields
+- migration
+---
+
+Before version 7.2, Genesis required developers to define fields, separate from tables in their own dictionary file.
+Since 7.2, Genesis supports a new syntax where fields are defined inline in the table.
+
+We went from this
+```kotlin
+table(name = "RIGHT", id = 1004) {
+    CODE
+    DESCRIPTION
+    primaryKey {
+        CODE
+    }
+}
+```
+
+to this:
+```kotlin
+table(name = "RIGHT", id = 1004) {
+    field("CODE").primaryKey()
+    field("DESCRIPTION")
+}
+```
+
+To help users migrate to the new syntax, Genesis provides a gradle plugin.
+To start, add the following line to the top of the **build.gradle.kts** file in your `-config` module:
+
+```kotlin
+plugins {
+    id("global.genesis.dictionary.upgrade")
+}
+```
+
+After doing a Gradle refresh, a new task: `updateTablesDictionary`
+should be available in the Gradle task list, under `genesis`.
+To migrate the table dictionaries in your config module, run the task


### PR DESCRIPTION
A guide for migrating table syntax has been added to the "Tables - migration" section. The document explains changes in Genesis from version 7.2, where fields are now defined inline in the table rather than in a separate dictionary file. A notification about this upgrade has also been added to the "Tables - basics" article to inform users about the simplified dictionary syntax and direct them to the migration guide.

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you checked all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
