### PR TITLE
docs(auth): document notify-based MFA toggle events (AUTH-463)

### DIFF
--- a/docs/001_develop/02_server-capabilities/008_access-control/02_authentication/index.mdx
+++ b/docs/001_develop/02_server-capabilities/008_access-control/02_authentication/index.mdx
@@ -470,6 +470,26 @@ security {
 }
 ```
 
+##### Enabling notify-based MFA per user
+
+Notify-based MFA is applied per user. A user is only prompted for it once their `NOTIFY_BASED_MFA_STATUS` record has `MFA_ENABLED` set to `true`.
+
+Use these events to toggle it, in the same way `EVENT_ENABLE_MFA_FOR_USER` / `EVENT_DISABLE_MFA_FOR_USER` toggle `qrcode` MFA:
+
+* `EVENT_ENABLE_NOTIFY_BASED_MFA_FOR_USER` — enables notify-based MFA for the user (requires the `MFA_ENABLE` right).
+* `EVENT_DISABLE_NOTIFY_BASED_MFA_FOR_USER` — disables it (requires the `MFA_DISABLE` right).
+
+Both take the target user in `DETAILS.USER_NAME`:
+
+```json
+{
+  "MESSAGE_TYPE": "EVENT_ENABLE_NOTIFY_BASED_MFA_FOR_USER",
+  "DETAILS": {
+    "USER_NAME": "exampleUser"
+  }
+}
+```
+
 ### `loginAck`
 
 The `loginAck` block enables you to define additional values to be sent back to the client as part of the `LOGIN_ACK` message sent upon successful authentication. When you configure the `loginAck` function, you have to supply a table or view as a parameter.


### PR DESCRIPTION
Thank you for contributing to the documentation.

Have you done a trial build to check all new or changed links?
No — no links were added or changed.

Is there anything else you would like us to know?
Documents the two new events (`EVENT_ENABLE_NOTIFY_BASED_MFA_FOR_USER` / `EVENT_DISABLE_NOTIFY_BASED_MFA_FOR_USER`) added in platform-auth under AUTH-463, in the `notify` MFA section of the authentication page. Pairs with platform-auth PR #713.

[AUTH-463](https://genesisglobal.atlassian.net/browse/AUTH-463)
