### PR TITLE
feat: change ScriptFile and ConfigFile to TestScriptFile and TestConfigFile, add additional explanation for new features related to dataserver and CsvData GSF 8.9 release (GSF-7186)

### DIFF
--- a/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
@@ -1273,7 +1273,7 @@ Create the test class using the code provided below:
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("positions-app-tutorial-dataserver.kts")
+@TestScriptFile("positions-app-tutorial-dataserver.kts")
 @CsvData("seed-data.csv")
 class DataServerTest {
 
@@ -1286,7 +1286,7 @@ class DataServerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("positions-app-tutorial-dataserver.kts")
+@TestScriptFile("positions-app-tutorial-dataserver.kts")
 @CsvData("seed-data.csv")
 public class DataServerTest {
 
@@ -1299,7 +1299,7 @@ public class DataServerTest {
 This test class does three things: 
 
 * It enables **GenesisJunit**.
-* It identifies the Data Server script that we want to test, using the `ScriptFile` annotation.
+* It identifies the Data Server script that we want to test, using the `TestScriptFile` annotation.
 * It identifies the source data for our test, using the `CsvData` annotation.
 
 There is more information about `GenesisJunit` and the various annotations in the section on [Integration testing](/develop/server-capabilities/testing-api/#integration-testing).
@@ -1324,7 +1324,7 @@ Before we can begin writing tests for our Data Server, we need to inject referen
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("positions-app-tutorial-dataserver.kts")
+@TestScriptFile("positions-app-tutorial-dataserver.kts")
 @CsvData("seed-data.csv")
 class DataServerTest {
 
@@ -1343,7 +1343,7 @@ class DataServerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("positions-app-tutorial-dataserver.kts")
+@TestScriptFile("positions-app-tutorial-dataserver.kts")
 @CsvData("seed-data.csv")
 public class DataServerTest {
 
@@ -1470,7 +1470,7 @@ To test dynamic authorization, add `@EnableInMemoryTestAuthCache` to your class 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
 @EnableInMemoryTestAuthCache
-@ScriptFile("hello-world-dataserver.kts")
+@TestScriptFile("hello-world-dataserver.kts")
 @CsvData("SystemTest/simple-data-load.csv")
 class DataServerTest {
 
@@ -1527,7 +1527,7 @@ class DataServerTest {
 ```java
 @ExtendWith(GenesisJunit.class)
 @EnableInMemoryTestAuthCache
-@ScriptFile("hello-world-dataserver.kts")
+@TestScriptFile("hello-world-dataserver.kts")
 @CsvData("SystemTest/simple-data-load.csv")
 public class DataServerTest {
 
@@ -1583,7 +1583,7 @@ public class DataServerTest {
 
 #### Await methods
 
-Finally, **QueryView** has some methods to help with making assertions on the data.
+**QueryView** has some methods to help with making assertions on the data.
 With the view itself being updated in the background, these methods will have a timeout.
 
 <Tabs defaultValue="kotlin" values={[{ label: 'Kotlin', value: 'kotlin', }, { label: 'Java', value: 'java', }]}>
@@ -1622,6 +1622,37 @@ void testUsdPositions() {
 
 </TabItem>
 </Tabs>
+
+#### Message flow related properties and methods
+
+Finally, **QueryView** also exposes properties and methods that allow full control on the dataserver subscription message flow.
+
+##### Properties
+
+| Kotlin Syntax | Java Syntax | Description | Default Value |
+|--------------|-------------|-------------|---------------|
+| `val queryUpdateMessagesReceived: Int` | `int getQueryUpdateMessagesReceived()` | The number of QUERY_UPDATE messages received so far. | `0` (initially no messages received). |
+| `val latestMoreRowsValueReceived: Boolean?` | `Boolean getLatestMoreRowsValueReceived()` | The last MORE_ROWS boolean value received in a QUERY_UPDATE message. | `null` (no value received yet). |
+| `val subscribed: Boolean` | `boolean getSubscribed()` | Indicates if the query subscription is active (`true`) or not (`false`). | `false` (subscription not active by default). |
+| `val allRawQueryUpdatesReceived: List<GenesisSet>` | `List<GenesisSet> getAllRawQueryUpdatesReceived` | Contains all raw QUERY_UPDATE messages in the order they were received. | Empty list (`[]`) (no updates received yet). |
+| `val latestRawQueryUpdate: GenesisSet?` | `GenesisSet getLatestRawQueryUpdate()` | Provides the raw content of the latest QUERY_UPDATE message for detailed inspection. | `null` (no updates received yet). |
+| `val rowsCount: Int?` | `Integer getRowsCount()` | Provides the ROWS_COUNT value received in the first QUERY_UPDATE message. | `null` (no count received yet). |
+
+##### Methods
+
+The methods below allow developers to create tests that deal with `MORE_ROWS` and `MORE_COLUMNS` message flows (see more in the [client API](#client-api) section). There are also a couple of utility methods (`retrieveRawQueryUpdateRowsFrom` and `checkExpectedRowsNumberFrom`) to query the total number and content of ROW updates received since a specific QUERY_UPDATE message.
+
+| Kotlin Syntax | Java Syntax | Description |
+|--------------|-------------|-------------|
+| `fun moreRows(viewNumber: Int, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreRows(int viewNumber, long timeout, TimeUnit unit)` | Sends a MORE_ROWS message specifying the view number and timeout settings. |
+| `fun moreRows(viewNumber: Int): Boolean` | `boolean moreRows(int viewNumber)` | Sends a MORE_ROWS message specifying the view number with default timeout (10 seconds). |
+| `fun moreRows(): Boolean` | `boolean moreRows()` | Sends a MORE_ROWS message using default view and timeout. |
+| `fun moreColumns(addColumns: List<String>, dropColumns: List<String>, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns, long timeout, TimeUnit unit)` | Sends a MORE_COLUMNS message with payload to add and remove columns along with timeout settings. |
+| `fun moreColumns(addColumns: List<String>, dropColumns: List<String>): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns)` | Sends a MORE_COLUMNS message with payload to add and remove columns using default timeout. |
+| `fun addColumns(addColumns: List<String>): Boolean` | `boolean addColumns(List<String> addColumns)` | Sends a MORE_COLUMNS message requesting columns to be added with default timeout (10 seconds). |
+| `fun dropColumns(dropColumns: List<String>): Boolean` | `boolean dropColumns(List<String> dropColumns)` | Sends a MORE_COLUMNS message requesting columns to be removed with default timeout (10 seconds). |
+| `fun retrieveRawQueryUpdateRowsFrom(fromQueryUpdateNumber: Int): List<GenesisSet>` | `List<GenesisSet> retrieveRawQueryUpdateRowsFrom(int fromQueryUpdateNumber)` | Returns all ROW GenesisSet values received since a specific QUERY_UPDATE message number, starting inclusively from the given number. |
+| `fun checkExpectedRowsNumberFrom(fromQueryUpdateNumber: Int, expectedRows: Int): Boolean` | `boolean checkExpectedRowsNumberFrom(int fromQueryUpdateNumber, int expectedRows)` | Checks if the total number of ROW updates received since a specific QUERY_UPDATE message number matches the expected number of rows, starting inclusively from the given number. |
 
 ### Integration testing (legacy)
 

--- a/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
@@ -1623,9 +1623,9 @@ void testUsdPositions() {
 </TabItem>
 </Tabs>
 
-#### Message flow related properties and methods
+#### Controlling and analysing message flow
 
-Finally, **QueryView** also exposes properties and methods that give you full control of the dataserver subscription message flow.
+Finally, **QueryView** also exposes properties and methods that enable you to control and analyse the dataserver subscription message flow.
 
 ##### Properties
 
@@ -1640,19 +1640,21 @@ Finally, **QueryView** also exposes properties and methods that give you full co
 
 ##### Methods
 
-The methods below enable you to create tests that deal with `MORE_ROWS` and `MORE_COLUMNS` message flows (see more in the [client API](#client-api) section). There are also a couple of utility methods (`retrieveRawQueryUpdateRowsFrom` and `checkExpectedRowsNumberFrom`) to query the total number and content of ROW updates received since a specific QUERY_UPDATE message.
+The methods below enable you to create tests that deal with `MORE_ROWS` and `MORE_COLUMNS` message flows (see more in the [client API](#client-api) section). 
+
+The majority of these methods enable you to send messages to control the message flow. The last two in the table (`retrieveRawQueryUpdateRowsFrom` and `checkExpectedRowsNumberFrom`) are utility methods that enable you to query the total number and content of ROW updates received since a specified QUERY_UPDATE message.
 
 | Kotlin Syntax | Java Syntax | Description |
 |--------------|-------------|-------------|
 | `fun moreRows(viewNumber: Int, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreRows(int viewNumber, long timeout, TimeUnit unit)` | Sends a MORE_ROWS message specifying the view number and timeout settings. |
-| `fun moreRows(viewNumber: Int): Boolean` | `boolean moreRows(int viewNumber)` | Sends a MORE_ROWS message specifying the view number with default timeout (10 seconds). |
-| `fun moreRows(): Boolean` | `boolean moreRows()` | Sends a MORE_ROWS message using default view and timeout. |
-| `fun moreColumns(addColumns: List<String>, dropColumns: List<String>, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns, long timeout, TimeUnit unit)` | Sends a MORE_COLUMNS message with payload to add and remove columns, along with timeout settings. |
+| `fun moreRows(viewNumber: Int): Boolean` | `boolean moreRows(int viewNumber)` | Sends a MORE_ROWS message specifying the view number. It automatically includes a default timeout (10 seconds). |
+| `fun moreRows(): Boolean` | `boolean moreRows()` | Sends a MORE_ROWS message using default view and timeout (10 seconds). |
+| `fun moreColumns(addColumns: List<String>, dropColumns: List<String>, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns, long timeout, TimeUnit unit)` | Sends a MORE_COLUMNS message with payload, which you can use to *add* and *remove* columns, along with timeout settings. |
 | `fun moreColumns(addColumns: List<String>, dropColumns: List<String>): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns)` | Sends a MORE_COLUMNS message with payload to add and remove columns using default timeout. |
-| `fun addColumns(addColumns: List<String>): Boolean` | `boolean addColumns(List<String> addColumns)` | Sends a MORE_COLUMNS message requesting columns to be added with default timeout (10 seconds). |
-| `fun dropColumns(dropColumns: List<String>): Boolean` | `boolean dropColumns(List<String> dropColumns)` | Sends a MORE_COLUMNS message requesting columns to be removed with default timeout (10 seconds). |
+| `fun addColumns(addColumns: List<String>): Boolean` | `boolean addColumns(List<String> addColumns)` | Sends a MORE_COLUMNS message requesting columns to be added. It automatically includes a default timeout (10 seconds). |
+| `fun dropColumns(dropColumns: List<String>): Boolean` | `boolean dropColumns(List<String> dropColumns)` | Sends a MORE_COLUMNS message requesting columns to be removed. It automatically includes a default timeout (10 seconds). |
 | `fun retrieveRawQueryUpdateRowsFrom(fromQueryUpdateNumber: Int): List<GenesisSet>` | `List<GenesisSet> retrieveRawQueryUpdateRowsFrom(int fromQueryUpdateNumber)` | Returns all ROW GenesisSet values received since a specific QUERY_UPDATE message number, starting inclusively from the given number. |
-| `fun checkExpectedRowsNumberFrom(fromQueryUpdateNumber: Int, expectedRows: Int): Boolean` | `boolean checkExpectedRowsNumberFrom(int fromQueryUpdateNumber, int expectedRows)` | Checks if the total number of ROW updates received since a specific QUERY_UPDATE message number matches the expected number of rows, starting inclusively from the given number. |
+| `fun checkExpectedRowsNumberFrom(fromQueryUpdateNumber: Int, expectedRows: Int): Boolean` | `boolean checkExpectedRowsNumberFrom(int fromQueryUpdateNumber, int expectedRows)` | Checks if the total number of ROW updates received since a specified QUERY_UPDATE message number matches the expected number of rows, starting inclusively from the specified number. |
 
 ### Integration testing (legacy)
 

--- a/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
@@ -1625,7 +1625,7 @@ void testUsdPositions() {
 
 #### Message flow related properties and methods
 
-Finally, **QueryView** also exposes properties and methods that allow full control on the dataserver subscription message flow.
+Finally, **QueryView** also exposes properties and methods that give you full control of the dataserver subscription message flow.
 
 ##### Properties
 
@@ -1640,14 +1640,14 @@ Finally, **QueryView** also exposes properties and methods that allow full contr
 
 ##### Methods
 
-The methods below allow developers to create tests that deal with `MORE_ROWS` and `MORE_COLUMNS` message flows (see more in the [client API](#client-api) section). There are also a couple of utility methods (`retrieveRawQueryUpdateRowsFrom` and `checkExpectedRowsNumberFrom`) to query the total number and content of ROW updates received since a specific QUERY_UPDATE message.
+The methods below enable you to create tests that deal with `MORE_ROWS` and `MORE_COLUMNS` message flows (see more in the [client API](#client-api) section). There are also a couple of utility methods (`retrieveRawQueryUpdateRowsFrom` and `checkExpectedRowsNumberFrom`) to query the total number and content of ROW updates received since a specific QUERY_UPDATE message.
 
 | Kotlin Syntax | Java Syntax | Description |
 |--------------|-------------|-------------|
 | `fun moreRows(viewNumber: Int, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreRows(int viewNumber, long timeout, TimeUnit unit)` | Sends a MORE_ROWS message specifying the view number and timeout settings. |
 | `fun moreRows(viewNumber: Int): Boolean` | `boolean moreRows(int viewNumber)` | Sends a MORE_ROWS message specifying the view number with default timeout (10 seconds). |
 | `fun moreRows(): Boolean` | `boolean moreRows()` | Sends a MORE_ROWS message using default view and timeout. |
-| `fun moreColumns(addColumns: List<String>, dropColumns: List<String>, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns, long timeout, TimeUnit unit)` | Sends a MORE_COLUMNS message with payload to add and remove columns along with timeout settings. |
+| `fun moreColumns(addColumns: List<String>, dropColumns: List<String>, timeout: Long, unit: TimeUnit): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns, long timeout, TimeUnit unit)` | Sends a MORE_COLUMNS message with payload to add and remove columns, along with timeout settings. |
 | `fun moreColumns(addColumns: List<String>, dropColumns: List<String>): Boolean` | `boolean moreColumns(List<String> addColumns, List<String> dropColumns)` | Sends a MORE_COLUMNS message with payload to add and remove columns using default timeout. |
 | `fun addColumns(addColumns: List<String>): Boolean` | `boolean addColumns(List<String> addColumns)` | Sends a MORE_COLUMNS message requesting columns to be added with default timeout (10 seconds). |
 | `fun dropColumns(dropColumns: List<String>): Boolean` | `boolean dropColumns(List<String> dropColumns)` | Sends a MORE_COLUMNS message requesting columns to be removed with default timeout (10 seconds). |

--- a/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/004_real-time-queries-data-server/index.mdx
@@ -1662,7 +1662,7 @@ The majority of these methods enable you to send messages to control the message
 This section covers testing your Data Server if you are using any version of the Genesis Server Framework before GSF v8.
 :::
 
-The Genesis platform provides the `AbstractGenesisTestSupport` abstract class, which enables end-to-end testing of specific areas of your application.
+The Genesis Application Platform provides the `AbstractGenesisTestSupport` abstract class, which enables end-to-end testing of specific areas of your application.
 
 In this case, we want to ensure that we have a database seeded with information. And we want to check that our Data Server configuration is used to create our Data Server. We also need to add the required packages and genesis home.
 

--- a/docs/001_develop/02_server-capabilities/005_snapshot-queries-request-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/005_snapshot-queries-request-server/index.mdx
@@ -761,7 +761,7 @@ Create the test class using the code provided below:
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("hello-world-reqrep.kts")
+@TestScriptFile("hello-world-reqrep.kts")
 class RequestServerTest {
 
     // our tests go here ...
@@ -773,7 +773,7 @@ class RequestServerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("hello-world-reqrep.kts")
+@TestScriptFile("hello-world-reqrep.kts")
 public class RequestServerTest {
 
     // our tests go here ...
@@ -785,7 +785,7 @@ public class RequestServerTest {
 This test class does three things: 
 
 * It enables **GenesisJunit**.
-* It identifies the Request Server script that we want to test, using the `ScriptFile` annotation.
+* It identifies the Request Server script that we want to test, using the `TestScriptFile` annotation.
 
 There is more information about `GenesisJunit` and the various annotations in the section on [Integration testing](/develop/server-capabilities/testing-api/#integration-testing).
 
@@ -803,7 +803,7 @@ Use the code below:
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("hello-world-reqrep.kts")
+@TestScriptFile("hello-world-reqrep.kts")
 class RequestServerTest {
 
     @Inject
@@ -820,7 +820,7 @@ class RequestServerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("hello-world-reqrep.kts")
+@TestScriptFile("hello-world-reqrep.kts")
 public class RequestServerTest {
 
     @Inject
@@ -968,7 +968,7 @@ In the code below, there are two tests, which both check the result of the autho
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("hello-world-reqrep.kts")
+@TestScriptFile("hello-world-reqrep.kts")
 @EnableInMemoryTestAuthCache
 class HelloWorldRequestServerTest {
     @Inject
@@ -1015,7 +1015,7 @@ class HelloWorldRequestServerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("hello-world-reqrep.kts")
+@TestScriptFile("hello-world-reqrep.kts")
 @EnableInMemoryTestAuthCache
 public class HelloWorldRequestServerJavaTest {
 

--- a/docs/001_develop/02_server-capabilities/006_core-business-logic-event-handler/index.mdx
+++ b/docs/001_develop/02_server-capabilities/006_core-business-logic-event-handler/index.mdx
@@ -1120,7 +1120,7 @@ First, use the code below to create the test class:
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("hello-world-eventhandler.kts")
+@TestScriptFile("hello-world-eventhandler.kts")
 class EventHandlerTest {
 
     // our tests go here ...
@@ -1132,7 +1132,7 @@ class EventHandlerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("hello-world-eventhandler.kts")
+@TestScriptFile("hello-world-eventhandler.kts")
 public class EventHandlerTest {
 
     // our tests go here ...
@@ -1144,7 +1144,7 @@ public class EventHandlerTest {
 The code above does two things: 
 
 * It enables **GenesisJunit**.
-* It specifies the Event Handler script that we want to test, using the `ScriptFile` annotation.
+* It specifies the Event Handler script that we want to test, using the `TestScriptFile` annotation.
 
 There is more information about `GenesisJunit` and the various annotations in the section on [Integration testing](/develop/server-capabilities/testing-api/#integration-testing).
 
@@ -1156,7 +1156,7 @@ Use the code below to inject an Event Handler client:
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("hello-world-eventhandler.kts")
+@TestScriptFile("hello-world-eventhandler.kts")
 class EventHandlerTest {
 
     @Inject
@@ -1171,7 +1171,7 @@ class EventHandlerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("hello-world-eventhandler.kts")
+@TestScriptFile("hello-world-eventhandler.kts")
 public class EventHandlerTest {
 
     @Inject
@@ -1308,7 +1308,7 @@ You also need to inject `InMemoryTestAuthCache` into your test class.
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("hello-world-eventhandler.kts")
+@TestScriptFile("hello-world-eventhandler.kts")
 class EventHandlerTest {
 
     @Inject
@@ -1358,7 +1358,7 @@ class EventHandlerTest {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("hello-world-eventhandler.kts")
+@TestScriptFile("hello-world-eventhandler.kts")
 public class EventHandlerJavaTest {
 
     @Inject

--- a/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
+++ b/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
@@ -250,8 +250,8 @@ public class ConfigFileExampleJavaTest {
 
 #### CsvData
 
-This annotation is used to load CSV data as part of a test and is also repeatable.
-The [DumpIt](/build-deploy-operate/operate/commands/#dumpit) CSV format is supported in bot .csv and .csv.gz extensions.
+This annotation is used to load CSV data as part of a test and is also repeatable. Both individual file paths and folder paths are accepted.
+In terms of individual files, the [DumpIt](/build-deploy-operate/operate/commands/#dumpit) CSV format is supported in both .csv and .csv.gz extensions.
 Alternatively, multi-table `DumpIt` format is supported too in the following format:
 
 ```text
@@ -287,16 +287,16 @@ internal class CsvDataExamples {
     }
 
     @Test
-    @CsvData("other-data.csv")
+    @CsvData("other-data.csv.gz")
     fun loadCsvDataFromOtherDataFile() {
-        // uses "my-data.csv" and "other-data.csv"
+        // uses "my-data.csv" and "other-data.csv.gz"
     }
 
     @Test
-    @CsvData("other-data.csv")
-    @CsvData("more-data.csv")
+    @CsvData("other-data.csv.gz")
+    @CsvData("data-folder")
     fun loadCsvDataFromMultipleFiles() {
-        // uses "my-data.csv", "other-data.csv" and "more-data.csv"
+        // uses "my-data.csv", "other-data.csv.gz" and the "data-folder" folder
     }
 }
 ```

--- a/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
+++ b/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
@@ -125,9 +125,11 @@ The `GenesisJunit` class can be found in the `global.genesis.testsupport.jupiter
 
 ### Annotations
 
-**GenesisJunit** supports the following annotations.
-Please note that none of these will work without adding `@ExtendWith(GenesisJunit::class)`
-or `@ExtendWith(GenesisJunit.class)` to your class or function.
+**GenesisJunit** supports a range of annotations.
+
+:::important
+You must add `@ExtendWith(GenesisJunit::class)` or `@ExtendWith(GenesisJunit.class)` to your class or function. This is essential.
+:::
 
 These `@ExtendWith(GenesisJunit.class)` and all the annotations below work on both the class and method level.
 

--- a/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
+++ b/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
@@ -252,7 +252,8 @@ public class ConfigFileExampleJavaTest {
 
 This annotation is used to load CSV data as part of a test and is also repeatable. Both individual file paths and folder paths are accepted.
 In terms of individual files, the [DumpIt](/build-deploy-operate/operate/commands/#dumpit) CSV format is supported in both .csv and .csv.gz extensions.
-Alternatively, multi-table `DumpIt` format is supported too in the following format:
+
+Alternatively, multi-table `DumpIt` format is supported in the following format:
 
 ```text
 #TABLE_NAME
@@ -261,7 +262,8 @@ COLUMN_VALUE1, COLUMN_VALUE2, COLUMN_VALUE3
 COLUMN_VALUE2, COLUMN_VALUE3, COLUMN_VALUE4
 ```
 
-So assuming two tables named FIRST_TABLE and SECOND_TABLE, both with `String` columns ID and TEXT, both containing 2 records each, a sample file would look like this:
+So, assuming two tables named FIRST_TABLE and SECOND_TABLE, both with `String` columns ID and TEXT, both containing 2 records each, a sample file would look like this:
+
 ```text
 #FIRST_TABLE
 ID,TEXT

--- a/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
+++ b/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
@@ -29,7 +29,9 @@ If you are testing against previous versions of the framework, see the page on [
 
 Genesis provides a Junit 5 extension that helps developers write integration tests.
 The extension will create a Genesis microservice for the duration of each test case.
-This page will deal with the GenesisJunit extension in general. 
+The GenesisJunit functionality is made available via the `genesis-testsupport` package.
+This page will deal with the GenesisJunit extension in general.
+
 
 ### Testing specific services
 
@@ -119,6 +121,7 @@ Let's break down what is happening here.
 * run the test
 * clean up resources
 
+The `GenesisJunit` class can be found in the `global.genesis.testsupport.jupiter` package.
 
 ### Annotation Reference
 
@@ -131,8 +134,9 @@ Some of the annotations are Repeatable, this means that you can provide multiple
 If you provide those Repeatable annotations on both the class and method level, both would be applied.
 If you provide non-Repeatable annotations on both the class and method level, the method level annotion would take precedence.
 The enable annotations (i.e. EnableDataDump and EnableInMemoryTestAuthCache) do not support disabling at the method level once enabled on the class level.
+All annotations can be found in the `global.genesis.testsupport.jupiter` package.
 
-#### ScriptFile
+#### TestScriptFile
 
 Use this annotation to load a script file as part of the test.
 This annotation is Repeatable.
@@ -142,7 +146,7 @@ This annotation is Repeatable.
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ScriptFile("my-eventhandler.kts")
+@TestScriptFile("my-eventhandler.kts")
 internal class ScriptFileExamples {
 
     @Test
@@ -151,14 +155,14 @@ internal class ScriptFileExamples {
     }
 
     @Test
-    @ScriptFile("other-eventhandler.kts")
+    @TestScriptFile("other-eventhandler.kts")
     fun testMoreScriptFiles() {
         // uses "my-eventhandler.kts" and "other-eventhandler.kts"
     }
 
     @Test
-    @ScriptFile("other-eventhandler.kts")
-    @ScriptFile("more-eventhandler.kts")
+    @TestScriptFile("other-eventhandler.kts")
+    @TestScriptFile("more-eventhandler.kts")
     fun testManyScriptFiles() {
         // uses "my-eventhandler.kts", "other-eventhandler.kts" and "more-eventhandler.kts"
     }
@@ -170,7 +174,7 @@ internal class ScriptFileExamples {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ScriptFile("my-eventhandler.kts")
+@TestScriptFile("my-eventhandler.kts")
 public class ScriptFileJavaExample {
 
     @Test
@@ -179,14 +183,14 @@ public class ScriptFileJavaExample {
     }
 
     @Test
-    @ScriptFile("other-eventhandler.kts")
+    @TestScriptFile("other-eventhandler.kts")
     public void testMoreScriptFiles() {
         // uses "my-eventhandler.kts" and "other-eventhandler.kts"
     }
 
     @Test
-    @ScriptFile("other-eventhandler.kts")
-    @ScriptFile("more-eventhandler.kts")
+    @TestScriptFile("other-eventhandler.kts")
+    @TestScriptFile("more-eventhandler.kts")
     public void testManyScriptFiles() {
         // uses "my-eventhandler.kts", "other-eventhandler.kts" and "more-eventhandler.kts"
     }
@@ -195,16 +199,16 @@ public class ScriptFileJavaExample {
 </TabItem>
 </Tabs>
 
-#### ConfigFile
-Use this annotation is used to load a config file as part of a test.
-This annoatation is not Repeatable.
+#### TestConfigFile
+Use this annotation to load a process config file as part of a test.
+This annotation is not Repeatable.
 
 <Tabs defaultValue="kotlin" values={[{ label: 'Kotlin', value: 'kotlin', }, { label: 'Java', value: 'java', }]}>
 <TabItem value="kotlin">
 
 ```kotlin
 @ExtendWith(GenesisJunit::class)
-@ConfigFile("my-process-config.kts")
+@TestConfigFile("my-process-config.kts")
 internal class ConfigFileExamples {
 
     @Test
@@ -213,7 +217,7 @@ internal class ConfigFileExamples {
     }
 
     @Test
-    @ConfigFile("other-process-config.kts")
+    @TestConfigFile("other-process-config.kts")
     fun otherProcessConfig() {
         // uses "other-process-config.kts"
     }
@@ -225,7 +229,7 @@ internal class ConfigFileExamples {
 
 ```java
 @ExtendWith(GenesisJunit.class)
-@ConfigFile("my-process-config.kts")
+@TestConfigFile("my-process-config.kts")
 public class ConfigFileExampleJavaTest {
 
     @Test
@@ -234,7 +238,7 @@ public class ConfigFileExampleJavaTest {
     }
 
     @Test
-    @ConfigFile("other-process-config.kts")
+    @TestConfigFile("other-process-config.kts")
     public void otherProcessConfig() {
         // uses "other-process-config.kts"
     }
@@ -246,8 +250,28 @@ public class ConfigFileExampleJavaTest {
 
 #### CsvData
 
-This annotation is used to load CSV data as part of a test.
-This annotation is Repeatable.
+This annotation is used to load CSV data as part of a test and is also repeatable.
+The [DumpIt](/build-deploy-operate/operate/commands/#dumpit) CSV format is supported in bot .csv and .csv.gz extensions.
+Alternatively, multi-table `DumpIt` format is supported too in the following format:
+
+```text
+#TABLE_NAME
+COLUMN_NAME1, COLUMN_NAME2, COLUMN_NAME3
+COLUMN_VALUE1, COLUMN_VALUE2, COLUMN_VALUE3
+COLUMN_VALUE2, COLUMN_VALUE3, COLUMN_VALUE4
+```
+
+So assuming two tables named FIRST_TABLE and SECOND_TABLE, both with `String` columns ID and TEXT, both containing 2 records each, a sample file would look like this:
+```text
+#FIRST_TABLE
+ID,TEXT
+id1,text1
+id2,text2
+#SECOND_TABLE
+ID,TEXT
+id1,text1
+id2,text2
+```
 
 <Tabs defaultValue="kotlin" values={[{ label: 'Kotlin', value: 'kotlin', }, { label: 'Java', value: 'java', }]}>
 <TabItem value="kotlin">

--- a/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
+++ b/docs/001_develop/02_server-capabilities/016_testing-api/index.mdx
@@ -123,17 +123,20 @@ Let's break down what is happening here.
 
 The `GenesisJunit` class can be found in the `global.genesis.testsupport.jupiter` package.
 
-### Annotation Reference
+### Annotations
 
 **GenesisJunit** supports the following annotations.
 Please note that none of these will work without adding `@ExtendWith(GenesisJunit::class)`
 or `@ExtendWith(GenesisJunit.class)` to your class or function.
 
-These `@ExtendWith(GenesisJunit.class)` and any of the annotations below work on both the class and method level.
-Some of the annotations are Repeatable, this means that you can provide multiple values at the same class or method.
-If you provide those Repeatable annotations on both the class and method level, both would be applied.
-If you provide non-Repeatable annotations on both the class and method level, the method level annotion would take precedence.
-The enable annotations (i.e. EnableDataDump and EnableInMemoryTestAuthCache) do not support disabling at the method level once enabled on the class level.
+These `@ExtendWith(GenesisJunit.class)` and all the annotations below work on both the class and method level.
+
+Some of the annotations are Repeatable; this means that you can provide multiple values at the same class or method.
+
+- If you provide these Repeatable annotations on both the class and method level, both are applied.
+- If you provide non-Repeatable annotations on both the class and method level, the method-level annotation takes precedence.
+- The enable annotations (`EnableDataDump` and `EnableInMemoryTestAuthCache`) do not support disabling at the method level once they have been enabled on the class level.
+
 All annotations can be found in the `global.genesis.testsupport.jupiter` package.
 
 #### TestScriptFile


### PR DESCRIPTION
ATTENTION! YOU SHOULD NOW BRANCH FROM PREPROD WHEN YOU UPDATE 

  - Please check the [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) for details
  
__________

Thank you for contributing to the documentation.

Have you done a trial build to check all new or changed links?
Yes

Is there anything else you would like us to know?
The old @ScriptFile and @ConfigFile annotations are still valid but deprecated. I have updated them to be @TestScriptFile and @TestConfigFile, which are the new non-deprecated versions.

**This week's exciting advice from the style guide**

- Write your headings in sentence case:

  - A good example
    This is a correct heading.
  - A Bad Example
    This is not a correct heading.

