### PR TITLE
docs: multiselect + categorized multiselect, and select tweaks PTL-1748 PTL-1741

### DIFF
--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
@@ -244,7 +244,7 @@ Property and attribute binding examples for Genesis Component syntax. Closing ta
   </tbody>
 </table>
 
-## Properties
+### Properties
 
 <table>
   <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
@@ -154,7 +154,7 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class MyComponent {
-  selectedOptions: any[] = [];
+  selectedOptions: string[] = [];
 
   options = [
     {

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
@@ -25,8 +25,6 @@ import CategorizedMultiselectDemo from '../../../../../examples/ui/client-capabi
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Categorized Multiselect
-
 Use cases:
 * Selecting one or more from a list of options
 * Adding extra information to the options in addition to what is possible with the select and multiselect components
@@ -246,7 +244,7 @@ Property and attribute binding examples for Genesis Component syntax. Closing ta
   </tbody>
 </table>
 
-# Properties
+## Properties
 
 <table>
   <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/categozried-multiselect.mdx
@@ -1,0 +1,349 @@
+---
+title: 'Categorized Multiselect'
+sidebar_label: 'Categorized Multiselect'
+id: client-interaction-categorized-multiselect
+keywords: [interaction, interactive, select, form, submit, data, multiselect, dropdown, options, filter, search, async, multiple selection, categorized, categories, grouped options]
+tags:
+- interaction
+- interactive
+- select
+- form
+- submit
+- data
+- multiselect
+- dropdown
+- search
+- filter
+- multiple selection
+- custom options
+- categorized options
+- grouped selection
+sidebar_position: 8
+---
+
+import CategorizedMultiselectDemo from '../../../../../examples/ui/client-capabilities/interaction/categorized-multiselect.js';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Categorized Multiselect
+
+Use cases:
+* Selecting one or more from a list of options
+* Adding extra information to the options in addition to what is possible with the select and multiselect components
+
+## Example
+
+<CategorizedMultiselectDemo />
+
+<Tabs defaultValue="genesis" values={[{ label: 'Genesis', value: 'genesis', }, { label: 'React', value: 'react', }, { label: 'Angular', value: 'angular', }]}>
+
+  <TabItem value="genesis">
+
+    Declaration
+    ```html
+    <rapid-categorized-multiselect></rapid-categorized-multiselect>
+    ```
+
+    Usage
+```typescript
+@customElement({
+  name: 'my-element',
+  template: html`
+    <rapid-categorized-multiselect
+      ${ref('multiselect')}
+      @selectionChange=${(x) => x.onChange()}
+      :options=${(x) => x.options}
+    >
+    </rapid-categorized-multiselect>
+  `,
+})
+export class MyElement extends GenesisElement {
+  @observable multiselect: CategorizedMultiselect;
+  const options = [
+    {
+      type: "First category",
+      value: 'First value',
+      label: 'This is the first value',
+      description:
+        'Here you can add further information about each categorized multiselect item if you would like to',
+    },
+    {
+      type: "Second category",
+      value: 'Second value',
+      label: 'This is the second value',
+    },
+    {
+      type: "Second category",
+      value: 'Third value',
+      label: "This is the third value, and it's disabled",
+      disabled: true,
+    },
+  ]
+  onChange() {
+    // You can also get the selected options via `event.detail`
+    console.log(this.multiselect.selectedOptions)
+  }
+}
+```
+
+  </TabItem>
+  <TabItem value="react">
+
+  Declaration
+  ```html
+  <rapid-categorized-multiselect></rapid-categorized-multiselect>
+  ```
+  Usage
+```tsx
+export function MyComponent() {
+  const [selectedOptions, setSelectedOptions] = useState([])
+
+  const options = [
+    {
+      type: "First category",
+      value: 'First value',
+      label: 'This is the first value',
+      description:
+        'Here you can add further information about each categorized multiselect item if you would like to',
+    },
+    {
+      type: "Second category",
+      value: 'Second value',
+      label: 'This is the second value',
+    },
+    {
+      type: "Second category",
+      value: 'Third value',
+      label: "This is the third value, and it's disabled",
+      disabled: true,
+    },
+  ]
+
+  const selectionChange = (e) => {
+    console.log(e.detail)
+    setSelectedOptions(e.detail)
+  }
+
+  return (
+    <rapid-categorized-multiselect options={options} onselectionChange={selectionChange} selectedOptions={selectedOptions}>
+    </rapid-categorized-multiselect>
+  )
+}
+```
+</TabItem>
+  <TabItem value="angular">
+
+  Declaration
+  ```html
+  <rapid-categorized-multiselect></rapid-categorized-multiselect>
+  ```
+
+  Usage
+```typescript
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+@Component({
+  selector: 'my-component',
+  template: `
+    <rapid-categorized-multiselect
+      [options]="options"
+      [selectedOptions]="selectedOptions"
+      (selectionChange)="selectionChange($event)">
+    </rapid-categorized-multiselect>
+  `,
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class MyComponent {
+  selectedOptions: any[] = [];
+
+  options = [
+    {
+      type: "First category",
+      value: 'First value',
+      label: 'This is the first value',
+      description:
+        'Here you can add further information about each categorized multiselect item if you would like to',
+    },
+    {
+      type: "Second category",
+      value: 'Second value',
+      label: 'This is the second value',
+    },
+    {
+      type: "Second category",
+      value: 'Third value',
+      label: "This is the third value, and it's disabled",
+      disabled: true,
+    },
+  ]
+
+  selectionChange(event: CustomEvent) {
+    console.log(event.detail);
+    this.selectedOptions = event.detail;
+  }
+}
+```
+</TabItem>
+</Tabs>
+
+## API
+
+Property and attribute binding examples for Genesis Component syntax. Closing tag omitted.
+
+### Attributes
+
+<table>
+  <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>name</td>
+      <td><code>string</code></td>
+      <td>Component identifier.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect name="myMultiselect">
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>auto-position</td>
+      <td><code>boolean</code></td>
+      <td>Controls automatic positioning behavior. Default <code>true</code>.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect auto-position>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>search</td>
+      <td><code>boolean</code></td>
+      <td>Controls search functionality visibility. Default <code>true</code>.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect search>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>disabled</td>
+      <td><code>boolean</code></td>
+      <td>Disables the component. Default <code>false</code>.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect disabled>
+```
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
+# Properties
+
+<table>
+  <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>options</td>
+      <td><code>CategorizedMultiselectOption[]</code></td>
+      <td>Data options. Default <code>[]</code>.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect :options=${() => [
+  { type: 'Category 1', value: 'opt1', label: 'Option 1' },
+  { type: 'Category 2', value: 'opt2', label: 'Option 2' }
+]}>
+<rapid-categorized-multiselect :options=${(x) => x.options}>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>selectedOptions</td>
+      <td><code>string[]</code></td>
+      <td>Selected option values. Default <code>[]</code>.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect :selectedOptions=${() => ['opt1', 'opt3']}>
+<rapid-categorized-multiselect :selectedOptions=${(x) => x.selectedOptions}>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>position</td>
+      <td><code>Position</code></td>
+      <td>Controls dropdown position. Default <code>Position.BELOW</code>.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect :position=${() => Position.ABOVE}>
+<rapid-categorized-multiselect :position=${(x) => x.dropdownPosition}>
+```
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
+### Slots
+
+| Name | Description |
+|---|---|
+| Default | For the component label content |
+| button-content | Customizable button content (defaults to a plus icon) |
+
+### Parts
+
+| Name | Description |
+|---|---|
+| root | The main container |
+| control | The control button area |
+| control-button | The button element |
+| label | The component label |
+| options | The dropdown options container |
+| filter-search | The search input field |
+| checkbox-container | Container for option checkboxes |
+| multiselect-checkbox | Individual checkbox items |
+
+### Events fired
+
+<table>
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Type</th>
+      <th>Use</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>selectionChange</td>
+      <td><code>string[]</code></td>
+      <td>Fired when selection changes. The event detail contains an array of selected option values.</td>
+<td>
+
+```typescript
+<rapid-categorized-multiselect @selectionChange="${(e) => handleSelectionChange(e.detail)}">
+```
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
+### Events listened to
+
+This component doesn't listen to any events.
+

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/multiselect.mdx
@@ -1,0 +1,429 @@
+---
+title: 'Multiselect'
+sidebar_label: 'Multiselect'
+id: client-interaction-multiselect
+keywords: [interaction, interactive, select, form, submit, data, multiselect, dropdown, options, filter, search, async, multiple selection]
+tags:
+- interaction
+- interactive
+- select
+- form
+- submit
+- data
+- multiselect
+- dropdown
+- search
+- filter
+- multiple selection
+- custom options
+sidebar_position: 8
+---
+
+import MultiselectDemo from '../../../../../examples/ui/client-capabilities/interaction/multiselect.js';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Multiselect
+
+Use cases:
+* Selecting one or more from a list of options
+* Adding extra information to the options in addition to what is possible with the standard select component
+
+## Example
+
+<MultiselectDemo />
+
+<Tabs defaultValue="genesis" values={[{ label: 'Genesis', value: 'genesis', }, { label: 'React', value: 'react', }, { label: 'Angular', value: 'angular', }]}>
+
+  <TabItem value="genesis">
+
+    Declaration
+    ```html
+    <rapid-multiselect></rapid-multiselect>
+    ```
+
+    Usage
+```typescript
+@customElement({
+  name: 'my-element',
+  template: html`
+    <rapid-multiselect
+      ${ref('multiselect')}
+      @selectionChange=${(x) => x.onChange()}
+      :options=${(x) => x.options}
+    >
+    </rapid-multiselect>
+  `,
+})
+export class MyElement extends GenesisElement {
+  @observable multiselect: Multiselect;
+  const options = [
+    {
+      value: 'First value',
+      label: 'This is the first value',
+    },
+    {
+      value: 'Second value',
+      label: 'This is the second value',
+    },
+    {
+      value: 'Third value',
+      label: "This is the third value, and it's disabled",
+      disabled: true,
+    },
+  ]
+  onChange() {
+    // You can also get the selected options via `event.detail`
+    console.log(this.multiselect.selectedOptions)
+  }
+}
+```
+
+  </TabItem>
+  <TabItem value="react">
+
+  Declaration
+  ```html
+  <rapid-multiselect></rapid-multiselect>
+  ```
+  Usage
+  ```tsx
+export function MyComponent() {
+  const [selectedOptions, setSelectedOptions] = useState([])
+
+  const options = [
+    {
+      value: 'First value',
+      label: 'This is the first value',
+    },
+    {
+      value: 'Second value',
+      label: 'This is the second value',
+    },
+    {
+      value: 'Third value',
+      label: "This is the third value, and it's disabled",
+      disabled: true,
+    },
+  ]
+
+  const selectionChange = (e) => {
+    console.log(e.detail)
+    setSelectedOptions(e.detail)
+  }
+
+  return (
+    <rapid-multiselect options={options} onselectionChange={selectionChange} selectedOptions={selectedOptions}>
+    </rapid-multiselect>
+  )
+}
+  ```
+</TabItem>
+  <TabItem value="angular">
+
+  Declaration
+  ```html
+  <rapid-multiselect></rapid-multiselect>
+  ```
+
+  Usage
+  ```typescript
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+@Component({
+  selector: 'my-component',
+  template: `
+    <rapid-multiselect
+      [options]="options"
+      [selectedOptions]="selectedOptions"
+      (selectionChange)="selectionChange($event)">
+    </rapid-multiselect>
+  `,
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class MyComponent {
+  selectedOptions: any[] = [];
+
+  options = [
+    {
+      value: 'First value',
+      label: 'This is the first value',
+    },
+    {
+      value: 'Second value',
+      label: 'This is the second value',
+    },
+    {
+      value: 'Third value',
+      label: "This is the third value, and it's disabled",
+      disabled: true,
+    },
+  ];
+
+  selectionChange(event: CustomEvent) {
+    console.log(event.detail);
+    this.selectedOptions = event.detail;
+  }
+}
+  ```
+</TabItem>
+</Tabs>
+
+## API
+
+Property and attribute binding examples for Genesis Component syntax. Closing tag omitted.
+
+### Attributes
+
+
+<table>
+  <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>name</td>
+      <td><code>string</code></td>
+      <td>The name of the multiselect component.</td>
+<td>
+
+```typescript
+<rapid-multiselect name="myMultiselect">
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>autoPosition</td>
+      <td><code>boolean</code></td>
+      <td>Controls if dropdown automatically positions based on available space.</td>
+<td>
+
+```typescript
+<rapid-multiselect autoPosition>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>all</td>
+      <td><code>boolean</code></td>
+      <td>Whether to show "Select All" option. Default <code>true</code>.</td>
+<td>
+
+```typescript
+<rapid-multiselect all>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>allSelected</td>
+      <td><code>boolean</code></td>
+      <td>Whether all options are selected by default.</td>
+<td>
+
+```typescript
+<rapid-multiselect allSelected>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>search</td>
+      <td><code>boolean</code></td>
+      <td>Whether to enable search functionality. Default <code>true</code>.</td>
+<td>
+
+```typescript
+<rapid-multiselect search>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>disabled</td>
+      <td><code>boolean</code></td>
+      <td>Whether the component is disabled.</td>
+<td>
+
+```typescript
+<rapid-multiselect disabled>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>creatable</td>
+      <td><code>boolean</code></td>
+      <td>Whether new options can be created.</td>
+<td>
+
+```typescript
+<rapid-multiselect creatable>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>async</td>
+      <td><code>boolean</code></td>
+      <td>Whether to use async data loading.</td>
+<td>
+
+```typescript
+<rapid-multiselect async>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>debounce</td>
+      <td><code>number</code></td>
+      <td>Debounce time for async searches.</td>
+<td>
+
+```typescript
+<rapid-multiselect debounce=300>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>filterByContains</td>
+      <td><code>boolean</code></td>
+      <td>Whether to filter using "contains" vs "starts with". Default <code>false</code>.</td>
+<td>
+
+```typescript
+<rapid-multiselect filterByContains>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>position</td>
+      <td><code>"below" | "above"</code></td>
+      <td>Controls dropdown positioning (positioning enum).</td>
+<td>
+
+```typescript
+<rapid-multiselect position="BELOW">
+```
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
+# Properties
+
+<table>
+  <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>valueFormatter</td>
+      <td><code>function</code></td>
+      <td>Function to format option display values.</td>
+<td>
+
+```typescript
+<rapid-multiselect :valueFormatter=${() => (option: MultiselectOption) => `${option.label} (${option.value})`}>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>options</td>
+      <td><code>MultiselectOption[]</code></td>
+      <td>Available options.</td>
+<td>
+
+```typescript
+<rapid-multiselect :options=${() => [
+  { value: 'opt1', label: 'Option 1' },
+  { value: 'opt2', label: 'Option 2' }
+]}>
+<rapid-multiselect :options=${(x) => x.options}>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>selectedOptions</td>
+      <td><code>string[]</code></td>
+      <td>Currently selected option values.</td>
+<td>
+
+```typescript
+<rapid-multiselect :selectedOptions=${() => ['opt1', 'opt3']}>
+<rapid-multiselect :selectedOptions=${(x) => x.selectedOptions}>
+```
+
+</td>
+    </tr>
+    <tr>
+      <td>onAllSelectedCallback</td>
+      <td><code>function</code></td>
+      <td>Callback when "select all" state changes.</td>
+<td>
+
+```typescript
+<rapid-multiselect :onAllSelectedCallback=${() => (allSelected: boolean) => console.log('All selected:', allSelected)}>
+```
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
+### Slots
+
+| Name | Description |
+|---|---|
+| label | Slot for the component label |
+| indicator | Slot used for the loading indicator |
+| Default | Used for datasource elements |
+
+### Parts
+
+| Name | Description |
+|---|---|
+| label | Part for the label element |
+| root | Part for the root container |
+| control | Part for the control container |
+| filter-search | Part for the search input field |
+| indicator | Part for the dropdown indicator/arrow |
+| options-ol | Part for the options list container |
+| checkbox | Part for the checkbox components |
+| option-label | Part for the label of each option |
+
+### Events fired
+
+<table>
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Type</th>
+      <th>Use</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>selectionChange</td>
+      <td><code>string[]</code></td>
+      <td>Emitted when a single option is selected or deselected, or when the "Select All" functionality is used. The event detail contains an array of selected option values.</td>
+<td>
+
+```typescript
+<rapid-multiselect @selectionChange="${(e) => handleSelectionChange(e.detail)}">
+```
+
+</td>
+    </tr>
+  </tbody>
+</table>
+
+### Events listened to
+
+This component doesn't listen to any events.
+

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/multiselect.mdx
@@ -23,8 +23,6 @@ import MultiselectDemo from '../../../../../examples/ui/client-capabilities/inte
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Multiselect
-
 Use cases:
 * Selecting one or more from a list of options
 * Adding extra information to the options in addition to what is possible with the standard select component
@@ -314,7 +312,7 @@ Property and attribute binding examples for Genesis Component syntax. Closing ta
   </tbody>
 </table>
 
-# Properties
+### Properties
 
 <table>
   <thead><tr><th>Name</th><th>Type</th><th>Description</th><th>Example</th></tr></thead>

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/multiselect.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/multiselect.mdx
@@ -87,7 +87,7 @@ export class MyElement extends GenesisElement {
   <rapid-multiselect></rapid-multiselect>
   ```
   Usage
-  ```tsx
+```tsx
 export function MyComponent() {
   const [selectedOptions, setSelectedOptions] = useState([])
 
@@ -117,7 +117,7 @@ export function MyComponent() {
     </rapid-multiselect>
   )
 }
-  ```
+```
 </TabItem>
   <TabItem value="angular">
 
@@ -127,7 +127,7 @@ export function MyComponent() {
   ```
 
   Usage
-  ```typescript
+```typescript
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 @Component({
   selector: 'my-component',
@@ -165,7 +165,7 @@ export class MyComponent {
     this.selectedOptions = event.detail;
   }
 }
-  ```
+```
 </TabItem>
 </Tabs>
 

--- a/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/select.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/003_form-inputs/select.mdx
@@ -22,9 +22,13 @@ import Options from '../../../../_includes/_options.mdx'
 
 Use cases:
 * Selecting from a list of options
-* Selecting multiple options
 * Sorting
 * Filtering
+
+:::tip
+If you want to allow the selection of multiple items check out the [multiselect](/develop/client-capabilities/forms/form-inputs/client-interaction-multiselect/)
+and [categorized multiselect](/develop/client-capabilities/forms/form-inputs/client-interaction-categorized-multiselect/) components.
+:::
 
 ## Example
 
@@ -120,6 +124,32 @@ Use cases:
 </TabItem>
 </Tabs>
 
+<Options />
+
+You can also use the repeat directive to create options dynamically in the code:
+
+```typescript
+const sampleSelectOptions = [
+  { label: 'Large', value: 'l' },
+  { label: 'Small', value: 's' },
+]
+```
+
+```typescript
+import { html, repeat } from '@genesislcap/web-core';
+html`
+  <rapid-select>
+    ${repeat(
+      (x) => x.sampleSelectOptions,
+      html`
+        <rapid-option value="${(x) => x.value}">${(x) => x.label}</rapid-option>
+      `
+    )}
+  </rapid-select>
+`
+```
+
+
 ## API
 
  Property and attribute binding examples for Genesis Component syntax. Closing tag omitted.
@@ -147,18 +177,6 @@ Use cases:
 
 ```typescript
 <rapid-select form="sampleForm">
-```
-
-</td>
-    </tr>
-    <tr>
-      <td>multiple</td>
-      <td><code>boolean</code></td>
-      <td>Enables the user to select more than one option; this automatically opens the selection and removes the side arrow. **Default:** `false`</td>
-<td>
-
-```typescript
-<rapid-select multiple>
 ```
 
 </td>
@@ -229,35 +247,6 @@ Use cases:
 :::note
   If you set the `size`, the list is displayed by default (the user does not need to click to view it). This overrides any setting you make for `open`.
 :::
-
-<Options /> 
-
-:::note
-- If you specify a `selected` or `value` to more than one `option` while `multiple = false`, then the component selects only the first in the `rapid-option` list
-:::
-
-You can also use the repeat directive to create options dynamically in the code:
-
-```typescript
-  const sampleSelectOptions = [
-    {label: 'Large', value: 'l'},
-    {label: 'Small', value: 's'},
-  ]
-```
-
-```typescript
-import {html, repeat} from '@genesislcap/web-core';
-html`
-  <rapid-select>
-    ${repeat(
-  (x) => x.sampleSelectOptions,
-  html`
-        <rapid-option value="${(x) => x.value}">${(x) => x.label}</rapid-option>
-      `,
-  )}
-    </rapid-select>
-`
-```
 
 # Properties
 

--- a/docs/001_develop/03_client-capabilities/007_forms/forms-index.js
+++ b/docs/001_develop/03_client-capabilities/007_forms/forms-index.js
@@ -18,6 +18,7 @@ import ToolbarDemo from '/examples/ui/client-capabilities/interaction/toolbar.js
 
 import CriteriaSegmentedControlDemo from '/examples/ui/client-capabilities/interaction/criteria-segmented-control.js';
 import SegmentedControlDemo from '/examples/ui/client-capabilities/interaction/segmented-control.js';
+import MultiselectDemo from '/examples/ui/client-capabilities/interaction/multiselect';
 
 const cardData = [
   {
@@ -49,6 +50,12 @@ const cardData = [
     "link": "/develop/client-capabilities/forms/form-inputs/client-interaction-file-upload/",
     "text": "Control for uploading files",
     children: <FileUploadDemo />,
+  },
+  {
+    "heading": "Multiselect",
+    "link": "/develop/client-capabilities/forms/form-inputs/client-interaction-multiselect/",
+    "text": "Select one or more options",
+    children: <MultiselectDemo />,
   },
   {
     "heading": "Number Field",

--- a/docs/001_develop/03_client-capabilities/007_forms/forms-index.js
+++ b/docs/001_develop/03_client-capabilities/007_forms/forms-index.js
@@ -19,6 +19,7 @@ import ToolbarDemo from '/examples/ui/client-capabilities/interaction/toolbar.js
 import CriteriaSegmentedControlDemo from '/examples/ui/client-capabilities/interaction/criteria-segmented-control.js';
 import SegmentedControlDemo from '/examples/ui/client-capabilities/interaction/segmented-control.js';
 import MultiselectDemo from '/examples/ui/client-capabilities/interaction/multiselect';
+import CategorizedMultiselectDemo from '../../../../examples/ui/client-capabilities/interaction/categorized-multiselect';
 
 const cardData = [
   {
@@ -26,6 +27,12 @@ const cardData = [
     "link": "/develop/client-capabilities/forms/form-inputs/client-interaction-button/",
     "text": "Clickable element to indicate action",
     children: <ButtonDemo />,
+  },
+  {
+    "heading": "Categorized Multiselect",
+    "link": "/develop/client-capabilities/forms/form-inputs/client-interaction-categorized-multiselect/",
+    "text": "Select multiple categorized options, including descriptions",
+    children: <CategorizedMultiselectDemo />,
   },
   {
     "heading": "Checkbox",

--- a/examples/ui/client-capabilities/interaction/categorized-multiselect.js
+++ b/examples/ui/client-capabilities/interaction/categorized-multiselect.js
@@ -1,0 +1,47 @@
+import { CodeLabel, CodeSection } from '../../documentationBase';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import { useState } from 'react';
+
+export default function CategorizedMultiselectDemo({inIndex = false}) {
+	const isBrowser = useIsBrowser();
+
+	if (isBrowser) {
+		const RapidImports = require('../../rapidImports');
+		RapidImports.registerComponents();
+	}
+
+	const [selectedOptions, setSelectedOptions] = useState([])
+
+	const options = [
+		{
+			type: "First category",
+			value: 'First value',
+			label: 'This is the first value',
+			...(!inIndex ? { description:
+    'Here you can add further information about each categorized multiselect item if you would like to',
+			} : {})
+		},
+		{
+			type: "Second category",
+			value: 'Second value',
+			label: 'This is the second value',
+		},
+		{
+			type: "Second category",
+			value: 'Third value',
+			label: "This is the third value, and it's disabled",
+			disabled: true,
+		},
+	]
+
+	const selectionChange = (e) => {
+		console.log(e.detail)
+		setSelectedOptions(e.detail)
+	}
+
+	return (<CodeSection>
+		{!inIndex && <p style={{color: 'white'}}>Click the button to open the Categorized Multiselect</p>}
+		<rapid-categorized-multiselect options={options} style={{width: '50%'}} onselectionChange={selectionChange} selectedOptions={selectedOptions}>
+		</rapid-categorized-multiselect>
+	</CodeSection >)
+}

--- a/examples/ui/client-capabilities/interaction/multiselect.js
+++ b/examples/ui/client-capabilities/interaction/multiselect.js
@@ -1,0 +1,40 @@
+import { CodeLabel, CodeSection } from '../../documentationBase';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import { useState } from 'react';
+
+export default function MultiselectDemo({inIndex = false}) {
+	const isBrowser = useIsBrowser();
+
+	if (isBrowser) {
+		const RapidImports = require('../../rapidImports');
+		RapidImports.registerComponents();
+	}
+
+	const [selectedOptions, setSelectedOptions] = useState([])
+
+	const options = [
+		{
+			value: 'First value',
+			label: 'This is the first value',
+		},
+		{
+			value: 'Second value',
+			label: 'This is the second value',
+		},
+		{
+			value: 'Third value',
+			label: "This is the third value, and it's disabled",
+			disabled: true,
+		},
+	]
+
+	const selectionChange = (e) => {
+		console.log(e.detail)
+		setSelectedOptions(e.detail)
+	}
+
+	return (<CodeSection>
+		<rapid-multiselect options={options} style={{width: '50%'}} onselectionChange={selectionChange} selectedOptions={selectedOptions}>
+		</rapid-multiselect>
+	</CodeSection >)
+}


### PR DESCRIPTION
* Adds docs, live example, and card link for the multiselect component
* Adds docs, live example, and card link for the catogorized multiselect component
* Tweaks the select component to align the docs with the normal format and remove references to the broken `multiple` attribute