### PR TITLE
PTL-1319: copy correct Timestamp info to Previous

### DIFF
--- a/versioned_docs/version-previous/02_database/01_fields-tables-views/05_timestamps.md
+++ b/versioned_docs/version-previous/02_database/01_fields-tables-views/05_timestamps.md
@@ -9,7 +9,12 @@ tags:
   - genesisflake
 ---
 
-When you generate a database on the Genesis low-code platform, every table in the database is given a timestamp field. This contains a timestamp value that is generated automatically by GenesisFlake every time a change is made to the database. The `TIMESTAMP` field in GenesisFlake represents the creation time of a record, not the last modified time.
+When you generate a database on the Genesis platform, every table in the database is given a TIMESTAMP and a RECORD_ID field.
+
+- The `TIMESTAMP` field value is generated automatically by GenesisFlake every time a change is made to the database.
+- The `RECORD_ID` field is the `TIMESTAMP` value when the record is first created, it will never change.
+
+The database generates a new `TIMESTAMP` for every modify operation, even if no other fields are changed.
 
 To create these values, GenesisFlake generates IDs in a similar manner to Twitter’s [snowflake](https://developer.twitter.com/en/docs/basics/twitter-ids). It is able to generate these IDs without having to perform database-level synchronisation - which ensures high performance. 
 


### PR DESCRIPTION
This was causing an issue

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
NO

Have you checked all new or changed links?
BUILDS CORRECTLY

Is there anything else you would like us to know?
NO

For reference: 

  - We have an [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4)
  - We have a [style guide](https://www.notion.so/genesisglobal/Documentation-style-guide-5b04ec6fe12f4262b90d192effd8059b) 

**This week's exciting excerpts from the style guide**

- We write in UK English, with Oxford English Dictionary (OED) spellings, grammar and vocabulary.  

Use the present tense wherever possible. Only use another tense where it is strictly necessary.

- Present tense (preferred whenever possible): *The script creates a new folder.*
- Future tense (avoid whenever possible): *The script will create a new folder.*
