### PR TITLE
docs: invert grids index items overview

### DIFF
--- a/docs/001_develop/03_client-capabilities/005_grids/index.mdx
+++ b/docs/001_develop/03_client-capabilities/005_grids/index.mdx
@@ -3,6 +3,16 @@ title: 'Grids'
 id: client-grids
 ---
 
+## [Entity Manager](./entity-manager)
+
+The Entity Manager is a sophisticated micro front-end component that serves as a comprehensive solution for data management interfaces. It combines the powerful `grid-pro` with integrated forms for entity creation and modification. One of its core strengths is its ability to automatically interface with backend resources for CRUD operations, while generating dynamic forms based on backend metadata. The component also features robust grid display and search capabilities that can be extensively configured.
+
+The Grid Configuration system forms a central part of the Entity Manager's functionality. It allows for detailed customization of columns, including properties such as width, headers, and styling options. The system supports various CRUD menu button placements, whether at the top, bottom, or within columns. Users can choose from different button style configurations, including default, vertical, and horizontal actions menus. Importantly, the component can maintain column states for persistence across sessions.
+
+Form Configuration in the Entity Manager is designed for maximum flexibility and ease of use. The system automatically generates forms using backend metadata, while still allowing for customization through form UI schemas for both create and update operations. It includes support for default values and implements comprehensive form validation and error handling mechanisms.
+
+The Integration Features of the Entity Manager enable seamless connectivity with backend systems. It can interface with backend resources through either `DATASERVER` queries or `REQUEST_SERVER` requests. The component includes configurable event handlers for create, update, and delete operations, along with search bar functionality and real-time data update capabilities.
+
 
 ## [Grid Pro](./grid-pro)
 
@@ -13,13 +23,3 @@ It provides robust Cell and Column components that enable detailed configuration
 Grid Pro's feature set is comprehensive, offering seamless integration with modern JavaScript frameworks and supporting both simple and connected data scenarios. Whether working with basic JSON data, REST APIs, or connected data through Data Server or Request Server, the system maintains high performance through smart optimization techniques like DOM virtualization and pagination. These features ensure smooth handling of large datasets while providing a responsive user experience.
 
 It can all be configured through common attributes and configurations, applicable to both client-side and server-side implementations. This flexibility allows developers to fine-tune grid behavior and appearance, ensuring the final implementation aligns perfectly with their application's needs while maintaining optimal performance and user experience.
-
-## [Entity Manager](./entity-manager)
-
-The Entity Manager is a sophisticated micro front-end component that serves as a comprehensive solution for data management interfaces. It combines the powerful `grid-pro` with integrated forms for entity creation and modification. One of its core strengths is its ability to automatically interface with backend resources for CRUD operations, while generating dynamic forms based on backend metadata. The component also features robust grid display and search capabilities that can be extensively configured.
-
-The Grid Configuration system forms a central part of the Entity Manager's functionality. It allows for detailed customization of columns, including properties such as width, headers, and styling options. The system supports various CRUD menu button placements, whether at the top, bottom, or within columns. Users can choose from different button style configurations, including default, vertical, and horizontal actions menus. Importantly, the component can maintain column states for persistence across sessions.
-
-Form Configuration in the Entity Manager is designed for maximum flexibility and ease of use. The system automatically generates forms using backend metadata, while still allowing for customization through form UI schemas for both create and update operations. It includes support for default values and implements comprehensive form validation and error handling mechanisms.
-
-The Integration Features of the Entity Manager enable seamless connectivity with backend systems. It can interface with backend resources through either `DATASERVER` queries or `REQUEST_SERVER` requests. The component includes configurable event handlers for create, update, and delete operations, along with search bar functionality and real-time data update capabilities.


### PR DESCRIPTION
This only inverts the grid pro/entity manager texts, so they match the sidebar (Entity Manager first, Grid Pro second).

Before: 

![image](https://github.com/user-attachments/assets/0dc0b61b-ff8d-4046-b90b-c79f4a5d917f)

After:

![image](https://github.com/user-attachments/assets/c2aabac8-5f65-4816-84da-6f06b701e5d5)

---

Do the changes you have made apply to both Current and Previous versions?
No

Have you done a trial build to check all new or changed links?
Yes

Is there anything else you would like us to know?
No