### PR TITLE
docs: index page message and fix broken link PTL-0

### DIFF
--- a/docs/001_develop/03_client-capabilities/013_toast-notifications/index.mdx
+++ b/docs/001_develop/03_client-capabilities/013_toast-notifications/index.mdx
@@ -209,10 +209,10 @@ Here's an example of using `banner` with the [showNotificationBanner](./docs/api
 
 ### Snackbar
  `snackbars` are notifications that appear at bottom of screen. These notifications can have interactive button unlike `toasts`. They can be used for brief updates that require user interaction, like showing a status or confirming an action.
- 
+
  `type` property in snackbar config can be used to set the notification style. Supported types are `error`,`success`, `info` or `warning`.
 
-Here's an example of using `snackbar` with the [showNotificationSnackbar](./docs/api/foundation-notifications.shownotificationSnackbar) method from the package.For the parameters, refer to [SnackbarStructure](./docs/api/foundation-notifications.snackbarstructure) in the package API documentation.
+Here's an example of using `snackbar` with the [showNotificationSnackbar](./docs/api/foundation-notifications.shownotificationsnackbar) method from the package.For the parameters, refer to [SnackbarStructure](./docs/api/foundation-notifications.snackbarstructure) in the package API documentation.
 
 <SnackbarDemo />
 <br/>
@@ -223,13 +223,13 @@ Here's an example of using `snackbar` with the [showNotificationSnackbar](./docs
     body: 'Lorem ipsum',
     snackbar: {
       confirmingActions: [{ label: 'Confirm', action: () => console.log('Lorem ipsum') }],
-      type: 'error', 
+      type: 'error',
     },
   },
   'rapid',
 );
 ```
- `Snackbar` are persistent until dismissed. They can disappear automatically after a short time by setting the `autoClose` property in the snackbar config. 
+ `Snackbar` are persistent until dismissed. They can disappear automatically after a short time by setting the `autoClose` property in the snackbar config.
 
 ```typescript
   showNotificationSnackbar(
@@ -237,7 +237,7 @@ Here's an example of using `snackbar` with the [showNotificationSnackbar](./docs
       body: 'Lorem ipsum',
       snackbar: {
         confirmingActions: [{ label: 'Confirm', action: () => console.log('Lorem ipsum') }],
-        type: 'error', 
+        type: 'error',
         autoClose: true
       },
     },
@@ -251,7 +251,7 @@ This notification component uses a modal-like window to display notification. `D
 
 One of the most common use case for dialog is `confirming before deleting`.
 
-An example for using `dialog` component is shown in the Example section above. 
+An example for using `dialog` component is shown in the Example section above.
 Multiple action buttons can be shown in a dialog by using `confirmingActions` property as shown in below snippet:
 
 ```typescript

--- a/src/components/LiveExampleBuilder.js
+++ b/src/components/LiveExampleBuilder.js
@@ -30,6 +30,9 @@ export default function LiveExampleBuilder({ itemData }) {
       {isLoading ? (
 		<LoadingRing />
       ) : (
+			<>
+					<p style={{textAlign: 'center'}}>Here is an index of components in this section. You can interact
+						with the live examples below, or click the card to navigate to the documentation.</p>
         <div style={{ visibility: isLoading ? 'hidden' : 'visible' }}>
           <CardList
             xs="12"
@@ -38,7 +41,7 @@ export default function LiveExampleBuilder({ itemData }) {
             items={processedItems}
           />
         </div>
-      )}
+      </>) }
     </>
   );
 }


### PR DESCRIPTION
1. Fix the last broken link in the client capabilities section
2. Adds a message explaning how to interact with the live example cards