### PR TITLE
fix: adding rewrite to nginx sample configuration

### DIFF
--- a/docs/06_operations/01_server-setup/03_config-management.mdx
+++ b/docs/06_operations/01_server-setup/03_config-management.mdx
@@ -73,9 +73,9 @@ For a manual set-up of nginx, use this nginx.conf file:
 
 ```text
 map $http_upgrade $connection_upgrade {
-      default upgrade;
-      ''      close;
-    }
+    default upgrade;
+    ''      close;
+}
 
 server {
 
@@ -86,8 +86,9 @@ server {
     root /data/positions/web;
 
     location ~ ^/(gwf)(.*)$ {
+        rewrite                 ^/gwf(.*)/$ /$1 break;
+        proxy_pass              http://127.0.0.1:9064;
         proxy_set_header        Host $host:$server_port;
-        proxy_pass              http://127.0.0.1:9064$2$is_args$args;
         proxy_http_version      1.1;
         proxy_set_header        X-Real-IP $remote_addr;
         proxy_set_header        HOSTNAME $remote_addr;


### PR DESCRIPTION
The configuration misses re-write, probably the previous proxy_pass structure was doing some manipulation at the url path that maybe has worked on certain versions.

Using a `rewrite` is the correct pattern, as we are dropping the path and forwarding direct to the router's root.

  - Please check the [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) for details
  
__________

Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you done a trial build to check all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

**This week's exciting advice from the style guide**

- Write your headings in sentence case:

  - A good example
    This is a correct heading.
  - A Bad Example
    This is not a correct heading.

