### PR TITLE
fix: update ReleaseCard image link target

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -15,7 +15,7 @@ export default function Card (props) {
     />;
 
   const imageWithWrapper = imageLink ? (
-    <a href={imageLink} title={heading} className="card-main-image-wrapper">
+    <a href={imageLink} title={heading} target="_blank" className="card-main-image-wrapper">
       {imageElement}
     </a>
   ) : (


### PR DESCRIPTION
Updates the target attribute of the image link in the ReleaseCard component so the link now opens in a new tab

Demo:


https://github.com/user-attachments/assets/d6627615-1a9d-455c-aa70-69689db0638d

