### PR TITLE
fix: temp remove scheduler component demo

### DIFF
--- a/docs/001_develop/03_client-capabilities/008_interaction/interaction-index.jsx
+++ b/docs/001_develop/03_client-capabilities/008_interaction/interaction-index.jsx
@@ -70,12 +70,12 @@ const cardData = [
     "text": "Focused overlay content",
     children: <ModalDemo />,
   },
-  {
-    "heading": "Scheduler",
-    "link": "/develop/client-capabilities/interaction/client-interaction-scheduler/",
-    "text": "component for scheduling tasks",
-    children: <CronSchedulerDemo />,
-  },
+  // {
+  //   "heading": "Scheduler",
+  //   "link": "/develop/client-capabilities/interaction/client-interaction-scheduler/",
+  //   "text": "component for scheduling tasks",
+  //   children: <CronSchedulerDemo />,
+  // },
   {
     "heading": "Tabs",
     "link": "/develop/client-capabilities/interaction/client-interaction-tabs/",


### PR DESCRIPTION
There's something going on with the scheduler setup or the actual FUI component. 

Will raise with the team to get this addressed, to unlock the screen this PR temporarily disables the failing component.

To test:

go to https://docs.genesis.global/docs/develop/client-capabilities/interaction/, you'll see your browser tab will freeze.

Run this branch locally, things work fine (after finding and disabling the failing component).
__________

Thank you for contributing to the documentation.

Have you done a trial build to check all new or changed links?
Yes

Is there anything else you would like us to know?
No

Please check the [internal contributions guide](https://www.notion.so/genesisglobal/Documentation-writing-guidelines-158e1d51b891806aaf08c405760b1563) for the most important guidance on updating the documentation.


