### PR TITLE
Add HTTP response caching & compression to Performance best practices

### DIFF
--- a/docs/001_develop/02_server-capabilities/011_integrations/04_custom-endpoints/index.mdx
+++ b/docs/001_develop/02_server-capabilities/011_integrations/04_custom-endpoints/index.mdx
@@ -336,6 +336,36 @@ webHandlers {
 }
 ```
 
+###### Setting the response status and headers
+
+The `status` parameter above is fixed at configuration time. When you need to choose the status code **at runtime** or set response **headers** — for example to return a conditional `304 Not Modified`, an `ETag`, or a `Cache-Control` header — return the result of `buildResponse` from `handleRequest`, and type the endpoint response as `HttpResponse`:
+
+```kotlin
+import global.genesis.router.server.web.http.extensions.HttpResponse
+
+endpoint<Unit, HttpResponse>(GET, "trades") {
+    handleRequest {
+        buildResponse {
+            status(HttpStatusCode.Ok)                 // or status(code, "reason")
+            header("ETag", "\"v1\"")
+            header("Cache-Control", "private, no-cache")
+            body(tradeClient.getAllTrades())          // omit body() for an empty response, e.g. a 304
+        }
+    }
+}
+```
+
+Inside `buildResponse` you can set:
+
+| Call | Purpose |
+| ---- | ------- |
+| `status(HttpStatusCode)` / `status(code, reason)` | The response status code |
+| `header(name, value)` | A response header (call repeatedly to set several) |
+| `body(value)` | The response body, serialised the same way as a returned value |
+| `contentType(contentType)` | Override the response content type |
+
+For a status code that does **not** depend on the request, prefer the [`status` parameter](#override-status-code) on `endpoint` or the [`HttpResponseCode` annotation](#httpresponsecode-annotation) instead.
+
 #### `multipartEndpoint`
 
 To support file uploads, use the multipartEndpoint function. This function parses the request body as a multipart request and makes the files available in the fileUploads property of the handleRequest block.

--- a/docs/001_develop/02_server-capabilities/017_runtime-configuration/09_genesis-router/index.mdx
+++ b/docs/001_develop/02_server-capabilities/017_runtime-configuration/09_genesis-router/index.mdx
@@ -102,6 +102,8 @@ Let's have a look at the different options for configuring this file. You have s
 
 `nettyLoggingEnabled` If set to true, this setting enables internal netty logging. Default value false.
 
+`httpCompression` If set to true, adds an [`HttpContentCompressor`](https://netty.io/4.1/api/io/netty/handler/codec/http/HttpContentCompressor.html) to the Netty pipeline, so HTTP responses are gzip/deflate-compressed for clients that send an `Accept-Encoding` request header. Useful for large JSON responses from custom endpoints. Default value: false. (Available since 8.15.)
+
 ### Netty configuration
 
 #### `httpServerCodecDefinition`

--- a/docs/001_develop/02_server-capabilities/017_runtime-configuration/09_genesis-router/index.mdx
+++ b/docs/001_develop/02_server-capabilities/017_runtime-configuration/09_genesis-router/index.mdx
@@ -102,7 +102,7 @@ Let's have a look at the different options for configuring this file. You have s
 
 `nettyLoggingEnabled` If set to true, this setting enables internal netty logging. Default value false.
 
-`httpCompression` If set to true, adds an [`HttpContentCompressor`](https://netty.io/4.1/api/io/netty/handler/codec/http/HttpContentCompressor.html) to the Netty pipeline, so HTTP responses are gzip/deflate-compressed for clients that send an `Accept-Encoding` request header. Useful for large JSON responses from custom endpoints. Default value: false. (Available since 8.15.)
+`httpCompression` If set to true, adds an [`HttpContentCompressor`](https://netty.io/4.1/api/io/netty/handler/codec/http/HttpContentCompressor.html) to the Netty pipeline, so HTTP responses are gzip/deflate-compressed for clients that send an `Accept-Encoding` request header. Useful for large JSON responses from custom endpoints. Default value: false. (Available since 8.14.31.)
 
 ### Netty configuration
 

--- a/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
@@ -1,0 +1,133 @@
+---
+title: 'Caching and compressing HTTP responses'
+sidebar_label: 'HTTP response caching'
+id: best-practices-performance-endpoint-caching
+sidebar_position: 4
+keywords: [performance, caching, etag, conditional requests, compression, gzip, server-timing, custom endpoints, request server]
+tags:
+  - performance
+  - caching
+  - etag
+  - compression
+  - custom endpoints
+  - request server
+---
+
+When a screen loads reference or snapshot data over HTTP — from a [custom endpoint](/develop/server-capabilities/integrations/custom-endpoints/) or the [Request Server](/develop/server-capabilities/snapshot-queries-request-server/) — two levers cut cost independently:
+
+- **Don't re-send data that hasn't changed.** Use HTTP conditional requests so an unchanged resource returns `304 Not Modified` with no body.
+- **Shrink what you do send.** Compress the response.
+
+Both are handled at the HTTP layer, so any browser client (including the [`Http` client in `foundation-comms`](/develop/client-capabilities/server-communications/comms-connect/)) benefits without bespoke client code. Use [`Server-Timing`](#measure-with-server-timing) to confirm where the time actually goes before and after tuning.
+
+:::tip
+This is complementary to [grid and Data Server tuning](/develop/best-practices/performance/): that bounds how many rows the browser holds; this bounds how often, and how many bytes, you send them.
+:::
+
+## Don't re-send unchanged data: conditional requests
+
+Give the response a strong [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) and a `Cache-Control` that forces revalidation. The browser then replays the tag as `If-None-Match` on the next request; if nothing changed, answer `304 Not Modified` with **no body**, and the browser serves its cached copy.
+
+```kotlin
+// *-web-handler.kts — a cache-aware custom endpoint
+endpoint<Unit, HttpResponse>(GET, "counterparty") {
+    handleRequest {
+        val ifNoneMatch = request.headers.firstValueIgnoreCase("If-None-Match")
+        val etag = "\"counterparty-${tableVersion()}\""   // see "Make change detection cheap"
+
+        if (ifNoneMatch == etag) {
+            // Unchanged: return 304 WITHOUT reading or serialising any rows.
+            buildResponse {
+                status(HttpStatusCode.NotModified)
+                header("ETag", etag)
+                header("Cache-Control", "private, no-cache")
+            }
+        } else {
+            buildResponse {
+                status(HttpStatusCode.Ok)
+                header("ETag", etag)
+                header("Cache-Control", "private, no-cache")
+                body(loadRows())
+            }
+        }
+    }
+}
+```
+
+`Cache-Control: private, no-cache` means *store the response but always revalidate* — so the client stays correct while still skipping the payload whenever the data is unchanged. Use `private` for per-user/authenticated responses so shared caches don't store them.
+
+## Make change detection cheap
+
+The `304` path only pays off if computing the ETag is **much cheaper than sending the data**. The common mistake is to read the whole table to build a fingerprint (row count + newest timestamp, or a content hash) on *every* request — that scans the table even when you then return `304`, so a large dataset gets no benefit.
+
+Derive the ETag from a value that changes on any write but costs **O(1)** to read:
+
+- **Audit trail (recommended).** An [audited table](/how-to/audit/) appends a monotonic record on every insert, modify and delete. The newest audit record id is a ready-made table version — a single indexed read, no table scan:
+
+  ```kotlin
+  val version = db.getBulkFromEnd(CounterpartyAudit.ById).firstOrNull()?.counterpartyAuditId ?: "empty"
+  ```
+
+- **A maintained version counter** — a metadata record bumped by a consolidator or event handler, or an in-memory counter kept current by a table listener. Reading it is a single lookup (or a field read).
+
+Only read and serialise the rows on a real change (the `200` branch). On an unchanged table the request becomes one indexed read plus an empty `304`, regardless of table size.
+
+:::caution
+Avoid hashing the full result set to build the ETag: it re-reads every row on every request — the opposite of the goal — and forces a full read even for a `304`.
+:::
+
+## Let the browser's HTTP cache do the work
+
+You rarely need an application-level cache in the client. With an `ETag` and a storable `Cache-Control`, the browser's HTTP cache stores the response, revalidates with `If-None-Match`, and transparently serves the cached body on a `304` — bounded, persistent, and RFC-compliant. The [`Http` client](/develop/client-capabilities/server-communications/comms-connect/) issues requests with the default `fetch` cache mode, so this works out of the box.
+
+- Don't set `cache: 'no-store'` on the client — that disables the HTTP cache entirely.
+- Treat `304` as success, not an error, if you inspect the raw response.
+- A client-side `Map`/dictionary cache keyed by URL duplicates the browser cache, is unbounded unless you cap it, and is lost on reload — prefer the HTTP cache.
+
+## Compress the response
+
+Conditional requests remove the body when data is unchanged; compression shrinks it when it *does* change. Enable HTTP compression on the router so responses are gzip/deflate-encoded for clients that send `Accept-Encoding`:
+
+```kotlin
+// genesis-router.kts
+router {
+    httpCompression = true
+}
+```
+
+JSON compresses well (often 3–10×), so a large snapshot response shrinks substantially on the wire. In deployments that terminate at a gateway (for example nginx), compression is frequently applied there instead — confirm it is enabled at exactly one layer and check for `Content-Encoding: gzip` on the response.
+
+## Read conditional (and other) request headers case-insensitively
+
+HTTP header **names** are case-insensitive, and proxies and HTTP/2 routinely normalise them to lowercase (`if-none-match`). Match them case-insensitively on the server; a case-sensitive lookup for `"If-None-Match"` silently misses the lowercase form, so every request falls through to a full `200` and the cache never engages.
+
+```kotlin
+fun HttpRequest<*>.firstValueIgnoreCase(name: String): String? =
+    headers.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }?.value?.firstOrNull()
+```
+
+## Measure with Server-Timing
+
+Add a [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) response header so the server-side breakdown shows up in the browser (DevTools › Network › the request › Timing › Server Timing) and in `PerformanceResourceTiming.serverTiming` — without a profiler or extra tooling.
+
+```kotlin
+header(
+    "Server-Timing",
+    "version;dur=$versionMs;desc=\"ETag lookup\", " +
+        "read;dur=$readMs;desc=\"Load rows\", " +
+        "total;dur=$totalMs",
+)
+```
+
+Measure first: it quickly shows whether time is going to change detection, the query, or serialisation, so you tune the part that matters.
+
+## Summary
+
+| Goal | Lever |
+| ---- | ----- |
+| Skip re-sending unchanged data | `ETag` + `Cache-Control: private, no-cache`, answer `304` on match |
+| Keep change detection cheap at scale | O(1) table version (audit trail / maintained counter), **not** a full-table fingerprint |
+| Avoid bespoke client caching | Rely on the browser HTTP cache via the `Http` client; don't use `no-store` |
+| Reduce payload size | `httpCompression = true` (or gateway gzip) |
+| Handle proxy/HTTP2 headers | Match request header names case-insensitively |
+| Know where time goes | Emit a `Server-Timing` header |

--- a/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
@@ -76,14 +76,6 @@ Only read and serialise the rows on a real change (the `200` branch). On an unch
 Avoid hashing the full result set to build the ETag: it re-reads every row on every request — the opposite of the goal — and forces a full read even for a `304`.
 :::
 
-## Let the browser's HTTP cache do the work
-
-You rarely need an application-level cache in the client. With an `ETag` and a storable `Cache-Control`, the browser's HTTP cache stores the response, revalidates with `If-None-Match`, and transparently serves the cached body on a `304` — bounded, persistent, and RFC-compliant. The [`Http` client](/develop/client-capabilities/server-communications/comms-connect/) issues requests with the default `fetch` cache mode, so this works out of the box.
-
-- Don't set `cache: 'no-store'` on the client — that disables the HTTP cache entirely.
-- Treat `304` as success, not an error, if you inspect the raw response.
-- A client-side `Map`/dictionary cache keyed by URL duplicates the browser cache, is unbounded unless you cap it, and is lost on reload — prefer the HTTP cache.
-
 ## Compress the response
 
 Conditional requests remove the body when data is unchanged; compression shrinks it when it *does* change. Enable HTTP compression on the router so responses are gzip/deflate-encoded for clients that send `Accept-Encoding`:
@@ -127,7 +119,6 @@ Measure first: it quickly shows whether time is going to change detection, the q
 | ---- | ----- |
 | Skip re-sending unchanged data | `ETag` + `Cache-Control: private, no-cache`, answer `304` on match |
 | Keep change detection cheap at scale | O(1) table version (audit trail / maintained counter), **not** a full-table fingerprint |
-| Avoid bespoke client caching | Rely on the browser HTTP cache via the `Http` client; don't use `no-store` |
 | Reduce payload size | `httpCompression = true` (or gateway gzip) |
 | Handle proxy/HTTP2 headers | Match request header names case-insensitively |
 | Know where time goes | Emit a `Server-Timing` header |

--- a/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
@@ -3,17 +3,16 @@ title: 'Caching and compressing HTTP responses'
 sidebar_label: 'HTTP response caching'
 id: best-practices-performance-endpoint-caching
 sidebar_position: 4
-keywords: [performance, caching, etag, conditional requests, compression, gzip, server-timing, custom endpoints, request server]
+keywords: [performance, caching, etag, conditional requests, compression, gzip, server-timing, custom endpoints]
 tags:
   - performance
   - caching
   - etag
   - compression
   - custom endpoints
-  - request server
 ---
 
-When a screen loads reference or snapshot data over HTTP — from a [custom endpoint](/develop/server-capabilities/integrations/custom-endpoints/) or the [Request Server](/develop/server-capabilities/snapshot-queries-request-server/) — two levers cut cost independently:
+When a [custom endpoint](/develop/server-capabilities/integrations/custom-endpoints/) serves data over HTTP, two levers cut cost independently:
 
 - **Don't re-send data that hasn't changed.** Use HTTP conditional requests so an unchanged resource returns `304 Not Modified` with no body.
 - **Shrink what you do send.** Compress the response.

--- a/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
@@ -94,7 +94,9 @@ JSON compresses well (often 3–10×), so a large snapshot response shrinks subs
 
 ## Read conditional (and other) request headers case-insensitively
 
-HTTP header **names** are case-insensitive, and proxies and HTTP/2 routinely normalise them to lowercase (`if-none-match`). Match them case-insensitively on the server; a case-sensitive lookup for `"If-None-Match"` silently misses the lowercase form, so every request falls through to a full `200` and the cache never engages.
+Endpoints normally read request headers with the [`by header("X")` / `by optionalHeader("X")`](/develop/server-capabilities/integrations/custom-endpoints/#header-parameters) syntax, which also lists the header in the endpoint's generated OpenAPI documentation. Those declarations match the name you declare **exactly**, though — and HTTP header names are case-insensitive, with proxies and HTTP/2 routinely sending them lowercased (`if-none-match`). So `optionalHeader("If-None-Match")` silently misses the lowercase form, every request falls through to a full `200`, and the cache never engages.
+
+For conditional-request headers, read them case-insensitively from the request instead. You forgo the automatic OpenAPI entry, but the match is correct regardless of how the client or proxy cases the name:
 
 ```kotlin
 fun HttpRequest<*>.firstValueIgnoreCase(name: String): String? =

