### PR TITLE
add on parsing error handler to fix streamer (FIX-176) + streamer pro…

### DIFF
--- a/docs/001_develop/02_server-capabilities/011_integrations/02_streamer-apis/01_streamer/index.mdx
+++ b/docs/001_develop/02_server-capabilities/011_integrations/02_streamer-apis/01_streamer/index.mdx
@@ -178,8 +178,8 @@ streams {
 }
 ```
 
-By default `terminateOnError` is set to true, which means the streamer process will crash as soon as the first record hits the `toGenesisSet` transformation.
-When the stream is terminated, the process will go into a WARNING state with the terminated streamer name detailed in the message column of `mon`.
+By default `terminateOnError` is set to true, which means the streamer process will crash as soon as the first record hits the `toGenesisSet` transformation.  
+When the stream is terminated, the process will go into a WARNING state with the terminated streamer name detailed in the message column of `mon`.  
 If set to `false`, the exception will be logged, but the streamer will continue process rows.
 
 

--- a/docs/001_develop/04_business-components/08_fix/fix-xlator.mdx
+++ b/docs/001_develop/04_business-components/08_fix/fix-xlator.mdx
@@ -83,7 +83,8 @@ fixStream<ExecutionReport>("EXECUTION_REPORT_VODL") {
 }
 ```
 
-There is an optional `onParsingError` handler that you can use to describe what behaviour you want to happen if there is an exception thrown when parsing the fix message.
+There is an optional `onParsingError` handler that you can use to describe what behaviour you want to happen if there is an exception thrown when parsing the fix message. 
+
 Here you have access to the entity which caused the exception as well as the exception itself:
 
 ```kotlin
@@ -93,8 +94,8 @@ fixStream<ExecutionReport>("EXECUTION_REPORT_VODL") {
     }
 
     onParsingError {
-            LOG.error("STREAM THREW PARSING EXCEPTION FOR {}", entity, throwable)
-            throw throwable
+        LOG.error("STREAM THREW PARSING EXCEPTION FOR {}", entity, throwable)
+        throw throwable
     }
 }
 ```


### PR DESCRIPTION
…cess goes into warning state when terminateOnError (GSF-7276)

ATTENTION! YOU SHOULD NOW BRANCH FROM PREPROD WHEN YOU UPDATE 

  - Please check the [internal contributions guide](https://www.notion.so/genesisglobal/Contributing-new-documentation-75953fb245f246ff872789035451a0c4) for details
  
__________

Thank you for contributing to the documentation.

Have you done a trial build to check all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

**This week's exciting advice from the style guide**

- Write your headings in sentence case:

  - A good example
    This is a correct heading.
  - A Bad Example
    This is not a correct heading.

