### PR TITLE
docs: add textTransform option docs for foundation forms (PTL-2058)

### DIFF
--- a/docs/001_develop/03_client-capabilities/007_forms/002_smart-forms/04_input_controls.mdx
+++ b/docs/001_develop/03_client-capabilities/007_forms/002_smart-forms/04_input_controls.mdx
@@ -47,6 +47,40 @@ const textInputUiSchema: UiSchema = {
 
 <StringFormExample/>
 
+###### Applying text transformation
+
+You can use `textTransform` in `StringRendererOptions` to normalize string input as users type and when the value is committed:
+
+- `'none'` (default): keeps the original input casing
+- `'uppercase'`: transforms the value to uppercase
+- `'lowercase'`: transforms the value to lowercase
+- custom function: apply your own transformation logic
+
+```ts
+const transformedTextUiSchema: UiSchema = {
+  type: 'VerticalLayout',
+  elements: [
+    {
+      type: 'Control',
+      scope: '#/properties/symbol',
+      options: {
+        textTransform: 'uppercase',
+        // Standard options can be combined with renderer-specific options
+        validateFn: (data, path, label) => [],
+      },
+    },
+  ],
+};
+```
+
+You can also pass a function:
+
+```ts
+options: {
+  textTransform: (value) => value.trim().toUpperCase(),
+}
+```
+
 ### Number control
 
 The number renderer creates a `number-field` in your form. This input only accepts numeric data. It sets a numeric value on the underlying form model.

--- a/docs/001_develop/03_client-capabilities/007_forms/002_smart-forms/docs/api/foundation-forms.stringrendereroptions.md
+++ b/docs/001_develop/03_client-capabilities/007_forms/002_smart-forms/docs/api/foundation-forms.stringrendereroptions.md
@@ -13,6 +13,7 @@ Configuration options available for string renderer.
 
 ```typescript
 export type StringRendererOptions = {
+    textTransform?: "none" | "uppercase" | "lowercase" | ((value: string) => string);
     isPassword?: boolean;
     textarea?: boolean;
 };

--- a/docs/001_develop/03_client-capabilities/007_forms/002_smart-forms/docs/api/foundation-forms.uischemaelementoptions.md
+++ b/docs/001_develop/03_client-capabilities/007_forms/002_smart-forms/docs/api/foundation-forms.uischemaelementoptions.md
@@ -7,7 +7,7 @@ format: md
 
 ## UiSchemaElementOptions type
 
-All configuration options that are available.
+All configuration options that are available. Standard options and renderer-specific options can be used together in the same `options` object.
 
 **Signature:**
 


### PR DESCRIPTION
Document textTransform values and function usage for string controls, and clarify options composition in Smart Forms/API docs.

Made-with: Cursor

ATTENTION! YOU SHOULD BRANCH FROM PREPROD WHEN YOU UPDATE 

__________

Thank you for contributing to the documentation.

Have you done a trial build to check all new or changed links?
<!--- Yes / No -->

Is there anything else you would like us to know?
<!--- Yes / No -->

Please check the [internal contributions guide](https://www.notion.so/genesisglobal/Documentation-writing-guidelines-158e1d51b891806aaf08c405760b1563) for the most important guidance on updating the documentation.