--- a/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
@@ -88,7 +88,7 @@ router {
 }
 ```
 
-[`httpCompression`](/develop/server-capabilities/runtime-configuration/genesis-router/#router-configuration) is a Genesis router option available in recent **8.15.x** platform releases.
+[`httpCompression`](/develop/server-capabilities/runtime-configuration/genesis-router/#router-configuration) is a Genesis router option available since **8.14.31**.
 
 JSON compresses well (often 3–10×), so a large snapshot response shrinks substantially on the wire. In deployments that terminate at a gateway (for example nginx), compression is frequently applied there instead — confirm it is enabled at exactly one layer and check for `Content-Encoding: gzip` on the response.
 

--- a/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx
@@ -53,6 +53,8 @@ endpoint<Unit, HttpResponse>(GET, "counterparty") {
 }
 ```
 
+The handler sets the status code and response headers with `buildResponse` — see [Setting the response status and headers](/develop/server-capabilities/integrations/custom-endpoints/#setting-the-response-status-and-headers) on the custom endpoints page.
+
 `Cache-Control: private, no-cache` means *store the response but always revalidate* — so the client stays correct while still skipping the payload whenever the data is unchanged. Use `private` for per-user/authenticated responses so shared caches don't store them.
 
 ## Make change detection cheap
@@ -61,7 +63,7 @@ The `304` path only pays off if computing the ETag is **much cheaper than sendin
 
 Derive the ETag from a value that changes on any write but costs **O(1)** to read:
 
-- **Audit trail (recommended).** An [audited table](/how-to/audit/) appends a monotonic record on every insert, modify and delete. The newest audit record id is a ready-made table version — a single indexed read, no table scan:
+- **Audit trail (recommended).** An [audited table](/how-to/ht-audit/) appends a monotonic record on every insert, modify and delete. The newest audit record id is a ready-made table version — a single indexed read, no table scan:
 
   ```kotlin
   val version = db.getBulkFromEnd(CounterpartyAudit.ById).firstOrNull()?.counterpartyAuditId ?: "empty"
@@ -85,6 +87,8 @@ router {
     httpCompression = true
 }
 ```
+
+[`httpCompression`](/develop/server-capabilities/runtime-configuration/genesis-router/#router-configuration) is a Genesis router option available in recent **8.15.x** platform releases.
 
 JSON compresses well (often 3–10×), so a large snapshot response shrinks substantially on the wire. In deployments that terminate at a gateway (for example nginx), compression is frequently applied there instead — confirm it is enabled at exactly one layer and check for `Content-Encoding: gzip` on the response.
 

--- a/docs/001_develop/06_best-practices/01_performance/index.mdx
+++ b/docs/001_develop/06_best-practices/01_performance/index.mdx
@@ -29,6 +29,7 @@ For a **non-technical guide** to help clients and business analysts agree data v
 | Read-only or custom grid UX | [Grid Pro](/develop/client-capabilities/grids/grid-pro/) directly |
 | Large dropdowns (select / combobox on reference data) | [`options-datasource`](/develop/client-capabilities/forms/form-inputs/client-options-datasource/) with **`infinite-scroll`** and tuned **`page-size`** |
 | Very wide Data Server grids (many columns, users hide columns) | [`grid-pro-genesis-datasource`](/develop/client-capabilities/grids/grid-pro/grid-pro-datasources/#grid-pro-genesis-datasource) with **`request-visible-columns-only`** |
+| Serving reference or snapshot data over HTTP from a [custom endpoint](/develop/server-capabilities/integrations/custom-endpoints/) | [Cache and compress the response](/develop/best-practices/performance/endpoint-caching/) — `ETag`/`304` plus `httpCompression` |
 
 Avoid loading an entire large query into the browser when server-side row model or pagination can keep each page bounded.
 
@@ -194,3 +195,4 @@ On the server, use Data Server start-up logs and [LMDB allocation](/develop/serv
 5. [Entity Manager](/develop/client-capabilities/grids/entity-manager/) if you use CRUD micro front-ends
 6. [Avoiding browser memory leaks](/develop/best-practices/performance/browser-memory-leaks/) for client-side retention and cleanup
 7. [Options datasource](/develop/client-capabilities/forms/form-inputs/client-options-datasource/) for large select and combobox lists
+8. [Caching and compressing HTTP responses](/develop/best-practices/performance/endpoint-caching/) for data served from custom endpoints


### PR DESCRIPTION
Targets **PTL-2061** to add to #2495.

Adds one page to the new UI Performance best-practices section:
`docs/001_develop/06_best-practices/01_performance/04_endpoint-caching/index.mdx` (sidebar label **HTTP response caching**). The best-practices sidebar is autogenerated by directory, so no `sidebars.js` change is needed.

### What it covers
HTTP-layer performance for data served over HTTP from a custom endpoint, complementing the existing grid/Data Server pages:

- **Conditional requests** — `ETag` + `Cache-Control: private, no-cache`, returning `304 Not Modified` with no body when unchanged.
- **Keep change detection O(1)** — derive the ETag from a cheap table version (newest audit-record id via `getBulkFromEnd`, or a maintained counter) instead of a full-table fingerprint/scan; only read rows on the `200` path. Includes a caution against hashing the whole result set.
- **Compression** — `httpCompression = true` on the router (or gateway gzip).
- **Case-insensitive conditional-header handling** — proxies/HTTP2 lowercase header names.
- **Server-Timing** — emit the header to see where server time goes in DevTools.

### Reference updates (addressing review feedback)
The caching page relied on two APIs that weren't documented elsewhere, so this PR documents them where they belong and links from the caching page:

- **`buildResponse`** — setting the response status/headers at runtime, on the [custom endpoints](/develop/server-capabilities/integrations/custom-endpoints/#setting-the-response-status-and-headers) page.
- **`httpCompression`** — on the [genesis-router](/develop/server-capabilities/runtime-configuration/genesis-router/#router-configuration) reference.

Also surfaced the page in the UI Performance **decision guide** and **reading order** for discoverability.

### Notes
- Internal links checked against the `PTL-2061` branch (audit resolves to `/how-to/ht-audit/`).
- Content is based on an implementation in the foundation-ui showcase (genesislcap/foundation-ui#2403) but written as general platform guidance.
- `buildResponse` is verified working on Genesis 8.15.29 — please confirm it is a supported public API before merge.

Happy to adjust wording/placement to fit the rest of the section.
