### PR TITLE
docs(request-server): document Request.Details on custom reqrep handlers

### DIFF
--- a/docs/001_develop/02_server-capabilities/005_snapshot-queries-request-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/005_snapshot-queries-request-server/index.mdx
@@ -474,7 +474,8 @@ requestReply<[InputClass], [OutputClass]> ("{optional name}") {
   // all three have these fields available:
   // 1. db          - readonly entity database
   // 2. userName    - the name of the user who made the request
-  // 3. LOG         - logger with name: global.genesis.requestreply.pal.{request name}
+  // 3. details     - Request.Details from the inbound request: orderBy, offset, viewNumber, maxRows, criteriaMatch
+  // 4. LOG         - logger with name: global.genesis.requestreply.pal.{request name}
 
   // either:
   reply { request ->
@@ -523,6 +524,26 @@ requestReply<Hello, World>("HELLO_WORLD_CHECK") {
             hello.name -> World("Hello ${hello.name}")
             else -> World("You're not ${hello.name}!")
         }
+    }
+}
+```
+
+The `details` property gives you access to the `Request.Details` fields sent by the client: `orderBy`, `offset`, `viewNumber`, `maxRows`, and `criteriaMatch`. This is useful when your handler needs to drive ordering or pagination itself rather than relying on the platform defaults.
+
+```kotlin
+data class TradeQuery(val counterpartyId: String)
+data class TradeSummary(val tradeId: String, val price: Double)
+
+requestReply<TradeQuery, TradeSummary>("TRADES_SORTED") {
+    replyList { query ->
+        val trades = db.getBulk(TRADE).toList()
+        val sorted = when (details.orderBy) {
+            "PRICE DESC" -> trades.sortedByDescending { it.tradePrice }
+            "PRICE ASC"  -> trades.sortedBy { it.tradePrice }
+            else         -> trades
+        }
+        val offset = details.offset?.toInt() ?: 0
+        sorted.drop(offset).map { TradeSummary(it.tradeId, it.tradePrice) }
     }
 }
 ```

--- a/docs/001_develop/02_server-capabilities/005_snapshot-queries-request-server/index.mdx
+++ b/docs/001_develop/02_server-capabilities/005_snapshot-queries-request-server/index.mdx
@@ -528,22 +528,23 @@ requestReply<Hello, World>("HELLO_WORLD_CHECK") {
 }
 ```
 
-The `details` property gives you access to the `Request.Details` fields sent by the client: `orderBy`, `offset`, `viewNumber`, `maxRows`, and `criteriaMatch`. This is useful when your handler needs to drive ordering or pagination itself rather than relying on the platform defaults.
+The `details` property gives you access to the `Request.Details` fields sent by the client: `orderBy`, `offset`, `viewNumber`, `maxRows`, and `criteriaMatch`. Combined with [`getByCriteria`](/develop/server-capabilities/data-access-apis/#getbycriteria), the platform can do the sorting and paging at the database layer.
 
 ```kotlin
 data class TradeQuery(val counterpartyId: String)
-data class TradeSummary(val tradeId: String, val price: Double)
 
-requestReply<TradeQuery, TradeSummary>("TRADES_SORTED") {
+requestReply<TradeQuery, Trade>("TRADES_BY_COUNTERPARTY") {
     replyList { query ->
-        val trades = db.getBulk(TRADE).toList()
-        val sorted = when (details.orderBy) {
-            "PRICE DESC" -> trades.sortedByDescending { it.tradePrice }
-            "PRICE ASC"  -> trades.sortedBy { it.tradePrice }
-            else         -> trades
-        }
-        val offset = details.offset?.toInt() ?: 0
-        sorted.drop(offset).map { TradeSummary(it.tradeId, it.tradePrice) }
+        val orderBy = details.orderBy
+        val maxRows = details.maxRows ?: 100
+        val viewNumber = details.viewNumber
+
+        db.getByCriteria(
+            criteria = "COUNTERPARTY_ID == '${query.counterpartyId}'",
+            ordering = OrderSpecProvider.fromString(orderBy),
+            paging = PagingSpec(maxRows, viewNumber),
+            table = Trade::class,
+        ).toList()
     }
 }
 ```


### PR DESCRIPTION
## Summary

- Adds `details` to the available-fields comment block in the custom request server syntax template
- Adds a new example showing how to read `details.orderBy` and `details.offset` inside a `replyList` handler to drive custom sorting and pagination

## Related

Follows genesis-server [PR #5886](https://github.com/genesislcap/genesis-server/pull/5886) (GSF-7676), which exposed `Request.Details` on the `CustomReqRepHandler` DSL receiver. Previously only `db` and `userName` were available in reply lambdas.

## Test plan

- [ ] Verify the new example renders correctly in the docs site
- [ ] Check no broken links or MDX syntax errors