### PR TITLE
Add @harryjhornby and @suarezcarlos as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # For reference see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
 # Default owners for everything in the repo.
-* @jay-taylerson @jacinpoz @skawian @matteematt @patrickoneill-genesis @kievitsp @harryjhornby
+* @jay-taylerson @jacinpoz @skawian @matteematt @patrickoneill-genesis @kievitsp @harryjhornby @suarezcarlos

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # For reference see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
 # Default owners for everything in the repo.
-* @jay-taylerson @jacinpoz @skawian @matteematt @patrickoneill-genesis @kievitsp
+* @jay-taylerson @jacinpoz @skawian @matteematt @patrickoneill-genesis @kievitsp @harryjhornby


### PR DESCRIPTION
Adds @harryjhornby and @suarezcarlos to the default `*` owners rule in CODEOWNERS.

Both already have `write` access to the repo, so the entries will take effect (they'll be auto-requested for review on PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)