### PR TITLE
docs: added rapid ds provider tag in CodeSection component

### DIFF
--- a/examples/ui/documentationBase.js
+++ b/examples/ui/documentationBase.js
@@ -2,17 +2,19 @@ import React, { useState } from "react";
 
 export function CodeSection({ children, color }) {
 	return (
-		<div
-			style={{
-				backgroundColor: '#292d3e',
-				borderRadius: '6px',
-				padding: '10px',
-				alignItems: 'center',
-				display: 'flex'
-			}}
-		>
-			{children}
-		</div>
+		<rapid-design-system-provider>
+			<div
+				style={{
+					backgroundColor: '#292d3e',
+					borderRadius: '6px',
+					padding: '10px',
+					alignItems: 'center',
+					display: 'flex'
+				}}
+			>
+				{children}
+			</div>
+		</rapid-design-system-provider>
 	);
 }
 


### PR DESCRIPTION
ATTENTION! NEW DOCS STRUCTURE
FOR THE NEXT THREE WEEKS, ONLY BRANCH FROM new-docs-structure
OTHERWISE, WAIT UNTIL THE NEW STRUCTURE HAS BEEN RELEASED

  - Please check the [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) for details
  
__________

Added rapid design system provider tag as even if with using rapid components you need this tag for default values of rapid token. Without this tag, fast design token values will be used, pink text color for example:
Before:

![Screenshot 2024-11-26 at 13 54 59](https://github.com/user-attachments/assets/23c53e86-6c14-40d9-94f8-dfaca25f99ef)

After:

![Screenshot 2024-11-26 at 14 12 45](https://github.com/user-attachments/assets/19535db2-9a52-4c17-8149-433301ba6aed)


Thank you for contributing to the documentation.

Do the changes you have made apply to both Current and Previous versions?
<!--- Yes / No -->

Have you done a trial build to check all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

**This week's exciting advice from the style guide**

- Write your headings in sentence case:

  - A good example
    This is a correct heading.
  - A Bad Example
    This is not a correct heading.

